### PR TITLE
[FEAT] 토큰 재발급 서비스 개발 및 테스트 코드 추가 

### DIFF
--- a/src/main/java/com/kt/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/kt/config/jwt/JwtAuthenticationFilter.java
@@ -46,7 +46,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 				SecurityContextHolder.getContext().setAuthentication(authenticationToken);
 			}
 		} catch(ExpiredJwtException e) {
-			reject(request, ErrorCode.AUTH_EXPIRED);
+			reject(request, ErrorCode.AUTH_ACCESS_EXPIRED);
 		} catch(JwtException | IllegalArgumentException e) {
 			reject(request, ErrorCode.AUTH_INVALID);
 		}

--- a/src/main/java/com/kt/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/kt/config/jwt/JwtTokenProvider.java
@@ -73,6 +73,10 @@ public class JwtTokenProvider {
 		);
 	}
 
+	public String getAccountId(String token) {
+		return getClaims(token).getSubject();
+	}
+
 	private DefaultCurrentUser toCurrentUser(String token) {
 		Claims claims = getClaims(token);
 		UUID id = UUID.fromString(claims.getSubject());

--- a/src/main/java/com/kt/constant/message/ErrorCode.java
+++ b/src/main/java/com/kt/constant/message/ErrorCode.java
@@ -13,7 +13,8 @@ public enum ErrorCode {
 	INVALID_DOMAIN_FIELD(HttpStatus.BAD_REQUEST, "도메인 필드 오류 : {0}"),
 	BODY_FIELD_ERROR(HttpStatus.BAD_REQUEST, "바디 필드 오류 : {0}"),
 	ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 계정입니다"),
-	AUTH_EXPIRED(HttpStatus.UNAUTHORIZED, "엑세스 토큰이 만료되었습니다."),
+	AUTH_ACCESS_EXPIRED(HttpStatus.UNAUTHORIZED, "엑세스 토큰이 만료되었습니다."),
+	AUTH_REFRESH_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다. 재로그인이 필요합니다."),
 	AUTH_INVALID(HttpStatus.UNAUTHORIZED, "올바르지 않은 인증 정보입니다."),
 	AUTH_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
 

--- a/src/main/java/com/kt/constant/redis/RedisKey.java
+++ b/src/main/java/com/kt/constant/redis/RedisKey.java
@@ -7,7 +7,8 @@ import java.time.Duration;
 @Getter
 public enum RedisKey {
 	SIGNUP_CODE("signup:code:", Duration.ofMinutes(3)),
-	SIGNUP_VERIFIED("signup:verified:", Duration.ofMinutes(5));
+	SIGNUP_VERIFIED("signup:verified:", Duration.ofMinutes(5)),
+	REFRESH_TOKEN("refresh-token:", Duration.ofHours(24));
 
 	private final String prefix;
 

--- a/src/main/java/com/kt/domain/dto/request/TokenReissueRequest.java
+++ b/src/main/java/com/kt/domain/dto/request/TokenReissueRequest.java
@@ -1,0 +1,6 @@
+package com.kt.domain.dto.request;
+
+public record TokenReissueRequest(
+	String refreshToken
+) {
+}

--- a/src/main/java/com/kt/domain/dto/response/TokenReissueResponse.java
+++ b/src/main/java/com/kt/domain/dto/response/TokenReissueResponse.java
@@ -1,0 +1,7 @@
+package com.kt.domain.dto.response;
+
+public record TokenReissueResponse(
+	String accessToken,
+	String refreshToken
+) {
+}

--- a/src/main/java/com/kt/infra/redis/RedisCache.java
+++ b/src/main/java/com/kt/infra/redis/RedisCache.java
@@ -24,8 +24,8 @@ public class RedisCache {
 		redisTemplate.opsForValue().set(key, value, ttl.toMillis(), TimeUnit.MILLISECONDS);
 	}
 
-	public <T> void set(RedisKey redisKey, Object email, T value) {
-		set(redisKey.key(email), value, redisKey.getTtl());
+	public <T> void set(RedisKey redisKey, Object keyParam, T value) {
+		set(redisKey.key(keyParam), value, redisKey.getTtl());
 	}
 
 	public <T> T get(String key, Class<T> clazz) {

--- a/src/main/java/com/kt/repository/AccountRepository.java
+++ b/src/main/java/com/kt/repository/AccountRepository.java
@@ -5,6 +5,8 @@ import com.kt.domain.entity.AbstractAccountEntity;
 
 import com.kt.exception.BaseException;
 
+import com.kt.exception.CustomException;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -13,6 +15,12 @@ import java.util.UUID;
 
 @Repository
 public interface AccountRepository extends JpaRepository<AbstractAccountEntity, UUID> {
+
+	default AbstractAccountEntity findByIdOrThrow(UUID accountId) {
+		return findById(accountId).orElseThrow(
+			() -> new CustomException(ErrorCode.ACCOUNT_NOT_FOUND)
+		);
+	}
 
 	default AbstractAccountEntity findByEmailOrThrow(String email) {
 		return findByEmail(email).orElseThrow(

--- a/src/main/java/com/kt/repository/user/UserRepository.java
+++ b/src/main/java/com/kt/repository/user/UserRepository.java
@@ -3,6 +3,8 @@ package com.kt.repository.user;
 import java.util.Optional;
 import java.util.UUID;
 
+import com.kt.exception.CustomException;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -12,6 +14,13 @@ import com.kt.exception.BaseException;
 
 @Repository
 public interface UserRepository extends JpaRepository<UserEntity, UUID>, UserRepositoryCustom {
+
+	default UserEntity findByEmailOrThrow(String email) {
+		return findByEmail(email).orElseThrow(
+			() -> new CustomException(ErrorCode.USER_NOT_FOUND)
+		);
+	}
+
 	Optional<UserEntity> findByEmail(String email);
 
 	default UserEntity findByIdOrThrow(UUID id) {

--- a/src/main/java/com/kt/service/AuthService.java
+++ b/src/main/java/com/kt/service/AuthService.java
@@ -3,6 +3,7 @@ package com.kt.service;
 import com.kt.domain.dto.request.LoginRequest;
 import com.kt.domain.dto.request.ResetPasswordRequest;
 import com.kt.domain.dto.request.SignupRequest;
+import com.kt.domain.dto.request.TokenReissueRequest;
 import com.mysema.commons.lang.Pair;
 
 public interface AuthService {
@@ -18,4 +19,6 @@ public interface AuthService {
 	void verifySignupCode(SignupRequest.VerifySignupCode request);
 
 	void resetPassword(ResetPasswordRequest request);
+
+	Pair<String, String> reissueToken(TokenReissueRequest request);
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

토큰 재발급 서비스 개발 및 테스트 코드 추가, 로그인 시 refreshToken 저장 로직 추가

resolves: #71 

## 📝작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->