### PR TITLE
[FEAT] AdminController 구현

### DIFF
--- a/src/main/java/com/kt/controller/admin/AdminController.java
+++ b/src/main/java/com/kt/controller/admin/AdminController.java
@@ -5,9 +5,9 @@ import static com.kt.common.api.ApiResult.*;
 import java.util.UUID;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -72,7 +72,7 @@ public class AdminController {
 		return empty();
 	}
 
-	@PatchMapping("/{adminId}")
+	@DeleteMapping("/{adminId}")
 	public ResponseEntity<ApiResult<Void>> deleteAdmin(@PathVariable UUID adminId) {
 		userService.deleteUser(adminId);
 		return empty();

--- a/src/test/java/com/kt/controller/admin/AdminControllerTest.java
+++ b/src/test/java/com/kt/controller/admin/AdminControllerTest.java
@@ -1,5 +1,24 @@
 package com.kt.controller.admin;
 
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kt.constant.Gender;
 import com.kt.constant.UserRole;
@@ -10,27 +29,7 @@ import com.kt.domain.entity.UserEntity;
 import com.kt.repository.user.UserRepository;
 import com.kt.security.DefaultCurrentUser;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-
-import org.springframework.http.MediaType;
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.web.servlet.MockMvc;
-
-import java.time.LocalDate;
-
-import static org.assertj.core.api.Assertions.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
-
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
 class AdminControllerTest {
@@ -48,7 +47,6 @@ class AdminControllerTest {
 
 	@BeforeEach
 	void setUp() {
-		userRepository.deleteAll();
 		testAdmin = UserEntity.create(
 			"테스트관리자1",
 			"test@example.com",
@@ -59,6 +57,11 @@ class AdminControllerTest {
 			"010-1231-1212"
 		);
 		userRepository.save(testAdmin);
+	}
+
+	@AfterEach
+	void cleanUp() {
+		userRepository.deleteAll();
 	}
 
 	private DefaultCurrentUser adminPrincipal() {
@@ -110,11 +113,9 @@ class AdminControllerTest {
 			"010-1111-1111"
 		);
 
-		String json = objectMapper.writeValueAsString(request);
-
 		mockMvc.perform(post("/api/admin/admins")
 				.contentType(MediaType.APPLICATION_JSON)
-				.content(json)
+				.content(objectMapper.writeValueAsString(request))
 				.with(user(adminPrincipal()))
 			)
 			.andDo(print())
@@ -135,11 +136,9 @@ class AdminControllerTest {
 			Gender.FEMALE
 		);
 
-		String json = objectMapper.writeValueAsString(requset);
-
 		mockMvc.perform(put("/api/admin/admins/{adminId}", testAdmin.getId())
 				.contentType(MediaType.APPLICATION_JSON)
-				.content(json)
+				.content(objectMapper.writeValueAsString(requset))
 				.with(user(adminPrincipal()))
 			)
 			.andDo(print())
@@ -154,7 +153,7 @@ class AdminControllerTest {
 	@Test
 	void 관리자_삭제_성공() throws Exception {
 
-		mockMvc.perform(patch("/api/admin/{adminId}", testAdmin.getId())
+		mockMvc.perform(delete("/api/admin/{adminId}", testAdmin.getId())
 				.with(user(adminPrincipal()))
 			)
 			.andDo(print())


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- resolves: #이슈번호, #이슈번호 -->
resolves:

## 📝작업 내용

<img width="1077" height="219" alt="image" src="https://github.com/user-attachments/assets/05949767-648a-4121-b0b9-74133e657c95" />

- 민서님께서 작성하신 AdminAccountController와 기능이 거의 똑같아서 많이 참고해서 진행했습니다.

준상님 api 규격 사용하려고 부득이하게 feature/api-response에서 브랜치 따서 진행했습니다!

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->