### PR TITLE
[FEAT] 계정 비밀번호 변경 (관리자) API 개발 및 테스트

### DIFF
--- a/src/main/java/com/kt/controller/admin/account/AdminAccountController.java
+++ b/src/main/java/com/kt/controller/admin/account/AdminAccountController.java
@@ -64,6 +64,12 @@ public class AdminAccountController implements AdminAccountSwaggerSupporter {
 		accountService.resetAccountPassword(accountId);
 		return empty();
 	}
+
+	@PatchMapping("/{accountId}/password/update")
+	public ResponseEntity<ApiResult<Void>> updateAccountPassword(@PathVariable UUID accountId) {
+		accountService.updateAccountPassword(accountId);
+		return empty();
+	}
 }
 
 

--- a/src/main/java/com/kt/controller/admin/account/AdminAccountSwaggerSupporter.java
+++ b/src/main/java/com/kt/controller/admin/account/AdminAccountSwaggerSupporter.java
@@ -57,4 +57,13 @@ public interface AdminAccountSwaggerSupporter extends SwaggerSupporter {
 		}
 	)
 	ResponseEntity<ApiResult<Void>> resetAccountPassword(UUID accountId);
+
+	@Operation(
+		summary = "계정 비밀번호 변경",
+		description = "관리자의 계정 비밀번호 변경 API",
+		parameters = {
+			@Parameter(name = "accountId" , description = "계정 ID")
+		}
+	)
+	ResponseEntity<ApiResult<Void>> updateAccountPassword(UUID accountId);
 }

--- a/src/test/java/com/kt/api/admin/account/AccountPasswordUpdateTest.java
+++ b/src/test/java/com/kt/api/admin/account/AccountPasswordUpdateTest.java
@@ -1,0 +1,94 @@
+package com.kt.api.admin.account;
+
+import com.kt.common.MockMvcTest;
+
+import com.kt.common.UserEntityCreator;
+import com.kt.constant.PasswordRequestStatus;
+import com.kt.constant.PasswordRequestType;
+import com.kt.domain.entity.PasswordRequestEntity;
+import com.kt.domain.entity.UserEntity;
+import com.kt.repository.PasswordRequestRepository;
+import com.kt.repository.user.UserRepository;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static com.kt.common.CurrentUserCreator.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@Slf4j
+@DisplayName("계정 비밀번호 초기화 - PATCH /api/admin/accounts/{accountId}/password/update")
+public class AccountPasswordUpdateTest extends MockMvcTest {
+
+	@Autowired
+	UserRepository userRepository;
+
+	@Autowired
+	PasswordRequestRepository passwordRequestRepository;
+
+	@Autowired
+	PasswordEncoder passwordEncoder;
+
+	UserEntity testUser;
+	static final String ORIGIN_PASSWORD = "1231231!";
+	static final String UPDATE_PASSWORD = "123123@@";
+	@BeforeEach
+	void setUp() {
+		testUser = UserEntityCreator.createMember(
+			"bjwnstkdbj@naver.com",
+			passwordEncoder.encode(ORIGIN_PASSWORD)
+		);
+		userRepository.save(testUser);
+		setPasswordRequest();
+	}
+
+	void setPasswordRequest() {
+		PasswordRequestEntity passwordRequest = PasswordRequestEntity.create(
+			testUser,
+			UPDATE_PASSWORD,
+			PasswordRequestType.UPDATE
+		);
+		passwordRequestRepository.save(passwordRequest);
+	}
+
+
+	@Test
+	void 계정_비밀번호_변경_성공__200_OK() throws Exception {
+		PasswordRequestEntity passwordRequest = null;
+		passwordRequest = passwordRequestRepository.findByAccountAndStatusAndRequestType(
+			testUser, PasswordRequestStatus.PENDING, PasswordRequestType.UPDATE
+		).orElse(null);
+		assertNotNull(passwordRequest);
+		assertNotNull(passwordRequest.getEncryptedPassword());
+		log.info("Before UpdatePassword Service: {}", passwordRequest.getEncryptedPassword());
+		ResultActions actions = mockMvc.perform(
+			patch(
+				"/api/admin/accounts/{accountId}/password/update",
+				testUser.getId()
+			).with(user(getAdminUserDetails()))
+		);
+
+		actions.andExpect(status().isOk());
+
+		assertTrue(
+			passwordEncoder.matches(UPDATE_PASSWORD, testUser.getPassword())
+		);
+		passwordRequest = passwordRequestRepository.findByAccountAndStatusAndRequestType(
+			testUser, PasswordRequestStatus.COMPLETED, PasswordRequestType.UPDATE
+		).orElse(null);
+
+		assertNotNull(passwordRequest);
+		assertNull(passwordRequest.getEncryptedPassword());
+		log.info("passwordRequest getPassword : {}", passwordRequest.getEncryptedPassword());
+	}
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

resolves: #164 

## 📝작업 내용

- 계정 비밀번호 변경 (관리자) API 개발 및 API 테스트

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->