### PR TITLE
[FIX] AccountServiceTest 간헐적 테스트 실패 해결

### DIFF
--- a/src/test/java/com/kt/service/AccountServiceTest.java
+++ b/src/test/java/com/kt/service/AccountServiceTest.java
@@ -1,7 +1,6 @@
 package com.kt.service;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.LocalDate;
 
@@ -23,7 +22,7 @@ import com.kt.repository.courier.CourierRepository;
 import com.kt.repository.user.UserRepository;
 
 @Transactional
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest
 @ActiveProfiles("test")
 class AccountServiceTest {
 


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- resolves: #이슈번호, #이슈번호 -->
resolves: - (이슈 생성 없는 PR 입니다)

AccontServiceTest 간헐적 테스트 실패 해결했습니다.

## 📝작업 내용

간헐적 실패 원인은 

**@SpringBootTest와 @Transcational의 잘못된 사용에서 발생한 문제**였습니다.

@SpringBootTest는 기본적으로 롤백 기능이 없습니다. 

그래서 @Transactional을 사용하면 각 테스트마다 db 변경 내용이 있을 경우 롤백 해주게 되는데 

@SpringBootTest를 다음과 같이 사용할 경우 롤백이 되지 않습니다.

**1. @SpringBootTest(WebEnvironment.RANDOM_PORT)
2. @SpringBootTest(WebEnvironment.DEFINED_PORT)**

두번째 해결 방법으로는 
@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
를 사용하는 방법이 있었습니다. 

이 방법은 각 테스트마다 Context를 모두 지우고 다시 생성하는 과정을 거치기 때문에 비용이 많이 들 수 있어서

그냥 @SpringBootTest의 RANDOM_PORT 속성만 제외시켰습니다.

다음 링크의 사이트를 참고하엿습니다.
https://be-student.tistory.com/65#SpringBootTest%EC%97%90%EC%84%9C%20rollback%20%EC%9D%B4%20%EB%90%98%EC%A7%80%20%EC%95%8A%EB%8A%94%20%EA%B2%BD%EC%9A%B0%EA%B0%80%20%EC%9E%88%EB%8B%A4-1
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->