### PR TITLE
[FEAT] 계정 비밀번호 초기화 요청 API 개발 및 테스트

### DIFF
--- a/src/main/java/com/kt/constant/message/ErrorCode.java
+++ b/src/main/java/com/kt/constant/message/ErrorCode.java
@@ -24,7 +24,7 @@ public enum ErrorCode {
 	AUTH_ACCOUNT_DISABLED(HttpStatus.FORBIDDEN, "해당 계정은 비활성화된 계정입니다."),
 	AUTH_ACCOUNT_RETIRED(HttpStatus.FORBIDDEN, "해당 계정은 탈퇴한 계정입니다."),
 	EMAIL_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 전송에 실패하였습니다."),
-	PASSWORD_RESET_ALREADY_REQUESTED(HttpStatus.CONFLICT, "비밀번호 초기화 요청이 이미 접수되어 처리 중입니다."),
+	PASSWORD_INIT_ALREADY_REQUESTED(HttpStatus.CONFLICT, "비밀번호 초기화 요청이 이미 접수되어 처리 중입니다."),
 	DUPLICATED_EMAIL(HttpStatus.CONFLICT, "해당 이메일로 등록된 계정이 이미 존재합니다."),
 	DUPLICATED_CATEGORY(HttpStatus.CONFLICT, "중복된 카테고리명 입니다."),
 	ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 주문은 존재하지 않습니다."),

--- a/src/main/java/com/kt/controller/auth/AuthController.java
+++ b/src/main/java/com/kt/controller/auth/AuthController.java
@@ -18,11 +18,9 @@ import com.mysema.commons.lang.Pair;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
 import static com.kt.common.api.ApiResult.*;
 
-@Slf4j
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
@@ -75,11 +73,20 @@ public class AuthController {
 		);
 	}
 
-	@PatchMapping("/init-password")
-	public ResponseEntity<ApiResult<Void>> resetPassword(
-		@RequestBody @Valid PasswordManagementRequest.PasswordReset request
+	@PatchMapping("/password-init")
+	public ResponseEntity<ApiResult<Void>> initPassword(
+		@RequestBody @Valid PasswordManagementRequest.PasswordInit request
 	) {
-		authService.resetPassword(request);
+		authService.initPassword(request);
 		return empty();
 	}
+
+	@PostMapping("/password-init/requests")
+	public ResponseEntity<ApiResult<Void>> requestPasswordInit(
+		@RequestBody @Valid PasswordManagementRequest.PasswordInit request
+	) {
+		authService.requestPasswordInit(request);
+		return empty();
+	}
+
 }

--- a/src/main/java/com/kt/domain/dto/request/PasswordManagementRequest.java
+++ b/src/main/java/com/kt/domain/dto/request/PasswordManagementRequest.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.NotBlank;
 
 public class PasswordManagementRequest {
 
-	public record PasswordReset(
+	public record PasswordInit(
 		@Email(message = "올바른 이메일 형식이 아닙니다.")
 		@NotBlank(message = "이메일은 필수 항목입니다.")
 		String email

--- a/src/main/java/com/kt/service/AuthService.java
+++ b/src/main/java/com/kt/service/AuthService.java
@@ -17,9 +17,9 @@ public interface AuthService {
 
 	void verifySignupCode(SignupRequest.VerifySignupCode request);
 
-	void resetPassword(PasswordManagementRequest.PasswordReset request);
+	void initPassword(PasswordManagementRequest.PasswordInit request);
 
-	void requestResetPassword(PasswordManagementRequest.PasswordReset request);
+	void requestPasswordInit(PasswordManagementRequest.PasswordInit request);
 
-	void requestUpdatePassword(PasswordManagementRequest.PasswordUpdate request);
+	void requestPasswordUpdate(PasswordManagementRequest.PasswordUpdate request);
 }

--- a/src/main/java/com/kt/service/AuthServiceImpl.java
+++ b/src/main/java/com/kt/service/AuthServiceImpl.java
@@ -26,7 +26,6 @@ import com.kt.repository.PasswordRequestRepository;
 import com.kt.repository.courier.CourierRepository;
 import com.kt.repository.user.UserRepository;
 
-import com.kt.util.EncryptUtil;
 import com.mysema.commons.lang.Pair;
 
 import lombok.RequiredArgsConstructor;
@@ -148,7 +147,7 @@ public class AuthServiceImpl implements AuthService {
 	}
 
 	@Override
-	public void resetPassword(PasswordManagementRequest.PasswordReset request) {
+	public void initPassword(PasswordManagementRequest.PasswordInit request) {
 		String email = request.email();
 		AbstractAccountEntity account = accountRepository
 			.findByEmailOrThrow(email);
@@ -163,7 +162,7 @@ public class AuthServiceImpl implements AuthService {
 	}
 
 	@Override
-	public void requestResetPassword(PasswordManagementRequest.PasswordReset request) {
+	public void requestPasswordInit(PasswordManagementRequest.PasswordInit request) {
 		AbstractAccountEntity account = accountRepository
 			.findByEmailOrThrow(request.email());
 
@@ -177,13 +176,13 @@ public class AuthServiceImpl implements AuthService {
 			);
 
 		if (!passwordRequest.isNew())
-			throw new CustomException(ErrorCode.PASSWORD_RESET_ALREADY_REQUESTED);
+			throw new CustomException(ErrorCode.PASSWORD_INIT_ALREADY_REQUESTED);
 
 		passwordRequestRepository.save(passwordRequest);
 	}
 
 	@Override
-	public void requestUpdatePassword(PasswordManagementRequest.PasswordUpdate request) {
+	public void requestPasswordUpdate(PasswordManagementRequest.PasswordUpdate request) {
 		AbstractAccountEntity account = accountRepository
 			.findByEmailOrThrow(request.email());
 

--- a/src/test/java/com/kt/api/auth/AuthInitPasswordRequestTest.java
+++ b/src/test/java/com/kt/api/auth/AuthInitPasswordRequestTest.java
@@ -1,0 +1,82 @@
+package com.kt.api.auth;
+
+import com.kt.common.MockMvcTest;
+import com.kt.constant.PasswordRequestStatus;
+import com.kt.constant.PasswordRequestType;
+import com.kt.domain.dto.request.PasswordManagementRequest;
+import com.kt.domain.entity.PasswordRequestEntity;
+import com.kt.domain.entity.UserEntity;
+import com.kt.repository.PasswordRequestRepository;
+import com.kt.repository.user.UserRepository;
+
+import com.kt.security.CurrentUser;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static com.kt.common.UserEntityCreator.createMember;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static com.kt.common.CurrentUserCreator.getAdminUserDetails;
+import static org.junit.jupiter.api.Assertions.*;
+
+@Slf4j
+@DisplayName("비밀번호 초기화 요청 - POST /api/auth/password-init/requests")
+public class AuthInitPasswordRequestTest extends MockMvcTest {
+
+	@Autowired
+	UserRepository userRepository;
+
+	@Autowired
+	PasswordRequestRepository passwordRequestRepository;
+
+	UserEntity testUser;
+	CurrentUser currentUser;
+	@BeforeEach
+	void setUp() {
+		saveTestUser();
+	}
+
+	void saveTestUser() {
+		testUser = createMember();
+		currentUser = getAdminUserDetails();
+		userRepository.save(testUser);
+	}
+
+	@Test
+	void 계정_비밀번호_초기화_요청_성공__200_OK() throws Exception {
+		PasswordManagementRequest.PasswordInit request =
+			new PasswordManagementRequest.PasswordInit(
+				testUser.getEmail()
+			);
+
+		ResultActions actions = mockMvc.perform(
+			post("/api/auth/password-init/requests")
+				.with(user(getAdminUserDetails()))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request))
+		);
+		actions.andDo(print());
+
+		PasswordRequestEntity passwordRequest =
+			passwordRequestRepository.findByAccountAndStatusAndRequestType(
+				testUser, PasswordRequestStatus.PENDING, PasswordRequestType.RESET
+			).orElse(null);
+
+		assertNotNull(passwordRequest);
+		assertEquals(
+			testUser.getId(),
+			passwordRequest.getAccount().getId()
+		);
+		log.info("passRequest account id : {}", passwordRequest.getAccount().getId());
+
+	}
+}

--- a/src/test/java/com/kt/controller/auth/AuthControllerTest.java
+++ b/src/test/java/com/kt/controller/auth/AuthControllerTest.java
@@ -81,8 +81,8 @@ class AuthControllerTest {
 			"010-3333-2222"
 		);
 		UserEntity savedUser = userRepository.save(user);
-		PasswordManagementRequest.PasswordReset resetPasswordRequest =
-			new PasswordManagementRequest.PasswordReset(
+		PasswordManagementRequest.PasswordInit resetPasswordRequest =
+			new PasswordManagementRequest.PasswordInit(
 				savedUser.getEmail()
 			);
 

--- a/src/test/java/com/kt/service/AuthServiceTest.java
+++ b/src/test/java/com/kt/service/AuthServiceTest.java
@@ -381,12 +381,12 @@ public class AuthServiceTest {
 	@Test
 	@Transactional
 	void 계정_비밀번호_초기화_성공() {
-		PasswordManagementRequest.PasswordReset resetRequest =
-			new PasswordManagementRequest.PasswordReset(
+		PasswordManagementRequest.PasswordInit resetRequest =
+			new PasswordManagementRequest.PasswordInit(
 				user.getEmail()
 			);
 
-		authService.resetPassword(resetRequest);
+		authService.initPassword(resetRequest);
 
 		assertEquals(false, passwordEncoder.matches(rawPassword, user.getPassword()));
 
@@ -395,13 +395,13 @@ public class AuthServiceTest {
 	@Test
 	void 계정_비밀번호_초기화_실패_계정_없음() {
 		String notExistsEmail = "test@email.com";
-		PasswordManagementRequest.PasswordReset resetRequest =
-			new PasswordManagementRequest.PasswordReset(
+		PasswordManagementRequest.PasswordInit resetRequest =
+			new PasswordManagementRequest.PasswordInit(
 				notExistsEmail
 			);
 		assertThrowsExactly(
 			CustomException.class, () ->
-				authService.resetPassword(resetRequest)
+				authService.initPassword(resetRequest)
 		);
 	}
 
@@ -479,12 +479,12 @@ public class AuthServiceTest {
 
 	@Test
 	void 비밀번호_초기화_요청_성공() {
-		PasswordManagementRequest.PasswordReset request =
-			new PasswordManagementRequest.PasswordReset(
+		PasswordManagementRequest.PasswordInit request =
+			new PasswordManagementRequest.PasswordInit(
 				user.getEmail()
 			);
 
-		authService.requestResetPassword(request);
+		authService.requestPasswordInit(request);
 
 		PasswordRequestEntity passwordRequest = passwordRequestRepository
 			.findByAccountAndStatusAndRequestType(
@@ -500,12 +500,12 @@ public class AuthServiceTest {
 
 	@Test
 	void 비밀번호_초기화_요청_실패_데이터_존재() {
-		PasswordManagementRequest.PasswordReset request =
-			new PasswordManagementRequest.PasswordReset(
+		PasswordManagementRequest.PasswordInit request =
+			new PasswordManagementRequest.PasswordInit(
 				user.getEmail()
 			);
 
-		authService.requestResetPassword(request);
+		authService.requestPasswordInit(request);
 
 		PasswordRequestEntity passwordRequest = passwordRequestRepository
 			.findByAccountAndStatusAndRequestType(
@@ -515,9 +515,9 @@ public class AuthServiceTest {
 		assertNotNull(passwordRequest);
 
 		assertThatThrownBy(
-			() -> authService.requestResetPassword(request))
+			() -> authService.requestPasswordInit(request))
 			.isInstanceOf(CustomException.class)
-			.hasMessageContaining("PASSWORD_RESET_ALREADY_REQUESTED");
+			.hasMessageContaining("PASSWORD_INIT_ALREADY_REQUESTED");
 	}
 
 	@Test
@@ -528,7 +528,7 @@ public class AuthServiceTest {
 				user.getEmail(), updatePassword
 			);
 
-		authService.requestUpdatePassword(request);
+		authService.requestPasswordUpdate(request);
 
 		PasswordRequestEntity passwordRequest = passwordRequestRepository
 			.findByAccountAndStatusAndRequestType(
@@ -552,7 +552,7 @@ public class AuthServiceTest {
 				user.getEmail(), firstUpdatePassword
 			);
 
-		authService.requestUpdatePassword(firstRequest);
+		authService.requestPasswordUpdate(firstRequest);
 
 		PasswordRequestEntity firstSavePasswordRequest = passwordRequestRepository
 			.findByAccountAndStatusAndRequestType(
@@ -572,7 +572,7 @@ public class AuthServiceTest {
 				user.getEmail(), secondUpdatePassword
 			);
 
-		authService.requestUpdatePassword(secondRequest);
+		authService.requestPasswordUpdate(secondRequest);
 
 		PasswordRequestEntity secondSavePasswordRequest = passwordRequestRepository
 			.findByAccountAndStatusAndRequestType(


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- resolves: #이슈번호, #이슈번호 -->
resolves: #132 

## 📝작업 내용

  - 비밀 번호 초기화 요청 controller 생성
  - 비밀번호 초기화 요청 API Test 코드 생성
  - 초기화 naming : reset -> init
  - PasswordManagementRequest PasswordReset -> PasswordInit

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->