### PR TITLE
[REFACTOR] 인증(Auth) 관련 API 테스트 추가 및 기존 AuthController 테스트 제거

### DIFF
--- a/src/main/java/com/kt/controller/admin/AdminController.java
+++ b/src/main/java/com/kt/controller/admin/AdminController.java
@@ -73,7 +73,7 @@ public class AdminController implements AdminSwaggerSupporter {
 	@PostMapping
 	public ResponseEntity<ApiResult<Void>> createAdmin(
 		@AuthenticationPrincipal DefaultCurrentUser currentUser,
-		@RequestBody @Valid SignupRequest.SignupMember request
+ 		@RequestBody @Valid SignupRequest.SignupUser request
 	) {
 		adminAdminService.createAdmin(currentUser.getId(), request);
 		return empty();

--- a/src/main/java/com/kt/controller/admin/AdminSwaggerSupporter.java
+++ b/src/main/java/com/kt/controller/admin/AdminSwaggerSupporter.java
@@ -50,7 +50,7 @@ public interface AdminSwaggerSupporter {
 	)
 	ResponseEntity<ApiResult<Void>> createAdmin(
 		@Parameter(hidden = true) DefaultCurrentUser defaultCurrentUser,
-		@RequestBody @Valid SignupRequest.SignupMember request
+		@RequestBody @Valid SignupRequest.SignupUser request
 	);
 
 	@Operation(

--- a/src/main/java/com/kt/controller/auth/AuthController.java
+++ b/src/main/java/com/kt/controller/auth/AuthController.java
@@ -58,20 +58,20 @@ public class AuthController extends SwaggerAssistance {
 	}
 
 	@Operation(
-		summary = "회원 가입",
-		description = "회원 가입 API"
+		summary = "유저 회원 가입",
+		description = "유저 회원 가입 API"
 	)
-	@PostMapping("/signup/member")
-	public ResponseEntity<ApiResult<Void>> signupMember(
-		@RequestBody @Valid SignupRequest.SignupMember request
+	@PostMapping("/signup/user")
+	public ResponseEntity<ApiResult<Void>> signupUser(
+		@RequestBody @Valid SignupRequest.SignupUser request
 	) {
-		authService.signupMember(request);
+		authService.signupUser(request);
 		return empty();
 	}
 
 	@Operation(
-		summary = "기사 가입",
-		description = "기사 가입 API"
+		summary = "기사 회원 가입",
+		description = "기사 회원 가입 API"
 	)
 	@PostMapping("/signup/courier")
 	public ResponseEntity<ApiResult<Void>> signupCourier(

--- a/src/main/java/com/kt/controller/auth/AuthController.java
+++ b/src/main/java/com/kt/controller/auth/AuthController.java
@@ -34,7 +34,7 @@ public class AuthController extends SwaggerAssistance {
 	private final AuthService authService;
 
 	@Operation(
-		summary = "인증 번호 전송",
+		summary = "이메일 인증 코드 전송",
 		description = "요청된 이메일로 인증 번호 전송 API"
 	)
 	@PostMapping("/email/code")
@@ -46,11 +46,11 @@ public class AuthController extends SwaggerAssistance {
 	}
 
 	@Operation(
-		summary = "인증 번호 검증",
+		summary = "이메일 인증 코드 검증",
 		description = "이메일로 전송된 인증 코드 검증 API"
 	)
 	@PostMapping("/email/verify")
-	public ResponseEntity<ApiResult<Void>> verifySignupCode(
+	public ResponseEntity<ApiResult<Void>> verifyAuthCode(
 		@RequestBody @Valid SignupRequest.VerifySignupCode request
 	) {
 		authService.verifySignupCode(request);

--- a/src/main/java/com/kt/domain/dto/request/SignupRequest.java
+++ b/src/main/java/com/kt/domain/dto/request/SignupRequest.java
@@ -31,8 +31,8 @@ public class SignupRequest {
 	) {
 	}
 
-	@Schema(name = "SignupMemberRequest")
-	public record SignupMember(
+	@Schema(name = "SignupUserRequest")
+	public record SignupUser(
 		@NotBlank(message = "이름은 필수 항목입니다.")
 		String name,
 

--- a/src/main/java/com/kt/service/AuthService.java
+++ b/src/main/java/com/kt/service/AuthService.java
@@ -7,7 +7,7 @@ import com.mysema.commons.lang.Pair;
 
 public interface AuthService {
 
-	void signupMember(SignupRequest.SignupMember request);
+	void signupUser(SignupRequest.SignupUser request);
 
 	void signupCourier(SignupRequest.SignupCourier request);
 

--- a/src/main/java/com/kt/service/AuthServiceImpl.java
+++ b/src/main/java/com/kt/service/AuthServiceImpl.java
@@ -53,7 +53,7 @@ public class AuthServiceImpl implements AuthService {
 	private final EmailClient emailClient;
 
 	@Override
-	public void signupMember(SignupRequest.SignupMember request) {
+	public void signupUser(SignupRequest.SignupUser request) {
 		String email = request.email();
 		requireVerifiedEmail(email);
 		requireDuplicatedEmail(email);

--- a/src/main/java/com/kt/service/UserService.java
+++ b/src/main/java/com/kt/service/UserService.java
@@ -34,7 +34,7 @@ public interface UserService {
 
 	void retireUser(UUID currentId, UUID subjectId) ;
 
-	void createAdmin(UUID userId, SignupRequest.SignupMember request);
+	void createAdmin(UUID userId, SignupRequest.SignupUser request);
 
 	void deleteAdmin(UUID currentId, UUID adminId);
 

--- a/src/main/java/com/kt/service/UserServiceImpl.java
+++ b/src/main/java/com/kt/service/UserServiceImpl.java
@@ -140,7 +140,7 @@ public class UserServiceImpl implements UserService {
 
 	// TODO: for admin
 	@Override
-	public void createAdmin(UUID userId, SignupRequest.SignupMember request) {
+	public void createAdmin(UUID userId, SignupRequest.SignupUser request) {
 		checkAdmin(userId);
 
 		UserEntity admin = UserEntity.create(

--- a/src/test/java/com/kt/api/auth/AuthLoginTest.java
+++ b/src/test/java/com/kt/api/auth/AuthLoginTest.java
@@ -2,6 +2,7 @@ package com.kt.api.auth;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.kt.common.MockMvcTest;
+import com.kt.common.UserEntityCreator;
 import com.kt.constant.Gender;
 import com.kt.constant.UserRole;
 import com.kt.domain.dto.request.LoginRequest;
@@ -19,7 +20,6 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MvcResult;
 
-import java.time.LocalDate;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
@@ -27,7 +27,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @Slf4j
 @ActiveProfiles("test")
-@DisplayName("이메일 인증 코드 검증 - POST /api/auth/login")
+@DisplayName("계정로그인 - POST /api/auth/login")
 public class AuthLoginTest extends MockMvcTest {
 
 	@Autowired
@@ -44,14 +44,8 @@ public class AuthLoginTest extends MockMvcTest {
 	}
 
 	void saveUser() {
-		UserEntity user = UserEntity.create(
-			"테스트유저",
-			EMAIL,
-			passwordEncoder.encode(PASSWORD),
-			UserRole.MEMBER,
-			Gender.MALE,
-			LocalDate.of(2000, 1, 30),
-			"010-1234-5678"
+		UserEntity user = UserEntityCreator.createMember(
+			EMAIL, passwordEncoder.encode(PASSWORD)
 		);
 		userRepository.save(user);
 		assertNotNull(user);
@@ -60,8 +54,7 @@ public class AuthLoginTest extends MockMvcTest {
 	@Test
 	void 로그인_성공_200__OK() throws Exception {
 		LoginRequest request = new LoginRequest(
-			EMAIL,
-			PASSWORD
+			EMAIL, PASSWORD
 		);
 		MvcResult result = mockMvc.perform(
 			post("/api/auth/login")

--- a/src/test/java/com/kt/api/auth/AuthLoginTest.java
+++ b/src/test/java/com/kt/api/auth/AuthLoginTest.java
@@ -1,0 +1,82 @@
+package com.kt.api.auth;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.kt.common.MockMvcTest;
+import com.kt.constant.Gender;
+import com.kt.constant.UserRole;
+import com.kt.domain.dto.request.LoginRequest;
+import com.kt.domain.entity.UserEntity;
+import com.kt.repository.user.UserRepository;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.time.LocalDate;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@Slf4j
+@ActiveProfiles("test")
+@DisplayName("이메일 인증 코드 검증 - POST /api/auth/login")
+public class AuthLoginTest extends MockMvcTest {
+
+	@Autowired
+	UserRepository userRepository;
+
+	@Autowired
+	PasswordEncoder passwordEncoder;
+
+	static final String EMAIL = "bjwnstkdbj@naver.com";
+	static final String PASSWORD = "123123!@";
+	@BeforeEach
+	void init() {
+		saveUser();
+	}
+
+	void saveUser() {
+		UserEntity user = UserEntity.create(
+			"테스트유저",
+			EMAIL,
+			passwordEncoder.encode(PASSWORD),
+			UserRole.MEMBER,
+			Gender.MALE,
+			LocalDate.of(2000, 1, 30),
+			"010-1234-5678"
+		);
+		userRepository.save(user);
+		assertNotNull(user);
+	}
+
+	@Test
+	void 로그인_성공_200__OK() throws Exception {
+		LoginRequest request = new LoginRequest(
+			EMAIL,
+			PASSWORD
+		);
+		MvcResult result = mockMvc.perform(
+			post("/api/auth/login")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request))
+		).andDo(print())
+			.andExpect(status().isOk())
+			.andReturn();
+
+		String response = result.getResponse().getContentAsString();
+		JsonNode json = objectMapper.readTree(response);
+		String accessToken = json.get("data").get("accessToken").asText();
+		String refreshToken = json.get("data").get("refreshToken").asText();
+
+		log.info("accessToken :: {}", accessToken);
+		log.info("refreshToken :: {}", refreshToken);
+	}
+}

--- a/src/test/java/com/kt/api/auth/AuthSendAuthCodeTest.java
+++ b/src/test/java/com/kt/api/auth/AuthSendAuthCodeTest.java
@@ -1,0 +1,54 @@
+package com.kt.api.auth;
+
+import com.kt.common.MockMvcTest;
+import com.kt.constant.redis.RedisKey;
+import com.kt.domain.dto.request.SignupRequest;
+import com.kt.domain.entity.UserEntity;
+import com.kt.infra.redis.RedisCache;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+
+@Slf4j
+@ActiveProfiles("test")
+@DisplayName("이메일 인증 코드 전송 - POST /api/auth/email/code")
+public class AuthSendAuthCodeTest extends MockMvcTest {
+
+	@Autowired
+	RedisCache redisCache;
+
+	UserEntity testUser;
+	static final String EMAIL = "bjwnstkdbj@naver.com";
+
+	@Test
+	void 인증번호_발송_성공__200__OK() throws Exception {
+		SignupRequest.SignupEmail request = new SignupRequest.SignupEmail(
+			EMAIL
+		);
+		ResultActions actions = mockMvc.perform(
+			post("/api/auth/email/code")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request))
+		);
+		actions.andDo(print());
+
+		String authCode = redisCache.get(
+			RedisKey.SIGNUP_CODE.key(EMAIL),
+			String.class
+		);
+
+		log.info("authCode :: {}", authCode);
+		assertNotNull(authCode);
+	}
+
+}

--- a/src/test/java/com/kt/api/auth/AuthSendVerifyCodeTest.java
+++ b/src/test/java/com/kt/api/auth/AuthSendVerifyCodeTest.java
@@ -1,0 +1,76 @@
+package com.kt.api.auth;
+
+import com.kt.common.MockMvcTest;
+import com.kt.constant.redis.RedisKey;
+import com.kt.domain.dto.request.SignupRequest;
+import com.kt.domain.entity.UserEntity;
+import com.kt.infra.redis.RedisCache;
+import com.kt.repository.user.UserRepository;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.ResultActions;
+
+
+import static com.kt.common.UserEntityCreator.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+
+@Slf4j
+@ActiveProfiles("test")
+@DisplayName("비밀번호 초기화 요청 - POST /api/auth/email/code")
+public class AuthSendVerifyCodeTest extends MockMvcTest {
+
+	@Autowired
+	UserRepository userRepository;
+	@Autowired
+	RedisCache redisCache;
+	@Autowired
+	PasswordEncoder passwordEncoder;
+
+	UserEntity testUser;
+	static final String EMAIL = "bjwnstkdbj@naver.com";
+	static final String PASSWORD = "1231231!";
+
+	@BeforeEach
+	void setUp() {
+		saveTestUser();
+	}
+
+	void saveTestUser() {
+		testUser = createMember(
+			EMAIL, passwordEncoder.encode(PASSWORD)
+		);
+		userRepository.save(testUser);
+	}
+
+	@Test
+	void 인증번호_발송_성공__200__OK() throws Exception {
+		SignupRequest.SignupEmail request = new SignupRequest.SignupEmail(
+			EMAIL
+		);
+		ResultActions actions = mockMvc.perform(
+			post("/api/auth/email/code")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request))
+		);
+		actions.andDo(print());
+
+		String authCode = redisCache.get(
+			RedisKey.SIGNUP_CODE.key(EMAIL),
+			String.class
+		);
+
+		log.info("authCode :: {}", authCode);
+		assertNotNull(authCode);
+	}
+
+}

--- a/src/test/java/com/kt/api/auth/AuthSignupCourierTest.java
+++ b/src/test/java/com/kt/api/auth/AuthSignupCourierTest.java
@@ -1,0 +1,68 @@
+package com.kt.api.auth;
+
+import com.kt.common.MockMvcTest;
+import com.kt.constant.Gender;
+import com.kt.constant.redis.RedisKey;
+import com.kt.domain.dto.request.SignupRequest;
+
+import com.kt.domain.entity.CourierEntity;
+import com.kt.infra.redis.RedisCache;
+import com.kt.repository.courier.CourierRepository;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Slf4j
+@ActiveProfiles("test")
+@DisplayName("이메일 인증 코드 검증 - POST /api/auth/signup/courier")
+public class AuthSignupCourierTest extends MockMvcTest {
+
+	@Autowired
+	RedisCache redisCache;
+
+	@Autowired
+	CourierRepository courierRepository;
+
+	static final String EMAIL = "bjwnstkdbj@naver.com";
+
+	@BeforeEach
+	void init() {
+		redisCache.set(RedisKey.SIGNUP_VERIFIED, EMAIL, true);
+	}
+	@Test
+	void 유저_회원갸입_성공_200__OK() throws Exception {
+
+		SignupRequest.SignupCourier request = new SignupRequest.SignupCourier(
+			"테스트기사",
+			EMAIL,
+			"123123",
+			Gender.MALE
+		);
+
+		ResultActions actions = mockMvc.perform(
+			post("/api/auth/signup/courier")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request))
+		);
+		actions.andDo(print());
+
+		CourierEntity courier = courierRepository.findByEmailOrThrow(EMAIL);
+		assertNotNull(courier);
+		assertNotNull(courier.getId());
+		log.info("courier id : {}", courier.getId());
+		assertEquals(courier.getEmail(), EMAIL);
+
+	}
+}

--- a/src/test/java/com/kt/api/auth/AuthSignupCourierTest.java
+++ b/src/test/java/com/kt/api/auth/AuthSignupCourierTest.java
@@ -1,7 +1,7 @@
 package com.kt.api.auth;
 
 import com.kt.common.MockMvcTest;
-import com.kt.constant.Gender;
+import com.kt.common.SignupCourierRequestCreator;
 import com.kt.constant.redis.RedisKey;
 import com.kt.domain.dto.request.SignupRequest;
 
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @Slf4j
 @ActiveProfiles("test")
-@DisplayName("이메일 인증 코드 검증 - POST /api/auth/signup/courier")
+@DisplayName("기사 회원가입 - POST /api/auth/signup/courier")
 public class AuthSignupCourierTest extends MockMvcTest {
 
 	@Autowired
@@ -42,14 +42,9 @@ public class AuthSignupCourierTest extends MockMvcTest {
 		redisCache.set(RedisKey.SIGNUP_VERIFIED, EMAIL, true);
 	}
 	@Test
-	void 유저_회원갸입_성공_200__OK() throws Exception {
-
-		SignupRequest.SignupCourier request = new SignupRequest.SignupCourier(
-			"테스트기사",
-			EMAIL,
-			"123123",
-			Gender.MALE
-		);
+	void 기사_회원가입_성공_200__OK() throws Exception {
+		SignupRequest.SignupCourier request =
+			SignupCourierRequestCreator.createSignupCourierRequest(EMAIL);
 
 		ResultActions actions = mockMvc.perform(
 			post("/api/auth/signup/courier")

--- a/src/test/java/com/kt/api/auth/AuthSignupUserTest.java
+++ b/src/test/java/com/kt/api/auth/AuthSignupUserTest.java
@@ -1,7 +1,7 @@
 package com.kt.api.auth;
 
 import com.kt.common.MockMvcTest;
-import com.kt.constant.Gender;
+import com.kt.common.SignupUserRequestCreator;
 import com.kt.constant.redis.RedisKey;
 import com.kt.domain.dto.request.SignupRequest;
 import com.kt.domain.entity.UserEntity;
@@ -28,7 +28,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 
 @Slf4j
 @ActiveProfiles("test")
-@DisplayName("이메일 인증 코드 검증 - POST /api/auth/signup/user")
+@DisplayName("유저 회원가입 - POST /api/auth/signup/user")
 public class AuthSignupUserTest extends MockMvcTest {
 	@Autowired
 	RedisCache redisCache;
@@ -44,16 +44,10 @@ public class AuthSignupUserTest extends MockMvcTest {
 	}
 
 	@Test
-	void 유저_회원갸입_성공_200__OK() throws Exception {
+	void 유저_회원가입_성공_200__OK() throws Exception {
 
-		SignupRequest.SignupUser request = new SignupRequest.SignupUser(
-			"테스트황",
-			EMAIL,
-			"1231231!",
-			Gender.MALE,
-			LocalDate.of(1998, 3, 13),
-			"010-1234-1234"
-		);
+		SignupRequest.SignupUser request =
+			SignupUserRequestCreator.createSignupUserRequest(EMAIL);
 
 		ResultActions actions = mockMvc.perform(
 			post("/api/auth/signup/user")

--- a/src/test/java/com/kt/api/auth/AuthSignupUserTest.java
+++ b/src/test/java/com/kt/api/auth/AuthSignupUserTest.java
@@ -1,0 +1,72 @@
+package com.kt.api.auth;
+
+import com.kt.common.MockMvcTest;
+import com.kt.constant.Gender;
+import com.kt.constant.redis.RedisKey;
+import com.kt.domain.dto.request.SignupRequest;
+import com.kt.domain.entity.UserEntity;
+import com.kt.infra.redis.RedisCache;
+
+import com.kt.repository.user.UserRepository;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+
+@Slf4j
+@ActiveProfiles("test")
+@DisplayName("이메일 인증 코드 검증 - POST /api/auth/signup/user")
+public class AuthSignupUserTest extends MockMvcTest {
+	@Autowired
+	RedisCache redisCache;
+
+	@Autowired
+	UserRepository userRepository;
+
+	static final String EMAIL = "bjwnstkdbj@naver.com";
+
+	@BeforeEach
+	void init() {
+		redisCache.set(RedisKey.SIGNUP_VERIFIED, EMAIL, true);
+	}
+
+	@Test
+	void 유저_회원갸입_성공_200__OK() throws Exception {
+
+		SignupRequest.SignupUser request = new SignupRequest.SignupUser(
+			"테스트황",
+			EMAIL,
+			"1231231!",
+			Gender.MALE,
+			LocalDate.of(1998, 3, 13),
+			"010-1234-1234"
+		);
+
+		ResultActions actions = mockMvc.perform(
+			post("/api/auth/signup/user")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request))
+		);
+		actions.andDo(print());
+
+		UserEntity user = userRepository.findByEmailOrThrow(EMAIL);
+		assertNotNull(user);
+		assertNotNull(user.getId());
+		assertEquals(user.getEmail(), EMAIL);
+		log.info("user.getId ::  {}", user.getId());
+	}
+
+}

--- a/src/test/java/com/kt/api/auth/AuthUpdatePasswordRequestTest.java
+++ b/src/test/java/com/kt/api/auth/AuthUpdatePasswordRequestTest.java
@@ -31,7 +31,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 
 @Slf4j
-@DisplayName("비밀번호 초기화 요청 - POST /api/auth/password-update/requests")
+@DisplayName("비밀번호 변경 요청 - POST /api/auth/password-update/requests")
 public class AuthUpdatePasswordRequestTest extends MockMvcTest {
 
 	@Autowired

--- a/src/test/java/com/kt/common/SignupUserRequestCreator.java
+++ b/src/test/java/com/kt/common/SignupUserRequestCreator.java
@@ -7,10 +7,10 @@ import java.time.LocalDate;
 import com.kt.constant.Gender;
 import com.kt.domain.dto.request.SignupRequest;
 
-public class SignupMemberRequestCreator {
+public class SignupUserRequestCreator {
 
-	public static SignupRequest.SignupMember createSignupMemberRequest() {
-		return new SignupRequest.SignupMember(
+	public static SignupRequest.SignupUser createSignupUserRequest() {
+		return new SignupRequest.SignupUser(
 			"테스트회원",
 			randomUUID() + "@test.com",
 			"1231231!",
@@ -20,10 +20,10 @@ public class SignupMemberRequestCreator {
 		);
 	}
 
-	public static SignupRequest.SignupMember createSignupMemberRequest(
+	public static SignupRequest.SignupUser createSignupUserRequest(
 		String email
 	) {
-		return new SignupRequest.SignupMember(
+		return new SignupRequest.SignupUser(
 			"테스트회원",
 			email,
 			"1231231!",

--- a/src/test/java/com/kt/controller/auth/AuthControllerTest.java
+++ b/src/test/java/com/kt/controller/auth/AuthControllerTest.java
@@ -53,35 +53,6 @@ class AuthControllerTest extends MockMvcTest {
 	}
 
 	@Test
-	void 인증코드_발송_성공() throws Exception {
-
-		// given
-		var request = new SignupRequest.SignupEmail(TEST_EMAIL);
-
-		// when
-		mockMvc.perform(
-				post("/api/auth/email/code")
-					.contentType(MediaType.APPLICATION_JSON)
-					.content(objectMapper.writeValueAsString(request))
-			)
-			.andDo(print())
-			.andExpectAll(
-				status().isOk(),
-				jsonPath("$.code").value("ok"),
-				jsonPath("$.message").value("성공")
-			);
-
-		// then
-		assertThat(redisCache.hasKey(RedisKey.SIGNUP_CODE.key(TEST_EMAIL))).isEqualTo(true);
-		String redisAuthCode = redisCache.get(
-			RedisKey.SIGNUP_CODE.key(TEST_EMAIL),
-			String.class
-		);
-		log.info("이메일 인증코드: - 발송: {}", redisAuthCode);
-		assertThat(redisAuthCode).isNotNull();
-	}
-
-	@Test
 	void 인증코드_인증_성공() throws Exception {
 
 		// given

--- a/src/test/java/com/kt/controller/auth/AuthControllerTest.java
+++ b/src/test/java/com/kt/controller/auth/AuthControllerTest.java
@@ -51,47 +51,4 @@ class AuthControllerTest extends MockMvcTest {
 		accountRepository.deleteAll();
 		redisCache.delete(RedisKey.SIGNUP_CODE.key(TEST_EMAIL));
 	}
-
-	@Test
-	void 로그인_성공() throws Exception {
-
-		String email = "dd@com";
-		String password = "123456";
-		// given
-
-		UserEntity user = UserEntity.create(
-			"김도현",
-			email,
-			passwordEncoder.encode(password),
-			UserRole.MEMBER,
-			Gender.MALE,
-			LocalDate.of(2000, 1, 1),
-			"010-3333-2222"
-		);
-		userRepository.save(user);
-
-		LoginRequest loginInfo = new LoginRequest(email, password);
-
-		// when
-		MvcResult result = mockMvc.perform(post("/api/auth/login")
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(objectMapper.writeValueAsString(loginInfo)))
-			.andDo(print())
-			.andExpectAll(
-				status().isOk(),
-				jsonPath("$.code").value("ok"),
-				jsonPath("$.message").value("성공")
-			).andReturn();
-
-		// then
-		String responseBody = result.getResponse().getContentAsString();
-		JsonNode json = objectMapper.readTree(responseBody);
-
-		String accessToken = json.get("data").get("accessToken").asText();
-		String refreshToken = json.get("data").get("refreshToken").asText();
-
-		assertThatCode(() -> jwtTokenProvider.validateToken(accessToken)).doesNotThrowAnyException();
-		assertThatCode(() -> jwtTokenProvider.validateToken(refreshToken)).doesNotThrowAnyException();
-	}
-
 }

--- a/src/test/java/com/kt/controller/auth/AuthControllerTest.java
+++ b/src/test/java/com/kt/controller/auth/AuthControllerTest.java
@@ -53,30 +53,6 @@ class AuthControllerTest extends MockMvcTest {
 	}
 
 	@Test
-	void 인증코드_인증_성공() throws Exception {
-
-		// given
-		String redisAuthCode = "123456";
-		redisCache.set(RedisKey.SIGNUP_CODE, TEST_EMAIL, redisAuthCode);
-
-		var request = new SignupRequest.VerifySignupCode(TEST_EMAIL, redisAuthCode);
-
-		// then
-		assertThat(redisAuthCode).isNotNull();
-		log.info("이메일 인증코드 - 인증: {}", redisAuthCode);
-
-		mockMvc.perform(post("/api/auth/email/verify")
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(objectMapper.writeValueAsString(request)))
-			.andDo(print())
-			.andExpectAll(
-				status().isOk(),
-				jsonPath("$.code").value("ok"),
-				jsonPath("$.message").value("성공")
-			);
-	}
-
-	@Test
 	void 멤버_회원가입_성공() throws Exception {
 		redisCache.set(RedisKey.SIGNUP_VERIFIED, TEST_EMAIL, true);
 		// then

--- a/src/test/java/com/kt/controller/auth/AuthControllerTest.java
+++ b/src/test/java/com/kt/controller/auth/AuthControllerTest.java
@@ -53,31 +53,6 @@ class AuthControllerTest extends MockMvcTest {
 	}
 
 	@Test
-	void 멤버_회원가입_성공() throws Exception {
-		redisCache.set(RedisKey.SIGNUP_VERIFIED, TEST_EMAIL, true);
-		// then
-		SignupRequest.SignupMember verifiedEmailUser = new SignupRequest.SignupMember(
-			"테스트",
-			TEST_EMAIL,
-			"비밀번호",
-			Gender.MALE,
-			LocalDate.now(),
-			"010-1020-1200"
-		);
-
-		// then
-		mockMvc.perform(post("/api/auth/signup/member")
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(objectMapper.writeValueAsString(verifiedEmailUser)))
-			.andDo(print())
-			.andExpectAll(
-				status().isOk(),
-				jsonPath("$.code").value("ok"),
-				jsonPath("$.message").value("성공")
-			);
-	}
-
-	@Test
 	void 배송기사_회원가입_성공() throws Exception {
 		redisCache.set(RedisKey.SIGNUP_VERIFIED, TEST_EMAIL, true);
 		// then

--- a/src/test/java/com/kt/controller/auth/AuthControllerTest.java
+++ b/src/test/java/com/kt/controller/auth/AuthControllerTest.java
@@ -53,29 +53,6 @@ class AuthControllerTest extends MockMvcTest {
 	}
 
 	@Test
-	void 배송기사_회원가입_성공() throws Exception {
-		redisCache.set(RedisKey.SIGNUP_VERIFIED, TEST_EMAIL, true);
-		// then
-		SignupRequest.SignupCourier verifiedEmailCourier = new SignupRequest.SignupCourier(
-			"테스트",
-			TEST_EMAIL,
-			"비밀번호",
-			Gender.MALE
-		);
-
-		// then
-		mockMvc.perform(post("/api/auth/signup/courier")
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(objectMapper.writeValueAsString(verifiedEmailCourier)))
-			.andDo(print())
-			.andExpectAll(
-				status().isOk(),
-				jsonPath("$.code").value("ok"),
-				jsonPath("$.message").value("성공")
-			);
-	}
-
-	@Test
 	void 로그인_성공() throws Exception {
 
 		String email = "dd@com";

--- a/src/test/java/com/kt/service/AuthServiceTest.java
+++ b/src/test/java/com/kt/service/AuthServiceTest.java
@@ -1,7 +1,7 @@
 package com.kt.service;
 
 import static com.kt.common.SignupCourierRequestCreator.*;
-import static com.kt.common.SignupMemberRequestCreator.*;
+import static com.kt.common.SignupUserRequestCreator.*;
 import static com.kt.common.UserEntityCreator.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
@@ -87,8 +87,8 @@ public class AuthServiceTest {
 		redisCache.set(RedisKey.SIGNUP_VERIFIED, email, true);
 
 		// when
-		SignupRequest.SignupMember request = createSignupMemberRequest(email);
-		authService.signupMember(request);
+		SignupRequest.SignupUser request = createSignupUserRequest(email);
+		authService.signupUser(request);
 
 		// then
 		UserEntity member = userRepository.findByEmailOrThrow(request.email());
@@ -104,12 +104,12 @@ public class AuthServiceTest {
 		Thread.sleep(200);
 
 		// when
-		SignupRequest.SignupMember request = createSignupMemberRequest(email);
+		SignupRequest.SignupUser request = createSignupUserRequest(email);
 
 		// then
 		assertThrowsExactly(
 			CustomException.class,
-			() -> authService.signupMember(request),
+			() -> authService.signupUser(request),
 			ErrorCode.AUTH_EMAIL_UNVERIFIED.getMessage()
 		);
 	}
@@ -117,11 +117,11 @@ public class AuthServiceTest {
 	@Test
 	void 맴버_회원가입_실패_인증정보_없음_이메일_키값() {
 		// when and then
-		SignupRequest.SignupMember request = createSignupMemberRequest();
+		SignupRequest.SignupUser request = createSignupUserRequest();
 
 		CustomException exception = assertThrowsExactly(
 			CustomException.class,
-			() -> authService.signupMember(request)
+			() -> authService.signupUser(request)
 		);
 		assertEquals(ErrorCode.AUTH_EMAIL_UNVERIFIED, exception.error());
 	}
@@ -131,15 +131,15 @@ public class AuthServiceTest {
 		// given
 		String email = "member@email.com";
 		redisCache.set(RedisKey.SIGNUP_VERIFIED, email, true);
-		SignupRequest.SignupMember firstSignup = createSignupMemberRequest(email);
-		authService.signupMember(firstSignup);
+		SignupRequest.SignupUser firstSignup = createSignupUserRequest(email);
+		authService.signupUser(firstSignup);
 
 		// when and then
-		SignupRequest.SignupMember secondSignup = createSignupMemberRequest(email);
+		SignupRequest.SignupUser secondSignup = createSignupUserRequest(email);
 
 		CustomException exception = assertThrowsExactly(
 			CustomException.class,
-			() -> authService.signupMember(secondSignup)
+			() -> authService.signupUser(secondSignup)
 		);
 		assertEquals(ErrorCode.DUPLICATED_EMAIL, exception.error());
 	}

--- a/src/test/java/com/kt/service/UserServiceTest.java
+++ b/src/test/java/com/kt/service/UserServiceTest.java
@@ -366,7 +366,7 @@ class UserServiceTest {
 	@Test
 	void 어드민_유저_생성() {
 		// given
-		SignupRequest.SignupMember request = new SignupRequest.SignupMember(
+		SignupRequest.SignupUser request = new SignupRequest.SignupUser(
 			"어드민생성",
 			"admin@test.com",
 			"1234",
@@ -391,7 +391,7 @@ class UserServiceTest {
 	@Test
 	void 어드민_유저_생성__실패_어드민아님() {
 		// given
-		SignupRequest.SignupMember request = new SignupRequest.SignupMember(
+		SignupRequest.SignupUser request = new SignupRequest.SignupUser(
 			"어드민생성",
 			"admin@test.com",
 			"1234",


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- resolves: #이슈번호, #이슈번호 -->
resolves: #174 

## 📝작업 내용

인증(Auth) 관련 API 테스트 추가 및 기존 AuthController 테스트 제거

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

SignupRequest.SignupMember -> SignupUser 로 변경해서 파일 바뀐게 좀 많을겁니다 훑어봐주세요~!