### PR TITLE
[FEAT] Service 행위자 단위로 분리 #178

### DIFF
--- a/src/main/java/com/kt/controller/admin/AdminController.java
+++ b/src/main/java/com/kt/controller/admin/AdminController.java
@@ -29,6 +29,7 @@ import com.kt.domain.dto.response.UserResponse;
 import com.kt.security.DefaultCurrentUser;
 import com.kt.service.AccountService;
 import com.kt.service.UserService;
+import com.kt.service.admin.AdminAdminService;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -40,7 +41,7 @@ import static com.kt.common.api.ApiResult.*;
 @RequiredArgsConstructor
 public class AdminController implements AdminSwaggerSupporter {
 
-	private final UserService userService;
+	private final AdminAdminService adminAdminService;
 	private final AccountService accountService;
 
 	@Override
@@ -64,7 +65,7 @@ public class AdminController implements AdminSwaggerSupporter {
 		@PathVariable UUID adminId
 	) {
 		return wrap(
-			userService.getUserDetail(currentUser.getId(), adminId)
+			adminAdminService.getAdminDetail(currentUser.getId(), adminId)
 		);
 	}
 
@@ -74,7 +75,7 @@ public class AdminController implements AdminSwaggerSupporter {
 		@AuthenticationPrincipal DefaultCurrentUser currentUser,
 		@RequestBody @Valid SignupRequest.SignupMember request
 	) {
-		userService.createAdmin(currentUser.getId(), request);
+		adminAdminService.createAdmin(currentUser.getId(), request);
 		return empty();
 	}
 
@@ -85,7 +86,7 @@ public class AdminController implements AdminSwaggerSupporter {
 		@RequestBody @Valid UserRequest.UpdateDetails request,
 		@PathVariable UUID adminId
 	) {
-		userService.updateUserDetail(currentUser.getId(), adminId, request);
+		adminAdminService.updateDetail(currentUser.getId(), adminId, request);
 		return empty();
 	}
 
@@ -95,7 +96,7 @@ public class AdminController implements AdminSwaggerSupporter {
 		@AuthenticationPrincipal DefaultCurrentUser defaultCurrentUser,
 		@PathVariable UUID adminId
 	) {
-		userService.deleteUser(defaultCurrentUser.getId(), adminId);
+		adminAdminService.deleteAdmin(defaultCurrentUser.getId(), adminId);
 		return empty();
 	}
 

--- a/src/main/java/com/kt/controller/admin/account/AdminAccountController.java
+++ b/src/main/java/com/kt/controller/admin/account/AdminAccountController.java
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.kt.common.Paging;
-import com.kt.service.AccountService;
+import com.kt.service.admin.AdminAccountService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -32,7 +32,7 @@ import static com.kt.common.api.ApiResult.*;
 @RequestMapping("/api/admin/accounts")
 @RequiredArgsConstructor
 public class AdminAccountController implements AdminAccountSwaggerSupporter {
-	private final AccountService accountService;
+	private final AdminAccountService AdminAccountService;
 
 	@Override
 	@GetMapping
@@ -41,7 +41,7 @@ public class AdminAccountController implements AdminAccountSwaggerSupporter {
 		@ModelAttribute Paging paging
 	) {
 		return page(
-			accountService.searchAccounts(
+			AdminAccountService.searchAccounts(
 				request,
 				paging.toPageable()
 			)
@@ -51,26 +51,26 @@ public class AdminAccountController implements AdminAccountSwaggerSupporter {
 	@Override
 	@DeleteMapping("/{accountId}")
 	public ResponseEntity<ApiResult<Void>> deleteAccount(@PathVariable UUID accountId) {
-		accountService.deleteAccount(accountId);
+		AdminAccountService.deleteAccount(accountId);
 		return empty();
 	}
 
 	@Override
 	@DeleteMapping("/{accountId}/force")
 	public ResponseEntity<ApiResult<Void>> deleteAccountPermanently(@PathVariable UUID accountId) {
-		accountService.deleteAccountPermanently(accountId);
+		AdminAccountService.deleteAccountPermanently(accountId);
 		return empty();
 	}
 
 	@PatchMapping("/{accountId}/password/reset")
 	public ResponseEntity<ApiResult<Void>> resetAccountPassword(@PathVariable UUID accountId) {
-		accountService.resetAccountPassword(accountId);
+		AdminAccountService.resetAccountPassword(accountId);
 		return empty();
 	}
 
 	@PatchMapping("/{accountId}/password/update")
 	public ResponseEntity<ApiResult<Void>> updateAccountPassword(@PathVariable UUID accountId) {
-		accountService.updateAccountPassword(accountId);
+		AdminAccountService.updateAccountPassword(accountId);
 		return empty();
 	}
 
@@ -79,7 +79,7 @@ public class AdminAccountController implements AdminAccountSwaggerSupporter {
 	public ResponseEntity<ApiResult<PageResponse<PasswordRequestResponse.Search>>> searchPasswordRequests(
 		@ParameterObject PasswordRequest.Search request,
 		@ModelAttribute Paging paging) {
-		return page(accountService.searchPasswordRequests(request, paging.toPageable()));
+		return page(AdminAccountService.searchPasswordRequests(request, paging.toPageable()));
 	}
 }
 

--- a/src/main/java/com/kt/controller/admin/category/AdminCategoryController.java
+++ b/src/main/java/com/kt/controller/admin/category/AdminCategoryController.java
@@ -2,10 +2,12 @@ package com.kt.controller.admin.category;
 
 import static com.kt.common.api.ApiResult.*;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -15,7 +17,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.kt.common.api.ApiResult;
 import com.kt.domain.dto.request.CategoryRequest;
-import com.kt.service.CategoryService;
+import com.kt.domain.dto.response.CategoryResponse;
+import com.kt.service.admin.AdminCategoryService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -24,14 +27,14 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class AdminCategoryController implements AdminCategorySwaggerSupporter {
 
-	private final CategoryService categoryService;
+	private final AdminCategoryService adminCategoryService;
 
 	@Override
 	@PostMapping
 	public ResponseEntity<ApiResult<Void>> create(
 		@RequestBody CategoryRequest.Create request
 	) {
-		categoryService.create(
+		adminCategoryService.create(
 			request.title(),
 			request.parentId()
 		);
@@ -44,7 +47,7 @@ public class AdminCategoryController implements AdminCategorySwaggerSupporter {
 		@RequestBody CategoryRequest.Update request,
 		@PathVariable UUID categoryId
 	) {
-		categoryService.update(
+		adminCategoryService.update(
 			categoryId,
 			request.title()
 		);
@@ -56,8 +59,15 @@ public class AdminCategoryController implements AdminCategorySwaggerSupporter {
 	public ResponseEntity<ApiResult<Void>> delete(
 		@PathVariable UUID categoryId
 	) {
-		categoryService.delete(categoryId);
+		adminCategoryService.delete(categoryId);
 		return empty();
+	}
+
+	@Override
+	@GetMapping
+	public ResponseEntity<ApiResult<List<CategoryResponse.CategoryTreeItem>>> getAllCategories() {
+		List<CategoryResponse.CategoryTreeItem> list = adminCategoryService.getAll();
+		return ApiResult.wrap(list);
 	}
 
 }

--- a/src/main/java/com/kt/controller/admin/category/AdminCategorySwaggerSupporter.java
+++ b/src/main/java/com/kt/controller/admin/category/AdminCategorySwaggerSupporter.java
@@ -1,5 +1,6 @@
 package com.kt.controller.admin.category;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.springdoc.core.annotations.ParameterObject;
@@ -16,6 +17,7 @@ import com.kt.domain.dto.request.CategoryRequest;
 import com.kt.domain.dto.request.SignupRequest;
 import com.kt.domain.dto.request.UserRequest;
 import com.kt.domain.dto.response.AccountResponse;
+import com.kt.domain.dto.response.CategoryResponse;
 import com.kt.domain.dto.response.UserResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -53,4 +55,9 @@ public interface AdminCategorySwaggerSupporter {
 		@PathVariable UUID categoryId
 	);
 
+	@Operation(
+		summary = "전체 카테고리 조회",
+		description = "전체 카테고리를 트리 구조로 조회하는 API"
+	)
+	ResponseEntity<ApiResult<List<CategoryResponse.CategoryTreeItem>>> getAllCategories();
 }

--- a/src/main/java/com/kt/controller/admin/courier/AdminCourierController.java
+++ b/src/main/java/com/kt/controller/admin/courier/AdminCourierController.java
@@ -15,6 +15,7 @@ import com.kt.common.api.ApiResult;
 import com.kt.domain.dto.response.CourierResponse;
 import com.kt.security.DefaultCurrentUser;
 import com.kt.service.CourierService;
+import com.kt.service.admin.AdminCourierService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -23,7 +24,7 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/admin/couriers")
 public class AdminCourierController implements AdminCourierSwaggerSupporter {
 
-	private final CourierService courierService;
+	private final AdminCourierService adminCourierService;
 
 	@Override
 	@GetMapping("/{courierId}")
@@ -31,6 +32,6 @@ public class AdminCourierController implements AdminCourierSwaggerSupporter {
 		@AuthenticationPrincipal DefaultCurrentUser defaultCurrentUser,
 		@PathVariable UUID courierId
 	) {
-		return wrap(courierService.getDetailForAdmin(defaultCurrentUser.getId(), courierId));
+		return wrap(adminCourierService.getDetail(defaultCurrentUser.getId(), courierId));
 	}
 }

--- a/src/main/java/com/kt/controller/admin/order/AdminOrderController.java
+++ b/src/main/java/com/kt/controller/admin/order/AdminOrderController.java
@@ -21,6 +21,7 @@ import com.kt.domain.dto.request.OrderRequest;
 import com.kt.domain.dto.response.AdminOrderResponse;
 import com.kt.security.DefaultCurrentUser;
 import com.kt.service.OrderService;
+import com.kt.service.admin.AdminOrderService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -28,14 +29,14 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @RequestMapping("/api/admin/orders")
 public class AdminOrderController implements AdminOrderSwaggerSupporter {
-	public final OrderService orderService;
+	public final AdminOrderService adminOrderService;
 
 	@Override
 	@GetMapping
 	public ResponseEntity<ApiResult<PageResponse<AdminOrderResponse.Search>>> searchOrder(
 		@ModelAttribute Paging paging
 	) {
-		return page(orderService.searchOrder(
+		return page(adminOrderService.searchOrder(
 			paging.toPageable()
 		));
 	}
@@ -45,7 +46,7 @@ public class AdminOrderController implements AdminOrderSwaggerSupporter {
 	public ResponseEntity<ApiResult<AdminOrderResponse.Detail>> getOrderDetail(
 		@PathVariable UUID orderId
 	) {
-		return wrap(orderService.getOrderDetail(orderId));
+		return wrap(adminOrderService.getOrderDetail(orderId));
 	}
 
 	@Override
@@ -54,7 +55,7 @@ public class AdminOrderController implements AdminOrderSwaggerSupporter {
 		@PathVariable UUID orderId,
 		@RequestBody OrderRequest.ChangeStatus request
 	) {
-		orderService.updateOrderStatus(orderId, request.status());
+		adminOrderService.updateOrderStatus(orderId, request.status());
 		return empty();
 	}
 
@@ -64,7 +65,7 @@ public class AdminOrderController implements AdminOrderSwaggerSupporter {
 		@AuthenticationPrincipal DefaultCurrentUser currentUser,
 		@PathVariable UUID orderId
 	) {
-		orderService.cancelOrder(currentUser.getId(), orderId);
+		adminOrderService.cancelOrder(currentUser.getId(), orderId);
 		return empty();
 	}
 }

--- a/src/main/java/com/kt/controller/admin/product/AdminProductController.java
+++ b/src/main/java/com/kt/controller/admin/product/AdminProductController.java
@@ -25,6 +25,7 @@ import com.kt.domain.dto.request.AdminProductRequest;
 import com.kt.domain.dto.response.ProductResponse;
 import com.kt.security.CurrentUser;
 import com.kt.service.ProductService;
+import com.kt.service.admin.AdminProductService;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -34,13 +35,13 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class AdminProductController implements AdminProductSwaggerSupporter {
 
-	private final ProductService productService;
+	private final AdminProductService adminProductService;
 
 	@PostMapping
 	public ResponseEntity<ApiResult<Void>> create(
 		@RequestBody @Valid AdminProductRequest.Create request
 	) {
-		productService.create(
+		adminProductService.create(
 			request.name(),
 			request.price(),
 			request.stock(),
@@ -53,7 +54,7 @@ public class AdminProductController implements AdminProductSwaggerSupporter {
 	public ResponseEntity<ApiResult<Void>> soldOutProducts(
 		@RequestBody @Valid AdminProductRequest.SoldOut request
 	) {
-		productService.soldOutProducts(request.productIds());
+		adminProductService.soldOutProducts(request.productIds());
 		return empty();
 	}
 
@@ -65,7 +66,7 @@ public class AdminProductController implements AdminProductSwaggerSupporter {
 		Paging paging
 	) {
 		return page(
-			productService.search(
+			adminProductService.search(
 				user.getRole(),
 				keyword,
 				type,
@@ -79,14 +80,14 @@ public class AdminProductController implements AdminProductSwaggerSupporter {
 		@AuthenticationPrincipal CurrentUser user,
 		@PathVariable UUID productId
 	) {
-		return wrap(productService.detail(user.getRole(), productId));
+		return wrap(adminProductService.detail(user.getRole(), productId));
 	}
 
 	@PatchMapping("/{productId}/toggle-sold-out")
 	public ResponseEntity<ApiResult<Void>> toggleActive(
 		@PathVariable UUID productId
 	) {
-		productService.toggleActive(productId);
+		adminProductService.toggleActive(productId);
 		return empty();
 	}
 
@@ -94,7 +95,7 @@ public class AdminProductController implements AdminProductSwaggerSupporter {
 	public ResponseEntity<ApiResult<Void>> activate(
 		@PathVariable UUID productId
 	) {
-		productService.activate(productId);
+		adminProductService.activate(productId);
 		return empty();
 	}
 
@@ -102,7 +103,7 @@ public class AdminProductController implements AdminProductSwaggerSupporter {
 	public ResponseEntity<ApiResult<Void>> inActivate(
 		@PathVariable UUID productId
 	) {
-		productService.inActivate(productId);
+		adminProductService.inActivate(productId);
 		return empty();
 	}
 
@@ -111,7 +112,7 @@ public class AdminProductController implements AdminProductSwaggerSupporter {
 		@PathVariable UUID productId,
 		@RequestBody @Valid AdminProductRequest.Update request
 	) {
-		productService.update(
+		adminProductService.update(
 			productId,
 			request.name(),
 			request.price(),
@@ -125,7 +126,7 @@ public class AdminProductController implements AdminProductSwaggerSupporter {
 	public ResponseEntity<ApiResult<Void>> delete(
 		@PathVariable UUID productId
 	) {
-		productService.delete(productId);
+		adminProductService.delete(productId);
 		return empty();
 	}
 

--- a/src/main/java/com/kt/controller/admin/review/AdminReviewController.java
+++ b/src/main/java/com/kt/controller/admin/review/AdminReviewController.java
@@ -20,7 +20,7 @@ import com.kt.common.api.PageResponse;
 import com.kt.constant.searchtype.ProductSearchType;
 import com.kt.domain.dto.response.ReviewResponse;
 import com.kt.security.DefaultCurrentUser;
-import com.kt.service.ReviewService;
+import com.kt.service.admin.AdminReviewService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -29,7 +29,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 
 public class AdminReviewController implements AdminReviewSwaggerSupporter {
-	private final ReviewService reviewService;
+	private final AdminReviewService adminReviewService;
 
 	@Override
 	@GetMapping
@@ -39,7 +39,7 @@ public class AdminReviewController implements AdminReviewSwaggerSupporter {
 		@RequestParam(required = false) ProductSearchType type
 	) {
 		return page(
-			reviewService.getReviewsByAdmin(
+			adminReviewService.getReviewsByAdmin(
 				paging.toPageable(),
 				keyword,
 				type
@@ -53,7 +53,7 @@ public class AdminReviewController implements AdminReviewSwaggerSupporter {
 		@AuthenticationPrincipal DefaultCurrentUser currentUser,
 		@PathVariable UUID reviewId
 	) {
-		reviewService.delete(currentUser.getEmail(), reviewId);
+		adminReviewService.delete(currentUser.getEmail(), reviewId);
 		return empty();
 	}
 }

--- a/src/main/java/com/kt/controller/admin/user/AdminUserController.java
+++ b/src/main/java/com/kt/controller/admin/user/AdminUserController.java
@@ -17,6 +17,7 @@ import com.kt.common.api.ApiResult;
 import com.kt.domain.dto.response.UserResponse;
 import com.kt.security.DefaultCurrentUser;
 import com.kt.service.UserService;
+import com.kt.service.admin.AdminUserService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -25,14 +26,14 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/admin/users")
 public class AdminUserController implements AdminUserSwaggerSupporter {
 
-	private final UserService userService;
+	private final AdminUserService adminUserService;
 
 	@GetMapping("/{userId}")
 	public ResponseEntity<ApiResult<UserResponse.UserDetail>> getAccountDetail(
 		@AuthenticationPrincipal DefaultCurrentUser defaultCurrentUser,
 		@PathVariable UUID userId
 	) {
-		return wrap(userService.getUserDetail(defaultCurrentUser.getId(), userId));
+		return wrap(adminUserService.getUserDetail(defaultCurrentUser.getId(), userId));
 	}
 
 	@PatchMapping("/{userId}/enabled")
@@ -40,7 +41,7 @@ public class AdminUserController implements AdminUserSwaggerSupporter {
 		@AuthenticationPrincipal DefaultCurrentUser defaultCurrentUser,
 		@PathVariable UUID userId
 	) {
-		userService.enableUser(defaultCurrentUser.getId(), userId);
+		adminUserService.enableUser(defaultCurrentUser.getId(), userId);
 		return empty();
 	}
 
@@ -49,7 +50,7 @@ public class AdminUserController implements AdminUserSwaggerSupporter {
 		@AuthenticationPrincipal DefaultCurrentUser defaultCurrentUser,
 		@PathVariable UUID userId
 	) {
-		userService.disableUser(defaultCurrentUser.getId(), userId);
+		adminUserService.disableUser(defaultCurrentUser.getId(), userId);
 		return empty();
 	}
 
@@ -58,7 +59,7 @@ public class AdminUserController implements AdminUserSwaggerSupporter {
 		@AuthenticationPrincipal DefaultCurrentUser defaultCurrentUser,
 		@PathVariable UUID userId
 	) {
-		userService.deleteUser(defaultCurrentUser.getId(), userId);
+		adminUserService.deleteUser(defaultCurrentUser.getId(), userId);
 		return empty();
 	}
 

--- a/src/main/java/com/kt/service/CategoryServiceImpl.java
+++ b/src/main/java/com/kt/service/CategoryServiceImpl.java
@@ -22,6 +22,7 @@ import lombok.RequiredArgsConstructor;
 public class CategoryServiceImpl implements CategoryService {
 	private final CategoryRepository categoryRepository;
 
+	// TODO: for admin
 	@Override
 	public void create(String name, UUID parentId) {
 		isDuplicatedCategory(name);
@@ -34,6 +35,7 @@ public class CategoryServiceImpl implements CategoryService {
 
 	}
 
+	// TODO: for admin
 	@Override
 	public void update(UUID id, String name) {
 		isDuplicatedCategory(name);
@@ -56,6 +58,7 @@ public class CategoryServiceImpl implements CategoryService {
 			.stream().map(CategoryResponse.CategoryTreeItem::of).toList();
 	}
 
+	// TODO: for admin
 	@Override
 	public void delete(UUID id) {
 		CategoryEntity category = categoryRepository.findById(id)

--- a/src/main/java/com/kt/service/CourierServiceImpl.java
+++ b/src/main/java/com/kt/service/CourierServiceImpl.java
@@ -39,7 +39,7 @@ public class CourierServiceImpl implements CourierService {
 		);
 	}
 
-
+	// TODO: for admin
 	@Override
 	public CourierResponse.DetailAdmin getDetailForAdmin(UUID currentId, UUID subjectId) {
 		verifyAccess(currentId, subjectId);

--- a/src/main/java/com/kt/service/OrderServiceImpl.java
+++ b/src/main/java/com/kt/service/OrderServiceImpl.java
@@ -125,6 +125,7 @@ public class OrderServiceImpl implements OrderService {
 		order.cancel();
 	}
 
+	// TODO: for seller
 	@Override
 	public void updateOrder(UUID userId, UUID orderId, OrderRequest.Update request) {
 		UserEntity user = userRepository.findByIdOrThrow(userId);

--- a/src/main/java/com/kt/service/ReviewServiceImpl.java
+++ b/src/main/java/com/kt/service/ReviewServiceImpl.java
@@ -28,6 +28,8 @@ import lombok.RequiredArgsConstructor;
 @Service
 @Transactional
 @RequiredArgsConstructor
+
+// TODO: 본인 확인 ID로 변경
 public class ReviewServiceImpl implements ReviewService {
 
 	private final ReviewRepository reviewRepository;
@@ -68,6 +70,7 @@ public class ReviewServiceImpl implements ReviewService {
 		review.update(content);
 	}
 
+	// TODO: 현재 본인만 리뷰 삭제 가능, 어드민 리뷰 삭제 검토
 	@Override
 	public void delete(
 		String email,
@@ -96,6 +99,7 @@ public class ReviewServiceImpl implements ReviewService {
 		return reviewRepository.searchReviewsByProductId(pageable, productId);
 	}
 
+	// TODO: for admin
 	@Override
 	public Page<ReviewResponse.Search> getReviewsByAdmin(
 		Pageable pageable,

--- a/src/main/java/com/kt/service/admin/AdminAccountService.java
+++ b/src/main/java/com/kt/service/admin/AdminAccountService.java
@@ -1,0 +1,38 @@
+package com.kt.service.admin;
+
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import com.kt.domain.dto.request.AccountRequest;
+import com.kt.domain.dto.request.PasswordRequest;
+import com.kt.domain.dto.response.AccountResponse;
+import com.kt.domain.dto.response.PasswordRequestResponse;
+
+public interface AdminAccountService {
+	Page<AccountResponse.Search> searchAccounts(
+		AccountRequest.Search request,
+		Pageable pageable
+	);
+
+	void resetAccountPassword(UUID accountId);
+
+	void updateAccountPassword(UUID accountId);
+
+	void updatePassword(
+		UUID accountId,
+		String currentPassword,
+		String newPassword
+	);
+
+	void deleteAccount(UUID accountId);
+
+	void deleteAccountPermanently(UUID accountId);
+
+	Page<PasswordRequestResponse.Search> searchPasswordRequests(
+		PasswordRequest.Search request,
+		Pageable pageable
+	);
+
+}

--- a/src/main/java/com/kt/service/admin/AdminAccountServiceImpl.java
+++ b/src/main/java/com/kt/service/admin/AdminAccountServiceImpl.java
@@ -36,8 +36,6 @@ public class AdminAccountServiceImpl implements AdminAccountService {
 	private final PasswordRequestRepository passwordRequestRepository;
 	private final EmailClient emailClient;
 
-	// FIXME: Admin도 회원탈퇴와 비밀번호 변경을 가능하게 할 것인지
-	// 회원 탈퇴와 비밀번호 변경은 AdminAccountTest 생성 X
 	@Override
 	public void updatePassword(
 		UUID accountId,

--- a/src/main/java/com/kt/service/admin/AdminAccountServiceImpl.java
+++ b/src/main/java/com/kt/service/admin/AdminAccountServiceImpl.java
@@ -50,8 +50,8 @@ public class AdminAccountServiceImpl implements AdminAccountService {
 		if (passwordEncoder.matches(newPassword, account.getPassword()))
 			throw new CustomException(ErrorCode.PASSWORD_UNCHANGED);
 
-		String hashedPassword = passwordEncoder.encode(newPassword);
-		account.updatePassword(hashedPassword);
+		String encodedPassword = passwordEncoder.encode(newPassword);
+		account.updatePassword(encodedPassword);
 	}
 
 	@Override

--- a/src/main/java/com/kt/service/admin/AdminAccountServiceImpl.java
+++ b/src/main/java/com/kt/service/admin/AdminAccountServiceImpl.java
@@ -1,53 +1,43 @@
-package com.kt.service;
+package com.kt.service.admin;
 
+import java.util.Random;
 import java.util.UUID;
-
-import com.kt.constant.PasswordRequestStatus;
-import com.kt.constant.PasswordRequestType;
-import com.kt.constant.mail.MailTemplate;
-import com.kt.domain.dto.request.AccountRequest;
-
-import com.kt.domain.dto.request.PasswordRequest;
-import com.kt.domain.dto.response.AccountResponse;
-import com.kt.domain.dto.response.PasswordRequestResponse;
-import com.kt.domain.entity.AbstractAccountEntity;
-
-import com.kt.domain.entity.PasswordRequestEntity;
-import com.kt.infra.mail.EmailClient;
-import com.kt.repository.PasswordRequestRepository;
-import com.kt.repository.account.AccountRepository;
-
-import com.kt.util.EncryptUtil;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
-
-import com.kt.constant.message.ErrorCode;
-import com.kt.exception.CustomException;
-
-import lombok.RequiredArgsConstructor;
-
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Random;
+import com.kt.constant.PasswordRequestStatus;
+import com.kt.constant.PasswordRequestType;
+import com.kt.constant.mail.MailTemplate;
+import com.kt.constant.message.ErrorCode;
+import com.kt.domain.dto.request.AccountRequest;
+import com.kt.domain.dto.request.PasswordRequest;
+import com.kt.domain.dto.response.AccountResponse;
+import com.kt.domain.dto.response.PasswordRequestResponse;
+import com.kt.domain.entity.AbstractAccountEntity;
+import com.kt.domain.entity.PasswordRequestEntity;
+import com.kt.exception.CustomException;
+import com.kt.infra.mail.EmailClient;
+import com.kt.repository.PasswordRequestRepository;
+import com.kt.repository.account.AccountRepository;
+import com.kt.util.EncryptUtil;
+
+import lombok.RequiredArgsConstructor;
 
 @Service
 @Transactional
 @RequiredArgsConstructor
-public class AccountServiceImpl implements AccountService {
+public class AdminAccountServiceImpl implements AdminAccountService {
 	private final PasswordEncoder passwordEncoder;
 	private final AccountRepository accountRepository;
 	private final PasswordRequestRepository passwordRequestRepository;
 	private final EmailClient emailClient;
 
-	@Override
-	public void deleteAccount(UUID accountId) {
-		AbstractAccountEntity account = accountRepository.findByIdOrThrow(accountId);
-		account.delete();
-	}
-
+	// FIXME: Admin도 회원탈퇴와 비밀번호 변경을 가능하게 할 것인지
+	// 회원 탈퇴와 비밀번호 변경은 AdminAccountTest 생성 X
 	@Override
 	public void updatePassword(
 		UUID accountId,
@@ -64,6 +54,12 @@ public class AccountServiceImpl implements AccountService {
 
 		String hashedPassword = passwordEncoder.encode(newPassword);
 		account.updatePassword(hashedPassword);
+	}
+
+	@Override
+	public void deleteAccount(UUID accountId) {
+		AbstractAccountEntity account = accountRepository.findByIdOrThrow(accountId);
+		account.delete();
 	}
 
 	@Override

--- a/src/main/java/com/kt/service/admin/AdminAdminService.java
+++ b/src/main/java/com/kt/service/admin/AdminAdminService.java
@@ -1,0 +1,22 @@
+package com.kt.service.admin;
+
+import java.util.UUID;
+
+import com.kt.domain.dto.request.SignupRequest;
+import com.kt.domain.dto.request.UserRequest;
+import com.kt.domain.dto.response.UserResponse;
+
+public interface AdminAdminService {
+	void createAdmin(UUID userId, SignupRequest.SignupMember request);
+
+	void deleteAdmin(UUID currentId, UUID adminId);
+
+	UserResponse.UserDetail getAdminDetail(UUID currentId, UUID subjectId);
+
+	void updateDetail(
+		UUID currentId,
+		UUID subjectId,
+		UserRequest.UpdateDetails details
+	);
+
+}

--- a/src/main/java/com/kt/service/admin/AdminAdminServiceImpl.java
+++ b/src/main/java/com/kt/service/admin/AdminAdminServiceImpl.java
@@ -1,0 +1,120 @@
+package com.kt.service.admin;
+
+import java.util.UUID;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kt.constant.UserRole;
+import com.kt.constant.message.ErrorCode;
+import com.kt.domain.dto.request.SignupRequest;
+import com.kt.domain.dto.request.UserRequest;
+import com.kt.domain.dto.response.UserResponse;
+import com.kt.domain.entity.UserEntity;
+import com.kt.repository.user.UserRepository;
+import com.kt.util.Preconditions;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AdminAdminServiceImpl implements AdminAdminService {
+
+	private final UserRepository userRepository;
+	private final PasswordEncoder passwordEncoder;
+
+	@Override
+	public void createAdmin(UUID userId, SignupRequest.SignupMember request) {
+		checkAdmin(userId);
+
+		UserEntity admin = UserEntity.create(
+			request.name(),
+			request.email(),
+			passwordEncoder.encode(request.password()),
+			UserRole.ADMIN,
+			request.gender(),
+			request.birth(),
+			request.mobile()
+		);
+		userRepository.save(admin);
+	}
+
+	@Override
+	public UserResponse.UserDetail getAdminDetail(UUID currentId, UUID subjectId) {
+		checkReadPermission(currentId, subjectId);
+
+		UserEntity user = userRepository.findByIdOrThrow(subjectId);
+		return new UserResponse.UserDetail(
+			user.getId(),
+			user.getName(),
+			user.getEmail(),
+			user.getRole(),
+			user.getGender(),
+			user.getBirth(),
+			user.getMobile()
+		);
+	}
+
+	@Override
+	public void deleteAdmin(UUID currentId, UUID adminId) {
+		checkAdmin(adminId);
+		checkModifyPermission(currentId, adminId);
+
+		UserEntity user = userRepository.findByIdOrThrow(adminId);
+		user.delete();
+	}
+
+	private void checkAdmin(UUID currentUserId) {
+		UserEntity user = userRepository.findByIdOrThrow(currentUserId);
+		Preconditions.validate(
+			user.getRole() == UserRole.ADMIN,
+			ErrorCode.NOT_ADMIN
+		);
+	}
+
+	// TODO: 테스트 작성
+	@Override
+	public void updateDetail(
+		UUID currentId,
+		UUID subjectId,
+		UserRequest.UpdateDetails details
+	) {
+		checkModifyPermission(currentId, subjectId);
+
+		UserEntity subjectUser = userRepository.findByIdOrThrow(subjectId);
+
+		subjectUser.updateDetails(
+			details.name(),
+			details.mobile(),
+			details.birth(),
+			details.gender()
+		);
+	}
+
+	private void checkReadPermission(UUID currentId, UUID subjectId) {
+		UserEntity currentUser = userRepository.findByIdOrThrow(currentId);
+		Preconditions.validate(
+			currentUser.getRole().equals(UserRole.ADMIN) | currentId.equals(subjectId),
+			ErrorCode.ACCOUNT_ACCESS_NOT_ALLOWED
+		);
+	}
+
+	private void checkModifyPermission(UUID currentId, UUID subjectId) {
+		UserEntity subjectUser = userRepository.findByIdOrThrow(subjectId);
+		if (subjectUser.getRole() == UserRole.ADMIN) {
+			Preconditions.validate(
+				currentId.equals(subjectId),
+				ErrorCode.ACCOUNT_ACCESS_NOT_ALLOWED
+			);
+		} else {
+			UserEntity currentUser = userRepository.findByIdOrThrow(currentId);
+			Preconditions.validate(
+				currentUser.getRole().equals(UserRole.ADMIN) | currentId.equals(subjectId),
+				ErrorCode.ACCOUNT_ACCESS_NOT_ALLOWED
+			);
+		}
+	}
+
+}

--- a/src/main/java/com/kt/service/admin/AdminCategoryService.java
+++ b/src/main/java/com/kt/service/admin/AdminCategoryService.java
@@ -1,0 +1,18 @@
+package com.kt.service.admin;
+
+import java.util.List;
+import java.util.UUID;
+
+import com.kt.domain.dto.response.CategoryResponse;
+
+public interface AdminCategoryService {
+
+	void create(String name, UUID parentId);
+
+	void update(UUID id, String name);
+
+	void delete(UUID id);
+
+	List<CategoryResponse.CategoryTreeItem> getAll();
+
+}

--- a/src/main/java/com/kt/service/admin/AdminCategoryServiceImpl.java
+++ b/src/main/java/com/kt/service/admin/AdminCategoryServiceImpl.java
@@ -1,9 +1,7 @@
-package com.kt.service;
+package com.kt.service.admin;
 
 import java.util.List;
 import java.util.UUID;
-
-import com.kt.exception.CustomException;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -11,7 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.kt.constant.message.ErrorCode;
 import com.kt.domain.dto.response.CategoryResponse;
 import com.kt.domain.entity.CategoryEntity;
-
+import com.kt.exception.CustomException;
 import com.kt.repository.CategoryRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -19,7 +17,7 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class CategoryServiceImpl implements CategoryService {
+public class AdminCategoryServiceImpl implements AdminCategoryService {
 	private final CategoryRepository categoryRepository;
 
 	@Override
@@ -72,5 +70,4 @@ public class CategoryServiceImpl implements CategoryService {
 			throw new CustomException(ErrorCode.DUPLICATED_CATEGORY);
 		}
 	}
-
 }

--- a/src/main/java/com/kt/service/admin/AdminCourierService.java
+++ b/src/main/java/com/kt/service/admin/AdminCourierService.java
@@ -1,0 +1,12 @@
+package com.kt.service.admin;
+
+import java.util.UUID;
+
+import com.kt.domain.dto.request.CourierRequest;
+import com.kt.domain.dto.response.CourierResponse;
+
+public interface AdminCourierService {
+	CourierResponse.DetailAdmin getDetail(UUID currentId, UUID subjectId);
+
+	void updateDetail(UUID currentId, UUID subjectId, CourierRequest.UpdateDetails updateDetail);
+}

--- a/src/main/java/com/kt/service/admin/AdminCourierServiceImpl.java
+++ b/src/main/java/com/kt/service/admin/AdminCourierServiceImpl.java
@@ -1,0 +1,64 @@
+package com.kt.service.admin;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kt.constant.UserRole;
+import com.kt.constant.message.ErrorCode;
+import com.kt.domain.dto.request.CourierRequest;
+import com.kt.domain.dto.response.CourierResponse;
+import com.kt.domain.entity.AbstractAccountEntity;
+import com.kt.domain.entity.CourierEntity;
+import com.kt.repository.account.AccountRepository;
+import com.kt.repository.courier.CourierRepository;
+import com.kt.util.Preconditions;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AdminCourierServiceImpl implements AdminCourierService {
+
+	private final CourierRepository courierRepository;
+	private final AccountRepository accountRepository;
+
+	@Override
+	public CourierResponse.DetailAdmin getDetail(UUID currentId, UUID subjectId) {
+		verifyAccess(currentId, subjectId);
+
+		CourierEntity courierEntity = courierRepository.findByIdOrThrow(subjectId);
+		return new CourierResponse.DetailAdmin(
+			courierEntity.getId(),
+			courierEntity.getName(),
+			courierEntity.getEmail(),
+			courierEntity.getGender(),
+			courierEntity.getStatus(),
+			courierEntity.getWorkStatus()
+		);
+	}
+
+	@Override
+	public void updateDetail(UUID currentId, UUID subjectId, CourierRequest.UpdateDetails details) {
+		verifyAccess(currentId, subjectId);
+
+		CourierEntity courier = courierRepository.findByIdOrThrow(subjectId);
+		courier.updateDetails(
+			details.name(),
+			details.gender()
+		);
+	}
+
+	private void verifyAccess(UUID currentId, UUID subjectId) {
+		AbstractAccountEntity currentUser = accountRepository.findByIdOrThrow(currentId);
+
+		if (currentUser.getRole() != UserRole.ADMIN) {
+			Preconditions.validate(
+				currentId.equals(subjectId),
+				ErrorCode.ACCOUNT_ACCESS_NOT_ALLOWED
+			);
+		}
+	}
+}

--- a/src/main/java/com/kt/service/admin/AdminOrderService.java
+++ b/src/main/java/com/kt/service/admin/AdminOrderService.java
@@ -1,0 +1,21 @@
+package com.kt.service.admin;
+
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import com.kt.constant.OrderStatus;
+import com.kt.domain.dto.response.AdminOrderResponse;
+
+public interface AdminOrderService {
+
+	void cancelOrder(UUID userId, UUID orderId);
+
+	Page<AdminOrderResponse.Search> searchOrder(Pageable pageable);
+
+	AdminOrderResponse.Detail getOrderDetail(UUID orderId);
+
+	void updateOrderStatus(UUID orderId, OrderStatus newStatus);
+
+}

--- a/src/main/java/com/kt/service/admin/AdminOrderServiceImpl.java
+++ b/src/main/java/com/kt/service/admin/AdminOrderServiceImpl.java
@@ -1,0 +1,108 @@
+package com.kt.service.admin;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kt.constant.OrderStatus;
+import com.kt.constant.UserRole;
+import com.kt.constant.message.ErrorCode;
+import com.kt.domain.dto.response.AdminOrderResponse;
+import com.kt.domain.entity.OrderEntity;
+import com.kt.domain.entity.OrderProductEntity;
+import com.kt.domain.entity.ProductEntity;
+import com.kt.domain.entity.UserEntity;
+import com.kt.exception.CustomException;
+import com.kt.repository.OrderRepository;
+import com.kt.repository.orderproduct.OrderProductRepository;
+import com.kt.repository.user.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+@Transactional
+public class AdminOrderServiceImpl implements AdminOrderService {
+
+	private final UserRepository userRepository;
+	private final OrderRepository orderRepository;
+	private final OrderProductRepository orderProductRepository;
+
+	@Override
+	public void cancelOrder(UUID userId, UUID orderId) {
+		UserEntity user = userRepository.findByIdOrThrow(userId);
+		OrderEntity order = orderRepository.findByIdOrThrow(orderId);
+
+		hasOrderCancelPermission(user, order);
+
+		if (!isCancelable(order.getStatus())) {
+			throw new CustomException(ErrorCode.ORDER_ALREADY_CONFIRMED);
+		}
+
+		List<OrderProductEntity> orderProducts = orderProductRepository.findAllByOrderId(orderId);
+
+		for (OrderProductEntity orderproduct : orderProducts) {
+			ProductEntity product = orderproduct.getProduct();
+			product.addStock(orderproduct.getQuantity());
+			orderproduct.cancel();
+		}
+		order.cancel();
+	}
+
+	@Override
+	public Page<AdminOrderResponse.Search> searchOrder(Pageable pageable) {
+		return orderRepository.findAll(pageable)
+			.map(AdminOrderResponse.Search::from);
+	}
+
+	@Override
+	public AdminOrderResponse.Detail getOrderDetail(UUID orderId) {
+
+		OrderEntity order = orderRepository.findById(orderId)
+			.orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
+
+		List<OrderProductEntity> orderProducts =
+			orderProductRepository.findAllByOrderId(orderId);
+
+		return AdminOrderResponse.Detail.from(order, orderProducts);
+	}
+
+	@Override
+	public void updateOrderStatus(UUID orderId, OrderStatus newStatus) {
+		OrderEntity order = orderRepository.findByIdOrThrow(orderId);
+
+		OrderStatus current = order.getStatus();
+
+		if (current == OrderStatus.PURCHASE_CONFIRMED) {
+			throw new CustomException(ErrorCode.ORDER_ALREADY_CONFIRMED);
+		}
+
+		if (current == OrderStatus.SHIPPING) {
+			throw new CustomException(ErrorCode.ORDER_ALREADY_SHIPPED);
+		}
+
+		order.updateStatus(newStatus);
+	}
+
+	private void hasOrderCancelPermission(UserEntity user, OrderEntity order) {
+		UserRole role = order.getOrderBy().getRole();
+		UUID orderId = order.getOrderBy().getId();
+		UUID userId = user.getId();
+
+		if (role != UserRole.ADMIN && !orderId.equals(userId)) {
+			throw new CustomException(ErrorCode.ORDER_ACCESS_NOT_ALLOWED);
+		}
+	}
+
+	private boolean isCancelable(OrderStatus status) {
+		if (status == OrderStatus.PURCHASE_CONFIRMED)
+			return false;
+		if (status == OrderStatus.SHIPPING_COMPLETED)
+			return false;
+		return true;
+	}
+}

--- a/src/main/java/com/kt/service/admin/AdminProductService.java
+++ b/src/main/java/com/kt/service/admin/AdminProductService.java
@@ -1,0 +1,32 @@
+package com.kt.service.admin;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import com.kt.constant.UserRole;
+import com.kt.constant.searchtype.ProductSearchType;
+import com.kt.domain.dto.response.ProductResponse;
+
+public interface AdminProductService {
+
+	void create(String name, Long price, Long stock, UUID categoryId);
+
+	void update(UUID productId, String name, Long price, Long stock, UUID categoryId);
+
+	void delete(UUID productId);
+
+	void activate(UUID productId);
+
+	void inActivate(UUID productId);
+
+	void soldOutProducts(List<UUID> productIds);
+
+	void toggleActive(UUID productId);
+
+	Page<ProductResponse.Search> search(UserRole role, String keyword, ProductSearchType type, Pageable pageable);
+
+	ProductResponse.Detail detail(UserRole role, UUID productId);
+}

--- a/src/main/java/com/kt/service/admin/AdminProductServiceImpl.java
+++ b/src/main/java/com/kt/service/admin/AdminProductServiceImpl.java
@@ -1,0 +1,113 @@
+package com.kt.service.admin;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kt.constant.ProductStatus;
+import com.kt.constant.UserRole;
+import com.kt.constant.message.ErrorCode;
+import com.kt.constant.searchtype.ProductSearchType;
+import com.kt.domain.dto.response.ProductResponse;
+import com.kt.domain.entity.CategoryEntity;
+import com.kt.domain.entity.ProductEntity;
+import com.kt.exception.CustomException;
+import com.kt.repository.CategoryRepository;
+import com.kt.repository.product.ProductRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AdminProductServiceImpl implements AdminProductService {
+
+	private final ProductRepository productRepository;
+	private final CategoryRepository categoryRepository;
+
+	// TODO: seller로 이전
+	@Override
+	public void create(
+		String name,
+		Long price,
+		Long stock,
+		UUID categoryId
+	) {
+		CategoryEntity category = categoryRepository.findById(categoryId).orElseThrow(
+			() -> new CustomException(ErrorCode.CATEGORY_NOT_FOUND)
+		);
+		ProductEntity product = ProductEntity.create(name, price, stock, category);
+		productRepository.save(product);
+	}
+
+	// TODO: seller로 이전
+	@Override
+	public void update(
+		UUID productId,
+		String name,
+		Long price,
+		Long stock,
+		UUID categoryId
+	) {
+		CategoryEntity category = categoryRepository.findById(categoryId).orElseThrow(
+			() -> new CustomException(ErrorCode.CATEGORY_NOT_FOUND)
+		);
+		ProductEntity product = productRepository.findByIdOrThrow(productId);
+		product.update(name, price, stock, category);
+	}
+
+	// TODO: seller와 공존
+	@Override
+	public void delete(UUID productId) {
+		ProductEntity product = productRepository.findByIdOrThrow(productId);
+		product.delete();
+	}
+
+	// TODO: seller와 공존
+	@Override
+	public void activate(UUID productId) {
+		ProductEntity product = productRepository.findByIdOrThrow(productId);
+		product.activate();
+	}
+
+	// TODO: seller와 공존
+	@Override
+	public void inActivate(UUID productId) {
+		ProductEntity product = productRepository.findByIdOrThrow(productId);
+		product.inActivate();
+	}
+
+	@Override
+	public void soldOutProducts(List<UUID> productIds) {
+		productRepository.findAllById(productIds).forEach(ProductEntity::inActivate);
+	}
+
+	// TODO: seller와 공존
+	@Override
+	public void toggleActive(UUID productId) {
+		ProductEntity product = productRepository.findByIdOrThrow(productId);
+		product.toggleActive();
+	}
+
+	// TODO: seller와 공존
+	@Override
+	public Page<ProductResponse.Search> search(UserRole role, String keyword, ProductSearchType type, Pageable pageable) {
+		return productRepository.search(role, pageable, keyword, type);
+	}
+
+	// TODO: seller와 공존
+	@Override
+	public ProductResponse.Detail detail(UserRole role, UUID productId) {
+		ProductEntity product = productRepository.findByIdOrThrow(productId);
+
+		if (role == UserRole.MEMBER && product.getStatus() != ProductStatus.ACTIVATED) {
+			throw new CustomException(ErrorCode.PRODUCT_NOT_FOUND);
+		}
+
+		return ProductResponse.Detail.from(product);
+	}
+}

--- a/src/main/java/com/kt/service/admin/AdminReviewService.java
+++ b/src/main/java/com/kt/service/admin/AdminReviewService.java
@@ -1,0 +1,23 @@
+package com.kt.service.admin;
+
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import com.kt.constant.searchtype.ProductSearchType;
+import com.kt.domain.dto.response.ReviewResponse;
+
+public interface AdminReviewService {
+	void delete(String email, UUID reviewId);
+
+	ReviewResponse.Search getReview(UUID orderProductId);
+
+	Page<ReviewResponse.Search> getReviewsByAdmin(Pageable pageable, String keyword, ProductSearchType type);
+
+	// TODO: 아래 두 서비스 메서드 컨트롤러 내 api 작성
+	Page<ReviewResponse.Search> getReviewByProductId(UUID productId, Pageable pageable);
+
+	Page<ReviewResponse.Search> getReviewsByUserId(Pageable pageable, UUID userId);
+
+}

--- a/src/main/java/com/kt/service/admin/AdminReviewServiceImpl.java
+++ b/src/main/java/com/kt/service/admin/AdminReviewServiceImpl.java
@@ -1,0 +1,82 @@
+package com.kt.service.admin;
+
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kt.constant.message.ErrorCode;
+import com.kt.constant.searchtype.ProductSearchType;
+import com.kt.domain.dto.response.ReviewResponse;
+import com.kt.domain.entity.AbstractAccountEntity;
+import com.kt.domain.entity.ReviewEntity;
+import com.kt.domain.entity.UserEntity;
+import com.kt.exception.CustomException;
+import com.kt.repository.account.AccountRepository;
+import com.kt.repository.review.ReviewRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AdminReviewServiceImpl implements AdminReviewService {
+
+	private final ReviewRepository reviewRepository;
+	private final AccountRepository accountRepository;
+
+	@Override
+	public ReviewResponse.Search getReview(UUID orderProductId) {
+		ReviewEntity reviewEntity = reviewRepository.findByOrderProductIdOrThrow(orderProductId);
+		return new ReviewResponse.Search(
+			reviewEntity.getId(),
+			reviewEntity.getContent()
+		);
+	}
+
+	@Override
+	public void delete(
+		String email,
+		UUID reviewId
+	) {
+		ReviewEntity review = reviewRepository.findByIdOrThrow(reviewId);
+		if (!hasReviewAccessPermission(email, review))
+			throw new CustomException(ErrorCode.REVIEW_ACCESS_NOT_ALLOWED);
+		review.delete();
+	}
+
+	@Override
+	public Page<ReviewResponse.Search> getReviewByProductId(
+		UUID productId,
+		Pageable pageable
+	) {
+		return reviewRepository.searchReviewsByProductId(pageable, productId);
+	}
+
+	@Override
+	public Page<ReviewResponse.Search> getReviewsByAdmin(
+		Pageable pageable,
+		String keyword,
+		ProductSearchType type
+	) {
+		return reviewRepository.searchReviews(pageable, keyword, type);
+	}
+
+	@Override
+	public Page<ReviewResponse.Search> getReviewsByUserId(Pageable pageable, UUID userId) {
+		return reviewRepository.searchReviewsByUserId(pageable, userId);
+	}
+
+	private boolean hasReviewAccessPermission(String email, ReviewEntity review) {
+		AbstractAccountEntity reviewEditor = accountRepository.findByEmailOrThrow(email);
+
+		UserEntity reviewOwner = review
+			.getOrderProduct()
+			.getOrder()
+			.getOrderBy();
+
+		return reviewEditor.getEmail().equals(reviewOwner.getEmail());
+	}
+}

--- a/src/main/java/com/kt/service/admin/AdminUserService.java
+++ b/src/main/java/com/kt/service/admin/AdminUserService.java
@@ -1,0 +1,34 @@
+package com.kt.service.admin;
+
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import com.kt.constant.UserRole;
+import com.kt.domain.dto.request.UserRequest;
+import com.kt.domain.dto.response.UserResponse;
+
+public interface AdminUserService {
+
+	UserResponse.UserDetail getUserDetail(UUID currentId, UUID subjectId);
+
+	void disableUser(UUID currentId, UUID subjectId);
+
+	void enableUser(UUID currentId, UUID subjectId);
+
+	void deleteUser(UUID currentId, UUID subjectId);
+
+	void deleteUserPermanently(UUID currentId, UUID id);
+
+	Page<UserResponse.Search> getUsers(UUID userId, Pageable pageable, String keyword, UserRole role);
+
+	// TODO: 아래 메서드 AdminUserController 내 메서드 구현 필요
+	UserResponse.Orders getOrdersByUserId(UUID currentId, UUID subjectId);
+
+	void updateUserDetail(UUID currentUserId, UUID targetUserId, UserRequest.UpdateDetails details);
+
+	// 어드민이 탈퇴 가능하게 할것인지?
+	void retireUser(UUID currentId, UUID subjectId);
+
+}

--- a/src/main/java/com/kt/service/admin/AdminUserServiceImpl.java
+++ b/src/main/java/com/kt/service/admin/AdminUserServiceImpl.java
@@ -1,38 +1,38 @@
-package com.kt.service;
+package com.kt.service.admin;
 
 import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import com.kt.constant.UserRole;
 import com.kt.constant.message.ErrorCode;
 import com.kt.domain.dto.request.UserRequest;
-import com.kt.domain.dto.request.SignupRequest;
-import com.kt.domain.dto.response.OrderProductResponse;
 import com.kt.domain.dto.response.UserResponse;
 import com.kt.domain.entity.OrderEntity;
 import com.kt.domain.entity.UserEntity;
-import com.kt.repository.orderproduct.OrderProductRepository;
 import com.kt.repository.OrderRepository;
 import com.kt.repository.user.UserRepository;
 import com.kt.util.Preconditions;
 
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 
 @Service
 @Transactional
 @RequiredArgsConstructor
-public class UserServiceImpl implements UserService {
+public class AdminUserServiceImpl implements AdminUserService {
 
-	private final OrderProductRepository orderProductRepository;
 	private final OrderRepository orderRepository;
 	private final UserRepository userRepository;
-	private final PasswordEncoder passwordEncoder;
+
+	@Override
+	public Page<UserResponse.Search> getUsers(UUID userId, Pageable pageable, String keyword, UserRole role) {
+		checkAdmin(userId);
+		return userRepository.searchUsers(pageable, keyword, role);
+	}
 
 	@Override
 	public UserResponse.Orders getOrdersByUserId(UUID currentId, UUID subjectId) {
@@ -44,15 +44,21 @@ public class UserServiceImpl implements UserService {
 	}
 
 	@Override
-	public Page<OrderProductResponse.SearchReviewable> getReviewableOrderProducts(Pageable pageable, UUID userId) {
-		return orderProductRepository.getReviewableOrderProductsByUserId(pageable, userId);
-	}
+	public void updateUserDetail(
+		UUID currentId,
+		UUID subjectId,
+		UserRequest.UpdateDetails details
+	) {
+		checkModifyPermission(currentId, subjectId);
 
-	@Override
-	public Page<UserResponse.Search> getUsers(UUID userId, Pageable pageable, String keyword, UserRole role) {
-		checkAdmin(userId);
+		UserEntity subjectUser = userRepository.findByIdOrThrow(subjectId);
 
-		return userRepository.searchUsers(pageable, keyword, role);
+		subjectUser.updateDetails(
+			details.name(),
+			details.mobile(),
+			details.birth(),
+			details.gender()
+		);
 	}
 
 	@Override
@@ -72,38 +78,6 @@ public class UserServiceImpl implements UserService {
 	}
 
 	@Override
-	public UserResponse.UserDetail getUserDetailSelf(UUID currentId) {
-		UserEntity user = userRepository.findByIdOrThrow(currentId);
-		return new UserResponse.UserDetail(
-			user.getId(),
-			user.getName(),
-			user.getEmail(),
-			user.getRole(),
-			user.getGender(),
-			user.getBirth(),
-			user.getMobile()
-		);
-	}
-
-	// TODO: for admin
-	@Override
-	public UserResponse.UserDetail getAdminDetail(UUID currentId, UUID subjectId) {
-		checkReadPermission(currentId, subjectId);
-
-		UserEntity user = userRepository.findByIdOrThrow(subjectId);
-		return new UserResponse.UserDetail(
-			user.getId(),
-			user.getName(),
-			user.getEmail(),
-			user.getRole(),
-			user.getGender(),
-			user.getBirth(),
-			user.getMobile()
-		);
-	}
-
-	// TODO: for admin
-	@Override
 	public void enableUser(UUID currentId, UUID subjectId) {
 		checkModifyPermission(currentId, subjectId);
 
@@ -111,7 +85,6 @@ public class UserServiceImpl implements UserService {
 		user.enabled();
 	}
 
-	// TODO: for admin
 	@Override
 	public void disableUser(UUID currentId, UUID subjectId) {
 		checkModifyPermission(currentId, subjectId);
@@ -120,7 +93,6 @@ public class UserServiceImpl implements UserService {
 		user.disabled();
 	}
 
-	// TODO: for admin
 	@Override
 	public void deleteUser(UUID currentId, UUID subjectId) {
 		checkModifyPermission(currentId, subjectId);
@@ -129,7 +101,6 @@ public class UserServiceImpl implements UserService {
 		user.delete();
 	}
 
-	// TODO: for admin
 	@Override
 	public void retireUser(UUID currentId, UUID subjectId) {
 		checkModifyPermission(currentId, subjectId);
@@ -138,24 +109,6 @@ public class UserServiceImpl implements UserService {
 		user.retired();
 	}
 
-	// TODO: for admin
-	@Override
-	public void createAdmin(UUID userId, SignupRequest.SignupMember request) {
-		checkAdmin(userId);
-
-		UserEntity admin = UserEntity.create(
-			request.name(),
-			request.email(),
-			passwordEncoder.encode(request.password()),
-			UserRole.ADMIN,
-			request.gender(),
-			request.birth(),
-			request.mobile()
-		);
-		userRepository.save(admin);
-	}
-
-	// TODO: for admin
 	@Override
 	public void deleteUserPermanently(UUID currentId, UUID subjectId) {
 		checkModifyPermission(currentId, subjectId);
@@ -165,51 +118,7 @@ public class UserServiceImpl implements UserService {
 		userRepository.delete(user);
 	}
 
-	// TODO: for admin
-	@Override
-	public void deleteAdmin(UUID currentId, UUID adminId) {
-		checkAdmin(adminId);
-		checkModifyPermission(currentId, adminId);
-
-		UserEntity user = userRepository.findByIdOrThrow(adminId);
-		user.delete();
-	}
-
-	// TODO: for admin
-	@Override
-	public void updateUserDetail(
-		UUID currentId,
-		UUID subjectId,
-		UserRequest.UpdateDetails details
-	) {
-		checkModifyPermission(currentId, subjectId);
-
-		UserEntity subjectUser = userRepository.findByIdOrThrow(subjectId);
-
-		subjectUser.updateDetails(
-			details.name(),
-			details.mobile(),
-			details.birth(),
-			details.gender()
-		);
-	}
-
-	// TODO: for admin
-	@Override
-	public void updateUserDetailSelf(
-		UUID userId,
-		UserRequest.UpdateDetails details
-	) {
-		UserEntity subjectUser = userRepository.findByIdOrThrow(userId);
-
-		subjectUser.updateDetails(
-			details.name(),
-			details.mobile(),
-			details.birth(),
-			details.gender()
-		);
-	}
-
+	// TODO: 서비스 분리로 인해 필요 없는 권한 체크 메서드 삭제 검토 필요
 	private void checkAdmin(UUID currentUserId) {
 		UserEntity user = userRepository.findByIdOrThrow(currentUserId);
 		Preconditions.validate(

--- a/src/test/java/com/kt/api/admin/category/CategoryListTest.java
+++ b/src/test/java/com/kt/api/admin/category/CategoryListTest.java
@@ -1,0 +1,51 @@
+package com.kt.api.admin.category;
+
+import static com.kt.common.CategoryEntityCreator.*;
+import static com.kt.common.CurrentUserCreator.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.ResultActions;
+
+import com.kt.common.MockMvcTest;
+import com.kt.domain.entity.CategoryEntity;
+import com.kt.repository.CategoryRepository;
+
+@DisplayName("카테고리 전체 조회 - GET /api/admin/categories")
+public class CategoryListTest extends MockMvcTest {
+
+	@Autowired
+	CategoryRepository categoryRepository;
+
+	CategoryEntity testCategory1;
+	CategoryEntity testCategory2;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		testCategory1 = createCategory();
+		testCategory2 = createCategory();
+		categoryRepository.save(testCategory1);
+		categoryRepository.save(testCategory2);
+	}
+
+	@Test
+	void 카테고리_전체_조회__200_OK() throws Exception {
+		// when
+		ResultActions actions = mockMvc.perform(
+			get("/api/admin/categories")
+				.with(user(getAdminUserDetails()))
+		);
+
+		// then
+		actions
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.length()").value(2));
+	}
+}

--- a/src/test/java/com/kt/service/AccountServiceTest.java
+++ b/src/test/java/com/kt/service/AccountServiceTest.java
@@ -60,6 +60,7 @@ class AccountServiceTest {
 	CourierEntity courier1;
 	CourierEntity courier2;
 
+
 	@BeforeEach
 	void setUp() {
 		member1 = UserEntity.create(

--- a/src/test/java/com/kt/service/CategoryServiceTest.java
+++ b/src/test/java/com/kt/service/CategoryServiceTest.java
@@ -52,37 +52,6 @@ class CategoryServiceTest {
 	}
 
 	@Test
-	void 카테고리_생성() {
-		categoryService.create("자식카테고리명", null);
-
-		// given
-		UUID id = categoryRepository.findByName("자식카데고리명")
-			.map(CategoryEntity::getId)
-			.orElseThrow();
-		CategoryEntity foundedCategory = categoryRepository.findById(id).orElseThrow();
-		// then
-		assertThat(foundedCategory).isNotNull();
-		assertThat(foundedCategory.getName()).isEqualTo("자식카데고리명");
-	}
-
-	@Test
-	void 카테고리_이름_수정() {
-		// given
-		CategoryEntity category = categoryRepository.save(
-			CategoryEntity.create("기존이름", null)
-		);
-
-		// when
-		categoryService.update(category.getId(), "수정");
-
-		// then
-		CategoryEntity updated = categoryRepository.findById(category.getId()).orElse(null);
-
-		assertThat(updated).isNotNull();
-		assertThat(updated.getName()).isEqualTo("수정");
-	}
-
-	@Test
 	void 카테고리_전체_조회() {
 		// when
 		List<CategoryResponse.CategoryTreeItem> result = categoryService.getAll();
@@ -98,27 +67,6 @@ class CategoryServiceTest {
 
 		assertThat(parent).isNotNull();
 		assertThat(parent.children()).hasSize(2);
-	}
-
-	@Test
-	void 카테고리_삭제_자식_없음() {
-		// given
-		CategoryEntity category = categoryRepository.findByName("자식카테고리명2").orElse(null);
-
-		// when
-		categoryService.delete(category.getId());
-
-		// then
-		assertThat(categoryRepository.findByName("자식카테고리명2")).isEmpty();
-	}
-
-	@Test
-	void 카테고리_삭제_실패__자식_있음() {
-		// given
-		CategoryEntity category = categoryRepository.findByName("자식있는부모").orElse(null);
-
-		assertThatThrownBy(() -> categoryService.delete(category.getId()))
-			.isInstanceOf(CustomException.class);
 	}
 
 }

--- a/src/test/java/com/kt/service/admin/AdminAccountServiceTest.java
+++ b/src/test/java/com/kt/service/admin/AdminAccountServiceTest.java
@@ -1,0 +1,408 @@
+package com.kt.service.admin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kt.constant.Gender;
+import com.kt.constant.PasswordRequestType;
+import com.kt.constant.UserRole;
+import com.kt.constant.UserStatus;
+import com.kt.domain.dto.request.AccountRequest;
+import com.kt.domain.dto.request.PasswordRequest;
+import com.kt.domain.dto.response.PasswordRequestResponse;
+import com.kt.domain.entity.AbstractAccountEntity;
+import com.kt.domain.entity.CourierEntity;
+import com.kt.domain.entity.PasswordRequestEntity;
+import com.kt.domain.entity.UserEntity;
+import com.kt.exception.CustomException;
+import com.kt.repository.PasswordRequestRepository;
+import com.kt.repository.account.AccountRepository;
+import com.kt.repository.courier.CourierRepository;
+import com.kt.repository.user.UserRepository;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Transactional
+@SpringBootTest
+@ActiveProfiles("test")
+class AccountServiceTest {
+
+	static final String TEST_PASSWORD = "1234567891011";
+	@Autowired
+	AdminAccountService adminAccountService;
+	@Autowired
+	UserRepository userRepository;
+	@Autowired
+	AccountRepository accountRepository;
+	@Autowired
+	CourierRepository courierRepository;
+	@Autowired
+	PasswordEncoder passwordEncoder;
+	@Autowired
+	PasswordRequestRepository passwordRequestRepository;
+
+	UserEntity member1;
+	UserEntity admin1;
+	CourierEntity courier1;
+	CourierEntity courier2;
+
+	@BeforeEach
+	void setUp() {
+		courierRepository.deleteAll();
+		userRepository.deleteAll();
+		accountRepository.deleteAll();
+
+		member1 = UserEntity.create(
+			"회원",
+			"bjwnstkdbj@naver.com",
+			"1234",
+			UserRole.MEMBER,
+			Gender.MALE,
+			LocalDate.of(2000, 1, 1),
+			"111111"
+		);
+		admin1 = UserEntity.create(
+			"관리자",
+			"aaa",
+			"1234",
+			UserRole.ADMIN,
+			Gender.MALE,
+			LocalDate.of(2000, 1, 1),
+			"111111"
+		);
+
+		userRepository.save(member1);
+		userRepository.save(admin1);
+
+		courier1 = CourierEntity.create(
+			"기사1",
+			"courier1@test.com",
+			"1234",
+			Gender.MALE
+		);
+
+		courier2 = CourierEntity.create(
+			"기사2",
+			"courier2@test.com",
+			"1234",
+			Gender.MALE
+		);
+
+		courierRepository.save(courier1);
+		courierRepository.save(courier2);
+	}
+
+	@Test
+	void 회원_조회_성공() {
+		// given
+
+		AccountRequest.Search request = new AccountRequest.Search(
+			UserRole.MEMBER,
+			null,
+			null,
+			"회원"
+		);
+
+		// when
+		Page<?> result = adminAccountService.searchAccounts(
+			request,
+			Pageable.ofSize(10)
+		);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.getContent()).hasSize(1);
+	}
+
+	@Test
+	void 관리자_조회_성공() {
+		// given
+
+		AccountRequest.Search request = new AccountRequest.Search(
+			UserRole.ADMIN,
+			null,
+			null,
+			""
+		);
+
+		// when
+		Page<?> result = adminAccountService.searchAccounts(
+			request,
+			Pageable.ofSize(10)
+		);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.getContent()).hasSize(1);
+	}
+
+	@Test
+	void 배송기사_조회_성공() {
+		// given
+
+		AccountRequest.Search request = new AccountRequest.Search(
+			UserRole.COURIER,
+			null,
+			null,
+			""
+		);
+
+		// when
+		Page<?> result = adminAccountService.searchAccounts(
+			request,
+			Pageable.ofSize(10)
+		);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.getContent()).hasSize(2);
+	}
+
+	@Test
+	void 회원계정_비밀번호변경_성공() {
+		UserEntity user = UserEntity.create(
+			"회원테스터",
+			"wjd123@naver.com",
+			passwordEncoder.encode(TEST_PASSWORD),
+			UserRole.MEMBER,
+			Gender.MALE,
+			LocalDate.of(1990, 1, 1),
+			"010-1234-5678"
+		);
+		userRepository.save(user);
+
+		adminAccountService.updatePassword(
+			user.getId(),
+			TEST_PASSWORD,
+			"12345678910"
+		);
+
+		boolean validResult = passwordEncoder.matches(
+			"12345678910",
+			user.getPassword()
+		);
+
+		Assertions.assertTrue(validResult);
+	}
+
+	@Test
+	void 배송기사계정_비밀번호변경_성공() {
+		CourierEntity courier = CourierEntity.create(
+			"배송기사테스터",
+			"wjd123@naver.com",
+			passwordEncoder.encode(TEST_PASSWORD),
+			Gender.MALE
+		);
+		courierRepository.save(courier);
+
+		adminAccountService.updatePassword(
+			courier.getId(),
+			TEST_PASSWORD,
+			"12345678910"
+		);
+
+		boolean validResult = passwordEncoder.matches(
+			"12345678910",
+			courier.getPassword()
+		);
+
+		Assertions.assertTrue(validResult);
+	}
+
+	@Test
+	void 계정비밀번호변경_실패__현재_비밀번호_불일치() {
+		UserEntity user = UserEntity.create(
+			"주문자테스터1",
+			"wjd123@naver.com",
+			passwordEncoder.encode(TEST_PASSWORD),
+			UserRole.MEMBER,
+			Gender.MALE,
+			LocalDate.of(1990, 1, 1),
+			"010-1234-5678"
+		);
+		userRepository.save(user);
+
+		assertThrowsExactly(
+			CustomException.class,
+			() -> {
+				adminAccountService.updatePassword(
+					user.getId(),
+					"틀린비밀번호입니다.......",
+					"22222222222222"
+				);
+			}
+		);
+	}
+
+	@Test
+	void 계정비밀번호변경_실패__변경할_비밀번호_동일() {
+		CourierEntity courier = CourierEntity.create(
+			"주문자테스터2",
+			"wjd123@naver.com",
+			passwordEncoder.encode(TEST_PASSWORD),
+			Gender.MALE
+		);
+		courierRepository.save(courier);
+
+		assertThrowsExactly(
+			CustomException.class,
+			() -> adminAccountService.updatePassword(
+				courier.getId(),
+				TEST_PASSWORD,
+				TEST_PASSWORD
+			)
+		);
+	}
+
+	@Test
+	void 계정삭제_성공_soft() {
+		CourierEntity courier = CourierEntity.create(
+			"배송기사테스터",
+			"wjd123@naver.com",
+			passwordEncoder.encode(TEST_PASSWORD),
+			Gender.MALE
+		);
+		courierRepository.save(courier);
+
+		adminAccountService.deleteAccount(courier.getId());
+		AbstractAccountEntity foundedAccount = accountRepository.findByIdOrThrow(courier.getId());
+
+		Assertions.assertEquals(UserStatus.DELETED, foundedAccount.getStatus());
+	}
+
+	@Test
+	void 계정삭제_성공_hard() {
+		CourierEntity courier = CourierEntity.create(
+			"배송기사테스터",
+			"wjd123@naver.com",
+			passwordEncoder.encode(TEST_PASSWORD),
+			Gender.MALE
+		);
+		courierRepository.save(courier);
+
+		adminAccountService.deleteAccountPermanently(courier.getId());
+
+		assertThatThrownBy(() -> accountRepository.findByIdOrThrow(courier.getId()))
+			.isInstanceOf(CustomException.class);
+
+	}
+
+	@Test
+	void 관리자_다른_계정_비밀번호_초기화_성공() {
+		PasswordRequestEntity passwordRequest = PasswordRequestEntity.create(
+			member1,
+			null,
+			PasswordRequestType.RESET
+		);
+		passwordRequestRepository.save(passwordRequest);
+		String originPassword = "1234";
+
+		adminAccountService.resetAccountPassword(member1.getId());
+
+		log.info(
+			"isMatch :: {}", passwordEncoder.matches(
+				originPassword, member1.getPassword()
+			)
+		);
+
+		assertFalse(
+			passwordEncoder.matches(
+				originPassword,
+				member1.getPassword()
+			)
+		);
+		log.info("passwordRequest status : {}", passwordRequest.getStatus());
+	}
+
+	@Test
+	void 관리자_다른_계정_비밀번호_초기화_실패_요청사항_없음() {
+
+		assertThatThrownBy(
+			() -> adminAccountService.resetAccountPassword(member1.getId())
+		).isInstanceOf(CustomException.class);
+
+	}
+
+	@Test
+	void 관리자_다른_계정_비밀번호_변경_성공() {
+		String originPassword = "1234";
+		String updatedPassword = "1231231!";
+		PasswordRequestEntity passwordRequest = PasswordRequestEntity.create(
+			member1,
+			updatedPassword,
+			PasswordRequestType.UPDATE
+		);
+		passwordRequestRepository.save(passwordRequest);
+
+		adminAccountService.updateAccountPassword(member1.getId());
+
+		log.info(
+			"isMatch :: {}", passwordEncoder.matches(
+				originPassword, member1.getPassword()
+			)
+		);
+
+		assertFalse(
+			passwordEncoder.matches(originPassword, member1.getPassword())
+		);
+
+		log.info("passwordRequest status : {}", passwordRequest.getStatus());
+	}
+
+	@Test
+	void 비밀번호_변경_및_초기화_요청_리스트_조회_성공() {
+		String updatePassword = "123123";
+
+		PasswordRequestEntity firstRequest = PasswordRequestEntity.create(
+			member1,
+			null,
+			PasswordRequestType.RESET
+		);
+
+		PasswordRequestEntity secondRequest = PasswordRequestEntity.create(
+			courier1,
+			updatePassword,
+			PasswordRequestType.UPDATE
+		);
+		passwordRequestRepository.save(firstRequest);
+		passwordRequestRepository.save(secondRequest);
+
+		Pageable pageable = Pageable.ofSize(10);
+
+		// when
+		PasswordRequest.Search request = new PasswordRequest.Search(
+			UserRole.COURIER,
+			null,
+			null,
+			""
+		);
+
+		Page<PasswordRequestResponse.Search> result =
+			adminAccountService.searchPasswordRequests(request, pageable);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.getContent()).hasSize(1);
+		assertThat(result.getContent()
+			.stream()
+			.map(PasswordRequestResponse.Search::accountId)
+		).contains(courier1.getId());
+
+	}
+
+}

--- a/src/test/java/com/kt/service/admin/AdminAccountServiceTest.java
+++ b/src/test/java/com/kt/service/admin/AdminAccountServiceTest.java
@@ -63,6 +63,7 @@ class AdminAccountServiceTest {
 
 	@BeforeEach
 	void setUp() {
+		passwordRequestRepository.deleteAll();
 		courierRepository.deleteAll();
 		userRepository.deleteAll();
 		accountRepository.deleteAll();

--- a/src/test/java/com/kt/service/admin/AdminAccountServiceTest.java
+++ b/src/test/java/com/kt/service/admin/AdminAccountServiceTest.java
@@ -40,7 +40,7 @@ import lombok.extern.slf4j.Slf4j;
 @Transactional
 @SpringBootTest
 @ActiveProfiles("test")
-class AccountServiceTest {
+class AdminAccountServiceTest {
 
 	static final String TEST_PASSWORD = "1234567891011";
 	@Autowired

--- a/src/test/java/com/kt/service/admin/AdminAdminServiceTest.java
+++ b/src/test/java/com/kt/service/admin/AdminAdminServiceTest.java
@@ -288,35 +288,35 @@ class AdminAdminServiceTest {
 		assertThat(foundedUser).isNotNull();
 		assertThat(foundedUser.getStatus()).isEqualTo(UserStatus.DELETED);
 	}
-
-	@Test
-	@Transactional(propagation = Propagation.NOT_SUPPORTED)
-	void 유저_하드_딜리트_성공() {
-		// given
-		UserEntity user = UserEntity.create(
-			"삭제",
-			"aaa",
-			"1234",
-			UserRole.MEMBER,
-			Gender.MALE,
-			LocalDate.of(1111, 1, 1),
-			"111"
-		);
-		UserEntity savedUser = userRepository.save(user);
-
-		OrderEntity order = OrderEntity.create(
-			ReceiverVO.create("이름", "번호", "도시", "시군구", "동", "상세"),
-			savedUser
-		);
-		OrderEntity savedOrder = orderRepository.save(order);
-
-		// when
-		adminUserService.deleteUserPermanently(testAdmin.getId(), savedUser.getId());
-
-		// then
-		assertThat(userRepository.existsById(savedUser.getId())).isFalse();
-		OrderEntity foundOrder = orderRepository.findById(savedOrder.getId()).orElse(null);
-		assertThat(foundOrder).isNotNull();
-	}
+	//
+	// @Test
+	// @Transactional(propagation = Propagation.NOT_SUPPORTED)
+	// void 유저_하드_딜리트_성공() {
+	// 	// given
+	// 	UserEntity user = UserEntity.create(
+	// 		"삭제",
+	// 		"aaa",
+	// 		"1234",
+	// 		UserRole.MEMBER,
+	// 		Gender.MALE,
+	// 		LocalDate.of(1111, 1, 1),
+	// 		"111"
+	// 	);
+	// 	UserEntity savedUser = userRepository.save(user);
+	//
+	// 	OrderEntity order = OrderEntity.create(
+	// 		ReceiverVO.create("이름", "번호", "도시", "시군구", "동", "상세"),
+	// 		savedUser
+	// 	);
+	// 	OrderEntity savedOrder = orderRepository.save(order);
+	//
+	// 	// when
+	// 	adminUserService.deleteUserPermanently(testAdmin.getId(), savedUser.getId());
+	//
+	// 	// then
+	// 	assertThat(userRepository.existsById(savedUser.getId())).isFalse();
+	// 	OrderEntity foundOrder = orderRepository.findById(savedOrder.getId()).orElse(null);
+	// 	assertThat(foundOrder).isNotNull();
+	// }
 
 }

--- a/src/test/java/com/kt/service/admin/AdminAdminServiceTest.java
+++ b/src/test/java/com/kt/service/admin/AdminAdminServiceTest.java
@@ -288,35 +288,35 @@ class AdminAdminServiceTest {
 		assertThat(foundedUser).isNotNull();
 		assertThat(foundedUser.getStatus()).isEqualTo(UserStatus.DELETED);
 	}
-	//
-	// @Test
-	// @Transactional(propagation = Propagation.NOT_SUPPORTED)
-	// void 유저_하드_딜리트_성공() {
-	// 	// given
-	// 	UserEntity user = UserEntity.create(
-	// 		"삭제",
-	// 		"aaa",
-	// 		"1234",
-	// 		UserRole.MEMBER,
-	// 		Gender.MALE,
-	// 		LocalDate.of(1111, 1, 1),
-	// 		"111"
-	// 	);
-	// 	UserEntity savedUser = userRepository.save(user);
-	//
-	// 	OrderEntity order = OrderEntity.create(
-	// 		ReceiverVO.create("이름", "번호", "도시", "시군구", "동", "상세"),
-	// 		savedUser
-	// 	);
-	// 	OrderEntity savedOrder = orderRepository.save(order);
-	//
-	// 	// when
-	// 	adminUserService.deleteUserPermanently(testAdmin.getId(), savedUser.getId());
-	//
-	// 	// then
-	// 	assertThat(userRepository.existsById(savedUser.getId())).isFalse();
-	// 	OrderEntity foundOrder = orderRepository.findById(savedOrder.getId()).orElse(null);
-	// 	assertThat(foundOrder).isNotNull();
-	// }
+
+	@Test
+	@Transactional(propagation = Propagation.NOT_SUPPORTED)
+	void 유저_하드_딜리트_성공() {
+		// given
+		UserEntity user = UserEntity.create(
+			"삭제",
+			"aaa",
+			"1234",
+			UserRole.MEMBER,
+			Gender.MALE,
+			LocalDate.of(1111, 1, 1),
+			"111"
+		);
+		UserEntity savedUser = userRepository.save(user);
+
+		OrderEntity order = OrderEntity.create(
+			ReceiverVO.create("이름", "번호", "도시", "시군구", "동", "상세"),
+			savedUser
+		);
+		OrderEntity savedOrder = orderRepository.save(order);
+
+		// when
+		adminUserService.deleteUserPermanently(testAdmin.getId(), savedUser.getId());
+
+		// then
+		assertThat(userRepository.existsById(savedUser.getId())).isFalse();
+		OrderEntity foundOrder = orderRepository.findById(savedOrder.getId()).orElse(null);
+		assertThat(foundOrder).isNotNull();
+	}
 
 }

--- a/src/test/java/com/kt/service/admin/AdminAdminServiceTest.java
+++ b/src/test/java/com/kt/service/admin/AdminAdminServiceTest.java
@@ -1,0 +1,322 @@
+package com.kt.service.admin;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kt.constant.Gender;
+import com.kt.constant.OrderProductStatus;
+import com.kt.constant.UserRole;
+import com.kt.constant.UserStatus;
+import com.kt.constant.message.ErrorCode;
+import com.kt.domain.dto.response.UserResponse;
+import com.kt.domain.entity.CategoryEntity;
+import com.kt.domain.entity.OrderEntity;
+import com.kt.domain.entity.OrderProductEntity;
+import com.kt.domain.entity.ProductEntity;
+import com.kt.domain.entity.ReceiverVO;
+import com.kt.domain.entity.UserEntity;
+import com.kt.exception.CustomException;
+import com.kt.repository.CategoryRepository;
+import com.kt.repository.OrderRepository;
+import com.kt.repository.orderproduct.OrderProductRepository;
+import com.kt.repository.product.ProductRepository;
+import com.kt.repository.review.ReviewRepository;
+import com.kt.repository.user.UserRepository;
+
+@Transactional
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class AdminAdminServiceTest {
+
+	@Autowired
+	AdminUserService adminUserService;
+	@Autowired
+	UserRepository userRepository;
+	@Autowired
+	OrderRepository orderRepository;
+	@Autowired
+	OrderProductRepository orderProductRepository;
+	@Autowired
+	ReviewRepository reviewRepository;
+	@Autowired
+	ProductRepository productRepository;
+	@Autowired
+	CategoryRepository categoryRepository;
+
+	UserEntity testUser;
+	UserEntity testUser2;
+	UserEntity testAdmin;
+	OrderEntity testOrder;
+	ProductEntity testProduct;
+	OrderProductEntity testOrderProduct;
+	UUID userId;
+	UUID AdminId;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		reviewRepository.deleteAll();
+		orderProductRepository.deleteAll();
+		orderRepository.deleteAll();
+		userRepository.deleteAll();
+		productRepository.deleteAll();
+		categoryRepository.deleteAll();
+
+		testUser = UserEntity.create(
+			"주문자테스터1",
+			"wjd123@naver.com",
+			"1234",
+			UserRole.MEMBER,
+			Gender.MALE,
+			LocalDate.of(1990, 1, 1),
+			"010-1234-5678"
+		);
+
+		testUser2 = UserEntity.create(
+			"주문자테스터2",
+			"dohyun@naver.com",
+			"1234",
+			UserRole.MEMBER,
+			Gender.MALE,
+			LocalDate.of(1990, 1, 1),
+			"010-1234-5678"
+		);
+
+		testAdmin = UserEntity.create(
+			"어드민테스터",
+			"dohyun@naver.com",
+			"1234",
+			UserRole.ADMIN,
+			Gender.MALE,
+			LocalDate.of(1990, 1, 1),
+			"010-1234-5678"
+		);
+
+		userRepository.save(testUser);
+		UserEntity savedUser = userRepository.save(testUser2);
+		UserEntity savedAdmin = userRepository.save(testAdmin);
+		userId = savedUser.getId();
+		AdminId = savedAdmin.getId();
+
+		ReceiverVO receiver = new ReceiverVO(
+			"수신자테스터1",
+			"010-1234-5678",
+			"강원도",
+			"원주시",
+			"행구로",
+			"주소설명"
+		);
+
+		testOrder = OrderEntity.create(
+			receiver,
+			testUser
+		);
+		orderRepository.save(testOrder);
+
+		CategoryEntity category = CategoryEntity.create("카테고리", null);
+		categoryRepository.save(category);
+
+		testProduct = ProductEntity.create(
+			"테스트상품명",
+			1000L,
+			5L,
+			category
+		);
+		productRepository.save(testProduct);
+
+		testOrderProduct = new OrderProductEntity(
+			5L,
+			5000L,
+			OrderProductStatus.CREATED,
+			testOrder,
+			testProduct
+		);
+		orderProductRepository.save(testOrderProduct);
+	}
+
+	@Test
+	void 내_주문_조회() {
+		UserEntity user = UserEntity.create(
+			"김도현",
+			"ddd",
+			"111",
+			UserRole.MEMBER,
+			Gender.MALE,
+			LocalDate.now(),
+			"0101010"
+		);
+
+		UserEntity savedUser = userRepository.save(user);
+
+		userId = savedUser.getId();
+
+		CategoryEntity category = CategoryEntity.create("카테고리", null);
+		categoryRepository.save(category);
+
+		ProductEntity product = ProductEntity.create(
+			"테스트물건",
+			3L,
+			3L,
+			category
+		);
+
+		ProductEntity savedProduct = productRepository.save(product);
+
+		OrderEntity order = OrderEntity.create(
+			ReceiverVO.create("이름", "번호", "도시", "시군구", "동", "상세"),
+			savedUser
+		);
+		orderRepository.save(order);
+		// when
+		UserResponse.Orders foundOrder = adminUserService.getOrdersByUserId(userId, userId);
+
+		// then
+		assertThat(foundOrder).isNotNull();
+		assertThat(foundOrder.userId()).isEqualTo(userId);
+		assertThat(foundOrder.orders()).isNotEmpty();
+	}
+
+	@Test
+	void 유저_리스트_조회() {
+
+		// when
+		Page<UserResponse.Search> result = adminUserService.getUsers(testAdmin.getId(), Pageable.ofSize(10), "테스터",
+			UserRole.MEMBER);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.getContent()).hasSize(2);
+	}
+
+	@Test
+	void 어드민_리스트_조회() {
+
+		// when
+		Page<UserResponse.Search> result = adminUserService.getUsers(testAdmin.getId(), Pageable.ofSize(10), "어드민",
+			UserRole.ADMIN);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.getContent()).hasSize(1);
+	}
+
+	@Test
+	void 유저_상세_본인조회() {
+		UserResponse.UserDetail savedUser = adminUserService.getUserDetail(userId, userId);
+
+		// then
+		assertThat(userId).isNotNull();
+		assertThat(savedUser.name()).isEqualTo("주문자테스터2");
+	}
+
+	@Test
+	void 유저_상세_조회__실패_다른사람조회() {
+		assertThatThrownBy(
+			() -> adminUserService.getUserDetail(userId, AdminId)
+		)
+			.isInstanceOf(CustomException.class)
+			.hasMessageContaining(ErrorCode.ACCOUNT_ACCESS_NOT_ALLOWED.name());
+	}
+
+	@Test
+	void 유저_상태_변경_disabled() {
+		// when
+		adminUserService.disableUser(testAdmin.getId(), testUser.getId());
+		UserEntity foundedUser = userRepository.findById(testUser.getId()).orElseThrow();
+
+		// then
+		assertThat(foundedUser).isNotNull();
+		assertThat(foundedUser.getStatus()).isEqualTo(UserStatus.DISABLED);
+	}
+
+	@Test
+	void 유저_상태_변경__실패_어드민아님() {
+		// then
+		assertThatThrownBy(
+			() -> adminUserService.disableUser(testUser2.getId(), testUser.getId())
+		)
+			.isInstanceOf(CustomException.class)
+			.hasMessageContaining(ErrorCode.ACCOUNT_ACCESS_NOT_ALLOWED.name());
+	}
+
+	@Test
+	void 유저_상태_변경_enabled() {
+
+		// when
+		adminUserService.disableUser(testAdmin.getId(), testUser.getId());
+		adminUserService.enableUser(testAdmin.getId(), testUser.getId());
+		UserEntity foundedUser = userRepository.findById(testUser.getId()).orElseThrow();
+
+		// then
+		assertThat(foundedUser).isNotNull();
+		assertThat(foundedUser.getStatus()).isEqualTo(UserStatus.ENABLED);
+
+	}
+
+	@Test
+	void 유저_상태_변경_retired() {
+
+		// when
+		adminUserService.retireUser(testAdmin.getId(), testUser.getId());
+		UserEntity foundedUser = userRepository.findById(testUser.getId()).orElseThrow();
+		// then
+		assertThat(foundedUser).isNotNull();
+		assertThat(foundedUser.getStatus()).isEqualTo(UserStatus.RETIRED);
+
+	}
+
+	@Test
+	void 유저_상태_변경_delete() {
+		// when
+		adminUserService.deleteUser(testUser.getId(), testUser.getId());
+		UserEntity foundedUser = userRepository.findById(testUser.getId()).orElseThrow();
+		// then
+		assertThat(foundedUser).isNotNull();
+		assertThat(foundedUser.getStatus()).isEqualTo(UserStatus.DELETED);
+	}
+
+	@Test
+	@Transactional(propagation = Propagation.NOT_SUPPORTED)
+	void 유저_하드_딜리트_성공() {
+		// given
+		UserEntity user = UserEntity.create(
+			"삭제",
+			"aaa",
+			"1234",
+			UserRole.MEMBER,
+			Gender.MALE,
+			LocalDate.of(1111, 1, 1),
+			"111"
+		);
+		UserEntity savedUser = userRepository.save(user);
+
+		OrderEntity order = OrderEntity.create(
+			ReceiverVO.create("이름", "번호", "도시", "시군구", "동", "상세"),
+			savedUser
+		);
+		OrderEntity savedOrder = orderRepository.save(order);
+
+		// when
+		adminUserService.deleteUserPermanently(testAdmin.getId(), savedUser.getId());
+
+		// then
+		assertThat(userRepository.existsById(savedUser.getId())).isFalse();
+		OrderEntity foundOrder = orderRepository.findById(savedOrder.getId()).orElse(null);
+		assertThat(foundOrder).isNotNull();
+	}
+
+}

--- a/src/test/java/com/kt/service/admin/AdminCategoryServiceTest.java
+++ b/src/test/java/com/kt/service/admin/AdminCategoryServiceTest.java
@@ -1,0 +1,126 @@
+package com.kt.service.admin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.kt.domain.dto.response.CategoryResponse;
+import com.kt.domain.entity.CategoryEntity;
+import com.kt.exception.CustomException;
+import com.kt.repository.CategoryRepository;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class AdminCategoryServiceTest {
+
+	@Autowired
+	private AdminCategoryService adminCategoryService;
+	@Autowired
+	private CategoryRepository categoryRepository;
+
+	@BeforeEach
+	void setUp() {
+
+		categoryRepository.deleteAll();
+
+		CategoryEntity parentCategory = categoryRepository.save(
+			CategoryEntity.create(
+				"자식있는부모",
+				null
+			));
+		CategoryEntity parentCategory2 = categoryRepository.save(
+			CategoryEntity.create(
+				"자식없는부모",
+				null
+			));
+		CategoryEntity childCategory = categoryRepository.save(
+			CategoryEntity.create(
+				"자식카데고리명",
+				parentCategory
+			));
+		CategoryEntity childCategory2 = categoryRepository.save(
+			CategoryEntity.create(
+				"자식카테고리명2",
+				parentCategory
+			));
+	}
+
+	@Test
+	void 카테고리_생성() {
+		adminCategoryService.create("자식카테고리명", null);
+
+		// given
+		UUID id = categoryRepository.findByName("자식카데고리명")
+			.map(CategoryEntity::getId)
+			.orElseThrow();
+		CategoryEntity foundedCategory = categoryRepository.findById(id).orElseThrow();
+		// then
+		assertThat(foundedCategory).isNotNull();
+		assertThat(foundedCategory.getName()).isEqualTo("자식카데고리명");
+	}
+
+	@Test
+	void 카테고리_이름_수정() {
+		// given
+		CategoryEntity category = categoryRepository.save(
+			CategoryEntity.create("기존이름", null)
+		);
+
+		// when
+		adminCategoryService.update(category.getId(), "수정");
+
+		// then
+		CategoryEntity updated = categoryRepository.findById(category.getId()).orElse(null);
+
+		assertThat(updated).isNotNull();
+		assertThat(updated.getName()).isEqualTo("수정");
+	}
+
+	@Test
+	void 카테고리_전체_조회() {
+		// when
+		List<CategoryResponse.CategoryTreeItem> result = adminCategoryService.getAll();
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result).hasSize(2);
+
+		CategoryResponse.CategoryTreeItem parent = result
+			.stream()
+			.filter(res -> res.name().equals("자식있는부모"))
+			.findFirst()
+			.orElseThrow();
+
+		assertThat(parent).isNotNull();
+		assertThat(parent.children()).hasSize(2);
+	}
+
+	@Test
+	void 카테고리_삭제_자식_없음() {
+		// given
+		CategoryEntity category = categoryRepository.findByName("자식카테고리명2").orElse(null);
+
+		// when
+		adminCategoryService.delete(category.getId());
+
+		// then
+		assertThat(categoryRepository.findByName("자식카테고리명2")).isEmpty();
+	}
+
+	@Test
+	void 카테고리_삭제_실패__자식_있음() {
+		// given
+		CategoryEntity category = categoryRepository.findByName("자식있는부모").orElse(null);
+
+		assertThatThrownBy(() -> adminCategoryService.delete(category.getId()))
+			.isInstanceOf(CustomException.class);
+	}
+
+}

--- a/src/test/java/com/kt/service/admin/AdminCategoryServiceTest.java
+++ b/src/test/java/com/kt/service/admin/AdminCategoryServiceTest.java
@@ -6,29 +6,35 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.util.List;
 import java.util.UUID;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.kt.domain.dto.response.CategoryResponse;
 import com.kt.domain.entity.CategoryEntity;
 import com.kt.exception.CustomException;
 import com.kt.repository.CategoryRepository;
+import com.kt.repository.product.ProductRepository;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
+@Transactional
 class AdminCategoryServiceTest {
 
 	@Autowired
 	private AdminCategoryService adminCategoryService;
 	@Autowired
 	private CategoryRepository categoryRepository;
+	@Autowired
+	private ProductRepository productRepository;
 
 	@BeforeEach
 	void setUp() {
-
+		productRepository.deleteAll();
 		categoryRepository.deleteAll();
 
 		CategoryEntity parentCategory = categoryRepository.save(
@@ -65,6 +71,12 @@ class AdminCategoryServiceTest {
 		// then
 		assertThat(foundedCategory).isNotNull();
 		assertThat(foundedCategory.getName()).isEqualTo("자식카데고리명");
+	}
+
+	@AfterEach
+	void tearDown() {
+
+		categoryRepository.deleteAll();
 	}
 
 	@Test

--- a/src/test/java/com/kt/service/admin/AdminCourierServiceTest.java
+++ b/src/test/java/com/kt/service/admin/AdminCourierServiceTest.java
@@ -1,0 +1,78 @@
+package com.kt.service.admin;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kt.common.CourierEntityCreator;
+import com.kt.common.UserEntityCreator;
+import com.kt.constant.Gender;
+import com.kt.domain.dto.request.CourierRequest;
+import com.kt.domain.dto.response.CourierResponse;
+import com.kt.domain.entity.CourierEntity;
+import com.kt.domain.entity.UserEntity;
+import com.kt.repository.courier.CourierRepository;
+import com.kt.repository.user.UserRepository;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+class AdminCourierServiceTest {
+
+	@Autowired
+	AdminCourierService adminCourierService;
+	@Autowired
+	CourierRepository courierRepository;
+	@Autowired
+	UserRepository userRepository;
+
+	CourierEntity testCourier;
+	UserEntity testAdmin;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		courierRepository.deleteAll();
+		testCourier = CourierEntityCreator.createCourierEntity();
+		courierRepository.save(testCourier);
+		testAdmin = UserEntityCreator.createAdmin();
+		userRepository.save(testAdmin);
+	}
+
+	@Test
+	void 배송기사정보수정_어드민_성공() {
+		// given
+		CourierRequest.UpdateDetails update = new CourierRequest.UpdateDetails(
+			"변경된 테스터명",
+			Gender.FEMALE
+		);
+
+		// when
+		adminCourierService.updateDetail(testAdmin.getId(), testCourier.getId(), update);
+
+		// then
+		Assertions.assertEquals(testCourier.getName(), update.name());
+	}
+
+	@Test
+	void 배송기사조회_어드민_성공() {
+		// when
+		CourierResponse.DetailAdmin savedCourier = adminCourierService.getDetail(testCourier.getId(), testCourier.getId());
+
+		// then
+		assertThat(savedCourier).satisfies(
+			courierEntity -> {
+				Assertions.assertEquals(courierEntity.id(), testCourier.getId());
+				Assertions.assertEquals(courierEntity.email(), testCourier.getEmail());
+			});
+	}
+
+}

--- a/src/test/java/com/kt/service/admin/AdminOrderServiceTest.java
+++ b/src/test/java/com/kt/service/admin/AdminOrderServiceTest.java
@@ -1,0 +1,266 @@
+package com.kt.service.admin;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kt.common.CategoryEntityCreator;
+import com.kt.common.ProductEntityCreator;
+import com.kt.common.ReceiverCreator;
+import com.kt.common.UserEntityCreator;
+import com.kt.constant.OrderProductStatus;
+import com.kt.constant.OrderStatus;
+import com.kt.constant.message.ErrorCode;
+import com.kt.domain.dto.response.AdminOrderResponse;
+import com.kt.domain.entity.CategoryEntity;
+import com.kt.domain.entity.OrderEntity;
+import com.kt.domain.entity.OrderProductEntity;
+import com.kt.domain.entity.ProductEntity;
+import com.kt.domain.entity.UserEntity;
+import com.kt.exception.CustomException;
+import com.kt.repository.AddressRepository;
+import com.kt.repository.CategoryRepository;
+import com.kt.repository.OrderRepository;
+import com.kt.repository.orderproduct.OrderProductRepository;
+import com.kt.repository.product.ProductRepository;
+import com.kt.repository.review.ReviewRepository;
+import com.kt.repository.user.UserRepository;
+
+@Transactional
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class AdminOrderServiceTest {
+
+	@Autowired
+	AdminOrderService adminOrderService;
+	@Autowired
+	UserRepository userRepository;
+	@Autowired
+	ProductRepository productRepository;
+	@Autowired
+	OrderRepository orderRepository;
+	@Autowired
+	OrderProductRepository orderProductRepository;
+	@Autowired
+	ReviewRepository reviewRepository;
+	@Autowired
+	CategoryRepository categoryRepository;
+	@Autowired
+	AddressRepository addressRepository;
+
+	CategoryEntity category;
+
+	@BeforeEach
+	void setup() {
+		reviewRepository.deleteAll();
+		orderProductRepository.deleteAll();
+		orderRepository.deleteAll();
+		productRepository.deleteAll();
+		userRepository.deleteAll();
+		categoryRepository.deleteAll();
+		addressRepository.deleteAll();
+
+		category = categoryRepository.save(CategoryEntityCreator.createCategory());
+	}
+
+	OrderEntity createOrder(UserEntity user, OrderStatus status) {
+		return orderRepository.save(
+			OrderEntity.create(
+				ReceiverCreator.createReceiver(),
+				user,
+				status
+			)
+		);
+	}
+
+	OrderProductEntity createOrderWithProducts(OrderEntity order, long quantity) {
+
+		ProductEntity product = productRepository.save(ProductEntityCreator.createProduct(category));
+		product.decreaseStock(quantity);
+		productRepository.save(product);
+
+		return orderProductRepository.save(
+			OrderProductEntity.create(
+				quantity,
+				product.getPrice(),
+				OrderProductStatus.CREATED,
+				order,
+				product
+			)
+		);
+	}
+
+	@Test
+	void 주문_취소_성공() {
+		// given
+		UserEntity user = userRepository.save(UserEntityCreator.createMember());
+		ProductEntity product = productRepository.save(ProductEntityCreator.createProduct(category));
+		OrderEntity order = createOrder(user, OrderStatus.WAITING_PAYMENT);
+
+		OrderProductEntity orderProduct = createOrderWithProducts(order, 3L);
+		long beforeStock = orderProduct.getProduct().getStock();
+
+		// when
+		adminOrderService.cancelOrder(user.getId(), order.getId());
+
+		// then
+		long afterStock = productRepository.findById(orderProduct.getProduct().getId()).get().getStock();
+		assertThat(afterStock).isEqualTo(beforeStock + 3L);
+	}
+
+	@Test
+	void 주문_취소_실패__이미_구매확정() {
+		// given
+		UserEntity user = userRepository.save(UserEntityCreator.createMember());
+		OrderEntity order = createOrder(user, OrderStatus.PURCHASE_CONFIRMED);
+
+		// when & then
+		assertThatThrownBy(() -> adminOrderService.cancelOrder(user.getId(), order.getId()))
+			.isInstanceOf(CustomException.class)
+			.hasMessageContaining("ORDER_ALREADY_CONFIRMED");
+	}
+
+	@Test
+	void 주문_리스트_조회_성공() {
+		// given
+		UserEntity user = userRepository.save(UserEntityCreator.createMember());
+		ProductEntity product = productRepository.save(ProductEntityCreator.createProduct(category));
+
+		OrderEntity order1 = createOrder(user, OrderStatus.CREATED);
+		OrderEntity order2 = createOrder(user, OrderStatus.WAITING_PAYMENT);
+
+		product.decreaseStock(1L);
+		productRepository.save(product);
+		orderProductRepository.save(
+			OrderProductEntity.create(
+				1L,
+				product.getPrice(),
+				OrderProductStatus.CREATED,
+				order1,
+				product
+			)
+		);
+
+		product.decreaseStock(2L);
+		productRepository.save(product);
+		orderProductRepository.save(
+			OrderProductEntity.create(
+				2L,
+				product.getPrice(),
+				OrderProductStatus.CREATED,
+				order2,
+				product
+			)
+		);
+
+		Pageable pageable = Pageable.ofSize(10);
+		// when
+		Page<AdminOrderResponse.Search> result = adminOrderService.searchOrder(pageable);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.getContent()).hasSize(2);
+		assertThat(result.getContent()
+			.stream()
+			.map(AdminOrderResponse.Search::orderId)
+		).contains(order1.getId(), order2.getId());
+	}
+
+	@Test
+	void 주문_상세_조회_성공() {
+		// given
+		UserEntity user = userRepository.save(UserEntityCreator.createMember());
+		ProductEntity product = productRepository.save(ProductEntityCreator.createProduct(category));
+
+		OrderEntity order = createOrder(user, OrderStatus.CREATED);
+		product.decreaseStock(3L);
+		productRepository.save(product);
+		orderProductRepository.save(
+			OrderProductEntity.create(
+				3L,
+				product.getPrice(),
+				OrderProductStatus.CREATED,
+				order,
+				product
+			)
+		);
+
+		// when
+		AdminOrderResponse.Detail detail = adminOrderService.getOrderDetail(order.getId());
+
+		// then
+		assertThat(detail).isNotNull();
+		assertThat(detail.orderId()).isEqualTo(order.getId());
+		assertThat(detail.ordererName()).isEqualTo(user.getName());
+		assertThat(detail.products()).hasSize(1);
+		assertThat(detail.products().get(0).quantity()).isEqualTo(3L);
+	}
+
+	@Test
+	void 주문_상태_변경_성공() {
+		// given
+		UserEntity user = userRepository.save(UserEntityCreator.createMember());
+		ProductEntity product = productRepository.save(ProductEntityCreator.createProduct(category));
+
+		OrderEntity order = createOrder(user, OrderStatus.CREATED);
+		product.decreaseStock(1L);
+		productRepository.save(product);
+		orderProductRepository.save(
+			OrderProductEntity.create(
+				1L,
+				product.getPrice(),
+				OrderProductStatus.CREATED,
+				order,
+				product
+			)
+		);
+		OrderStatus newStatus = OrderStatus.SHIPPING;
+
+		// when
+		adminOrderService.updateOrderStatus(order.getId(), newStatus);
+
+		// then
+		OrderEntity updated = orderRepository.findById(order.getId()).get();
+		assertThat(updated.getStatus()).isEqualTo(newStatus);
+	}
+
+	@Test
+	void 주문_상태_변경_실패__현재배송중() {
+		// given
+		UserEntity user = userRepository.save(UserEntityCreator.createMember());
+		ProductEntity product = productRepository.save(ProductEntityCreator.createProduct(category));
+
+		OrderEntity order = createOrder(user, OrderStatus.SHIPPING);
+		product.decreaseStock(1L);
+		productRepository.save(product);
+		orderProductRepository.save(
+			OrderProductEntity.create(
+				1L,
+				product.getPrice(),
+				OrderProductStatus.CREATED,
+				order,
+				product
+			)
+		);
+
+		OrderStatus newStatus = OrderStatus.CANCELED;
+
+		// when & then
+		assertThatThrownBy(() ->
+			adminOrderService.updateOrderStatus(order.getId(), newStatus)
+		)
+			.isInstanceOf(CustomException.class)
+			.hasMessageContaining(ErrorCode.ORDER_ALREADY_SHIPPED.name());
+	}
+
+}

--- a/src/test/java/com/kt/service/admin/AdminProductServiceTest.java
+++ b/src/test/java/com/kt/service/admin/AdminProductServiceTest.java
@@ -6,12 +6,14 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.kt.constant.ProductStatus;
 import com.kt.constant.UserRole;
@@ -21,11 +23,13 @@ import com.kt.domain.dto.response.ProductResponse;
 import com.kt.domain.entity.CategoryEntity;
 import com.kt.domain.entity.ProductEntity;
 import com.kt.repository.CategoryRepository;
+import com.kt.repository.orderproduct.OrderProductRepository;
 import com.kt.repository.product.ProductRepository;
 import com.kt.service.ProductService;
 
 @ActiveProfiles("test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Transactional
 class AdminProductServiceTest {
 
 	private final AdminProductService adminProductService;
@@ -34,9 +38,12 @@ class AdminProductServiceTest {
 
 	private final CategoryRepository categoryRepository;
 
+	private final OrderProductRepository orderProductRepository;
+
 	@Autowired
 	AdminProductServiceTest(AdminProductService adminProductService, ProductRepository productRepository,
-		CategoryRepository categoryRepository) {
+		CategoryRepository categoryRepository, OrderProductRepository orderProductRepository) {
+		this.orderProductRepository = orderProductRepository;
 		this.adminProductService = adminProductService;
 		this.productRepository = productRepository;
 		this.categoryRepository = categoryRepository;
@@ -44,6 +51,7 @@ class AdminProductServiceTest {
 
 	@BeforeEach
 	void tearDown() {
+		orderProductRepository.deleteAll();
 		productRepository.deleteAll();
 		categoryRepository.deleteAll();
 	}

--- a/src/test/java/com/kt/service/admin/AdminProductServiceTest.java
+++ b/src/test/java/com/kt/service/admin/AdminProductServiceTest.java
@@ -1,0 +1,355 @@
+package com.kt.service.admin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.kt.constant.ProductStatus;
+import com.kt.constant.UserRole;
+import com.kt.constant.searchtype.ProductSearchType;
+import com.kt.domain.dto.request.ProductRequest;
+import com.kt.domain.dto.response.ProductResponse;
+import com.kt.domain.entity.CategoryEntity;
+import com.kt.domain.entity.ProductEntity;
+import com.kt.repository.CategoryRepository;
+import com.kt.repository.product.ProductRepository;
+import com.kt.service.ProductService;
+
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class AdminProductServiceTest {
+
+	private final AdminProductService adminProductService;
+
+	private final ProductRepository productRepository;
+
+	private final CategoryRepository categoryRepository;
+
+	@Autowired
+	AdminProductServiceTest(AdminProductService adminProductService, ProductRepository productRepository,
+		CategoryRepository categoryRepository) {
+		this.adminProductService = adminProductService;
+		this.productRepository = productRepository;
+		this.categoryRepository = categoryRepository;
+	}
+
+	@BeforeEach
+	void tearDown() {
+		productRepository.deleteAll();
+		categoryRepository.deleteAll();
+	}
+
+	@Test
+	void 상품_생성() {
+		// given
+		CategoryEntity category = CategoryEntity.create("카테고리", null);
+		categoryRepository.save(category);
+
+		String productName = "상품1";
+		long productPrice = 1000L;
+		ProductRequest.Create request = new ProductRequest.Create(
+			productName,
+			productPrice,
+			10L
+		);
+
+		// when
+		adminProductService.create(request.name(), request.price(), request.stock(), category.getId());
+
+		// then
+		ProductEntity product = productRepository.findAll()
+			.stream()
+			.filter(it -> it.getName().equals(productName))
+			.findFirst()
+			.orElseThrow();
+
+		assertThat(product.getPrice()).isEqualTo(productPrice);
+	}
+
+	@Test
+	void 삼품_수정() {
+		// given
+		CategoryEntity category = CategoryEntity.create("카테고리", null);
+		categoryRepository.save(category);
+
+		CategoryEntity categorySports = CategoryEntity.create("책", null);
+		categoryRepository.save(categorySports);
+
+		ProductEntity product = ProductEntity.create(
+			"상품1",
+			1000L,
+			10L,
+			category
+		);
+
+		productRepository.save(product);
+
+		// when
+		ProductRequest.Update request = new ProductRequest.Update(
+			"수정된상품명",
+			2000L,
+			20L,
+			categorySports.getId()
+		);
+
+		adminProductService.update(
+			product.getId(),
+			request.name(),
+			request.price(),
+			request.stock(),
+			request.categoryId()
+		);
+
+		// then
+		ProductEntity savedProduct = productRepository.findByIdOrThrow(product.getId());
+		assertThat(savedProduct.getName()).isEqualTo(request.name());
+		assertThat(savedProduct.getCategory().getId()).isEqualTo(categorySports.getId());
+	}
+
+	@Test
+	void 상품_삭제() {
+		// given
+		CategoryEntity category = CategoryEntity.create("카테고리", null);
+		categoryRepository.save(category);
+
+		ProductEntity product = ProductEntity.create(
+			"상품1",
+			1000L,
+			10L,
+			category
+		);
+		productRepository.save(product);
+
+		// when
+		adminProductService.delete(product.getId());
+
+		// then
+		ProductEntity savedProduct = productRepository.findByIdOrThrow(product.getId());
+		assertThat(savedProduct.getStatus()).isEqualTo(ProductStatus.DELETED);
+	}
+
+	@Test
+	void 상품_목록_조회() {
+		// given
+		CategoryEntity category = CategoryEntity.create("카테고리", null);
+		categoryRepository.save(category);
+
+		List<ProductEntity> products = new ArrayList<>();
+		for (int i = 0; i < 20; i++) {
+			ProductEntity product = ProductEntity.create(
+				"상품" + i,
+				1000L,
+				10L,
+				category
+			);
+			products.add(product);
+		}
+		productRepository.saveAll(products);
+
+		// when
+		PageRequest pageRequest = PageRequest.of(1, 10);
+		Page<ProductResponse.Search> search = adminProductService.search(UserRole.ADMIN, null, null, pageRequest);
+
+		// then
+		assertThat(search.getTotalElements()).isEqualTo(20);
+		assertThat(search.getTotalPages()).isEqualTo(2);
+		assertThat(search.getContent().size()).isEqualTo(10);
+	}
+
+	@Test
+	void 상품_목록_조회__검색_카테고리명() {
+		// given
+		CategoryEntity categoryDog = CategoryEntity.create("강아지", null);
+		categoryRepository.save(categoryDog);
+		CategoryEntity categorySports = CategoryEntity.create("운동", null);
+		categoryRepository.save(categorySports);
+
+		List<ProductEntity> products = new ArrayList<>();
+		for (int i = 0; i < 10; i++) {
+			ProductEntity product = ProductEntity.create(
+				"상품" + i,
+				1000L,
+				10L,
+				categoryDog
+			);
+			products.add(product);
+		}
+
+		for (int i = 10; i < 15; i++) {
+			ProductEntity product = ProductEntity.create(
+				"상품" + i,
+				1000L,
+				10L,
+				categorySports
+			);
+			products.add(product);
+		}
+		productRepository.saveAll(products);
+
+		// when
+		PageRequest pageRequest = PageRequest.of(0, 5);
+		Page<ProductResponse.Search> search = adminProductService.search(
+			UserRole.ADMIN,
+			"운동",
+			ProductSearchType.CATEGORY,
+			pageRequest
+		);
+
+		// then
+		assertThat(search.getTotalElements()).isEqualTo(5);
+		assertThat(search.getTotalPages()).isEqualTo(1);
+		assertThat(search.getContent().size()).isEqualTo(5);
+	}
+
+	@Test
+	void 상품_목록_조회__검색_상품명() {
+		// given
+		CategoryEntity categorySports = CategoryEntity.create("운동", null);
+		categoryRepository.save(categorySports);
+		List<ProductEntity> products = new ArrayList<>();
+		for (int i = 0; i < 10; i++) {
+			ProductEntity product = ProductEntity.create(
+				"상품" + i,
+				1000L,
+				10L,
+				categorySports
+			);
+			productRepository.save(product);
+		}
+
+		// when
+		PageRequest pageRequest = PageRequest.of(0, 5);
+		Page<ProductResponse.Search> search = adminProductService.search(
+			UserRole.ADMIN,
+			"5",
+			ProductSearchType.NAME,
+			pageRequest
+		);
+
+		// then
+		assertThat(search.getTotalElements()).isEqualTo(1);
+		assertThat(search.getTotalPages()).isEqualTo(1);
+		assertThat(search.getContent().size()).isEqualTo(1);
+	}
+
+	@Test
+	void 상품_상세_조회() {
+		// given
+		CategoryEntity categorySports = CategoryEntity.create("운동", null);
+		categoryRepository.save(categorySports);
+		ProductEntity product = ProductEntity.create("상품", 1000L, 10L, categorySports);
+		productRepository.save(product);
+
+		// when
+		ProductResponse.Detail detail = adminProductService.detail(UserRole.ADMIN, product.getId());
+
+		// then
+		assertThat(detail.name()).isEqualTo("상품");
+		assertThat(detail.categoryId()).isEqualTo(categorySports.getId());
+	}
+
+	@Test
+	void 상품_활성화() {
+		// given
+		CategoryEntity categorySports = CategoryEntity.create("운동", null);
+		categoryRepository.save(categorySports);
+		ProductEntity product = ProductEntity.create("상품", 1000L, 10L, categorySports);
+		productRepository.save(product);
+
+		// when
+		adminProductService.activate(product.getId());
+
+		// then
+		ProductEntity savedProduct = productRepository.findByIdOrThrow(product.getId());
+		assertThat(savedProduct.getStatus()).isEqualTo(ProductStatus.ACTIVATED);
+	}
+
+	@Test
+	void 상품_비활성화() {
+		// given
+		CategoryEntity categorySports = CategoryEntity.create("운동", null);
+		categoryRepository.save(categorySports);
+		ProductEntity product = ProductEntity.create("상품", 1000L, 10L, categorySports);
+		productRepository.save(product);
+
+		// when
+		adminProductService.inActivate(product.getId());
+
+		// then
+		ProductEntity savedProduct = productRepository.findByIdOrThrow(product.getId());
+		assertThat(savedProduct.getStatus()).isEqualTo(ProductStatus.IN_ACTIVATED);
+	}
+
+	@Test
+	void 상품_품절_토글__비활성화에서_활성화() {
+		// given
+		CategoryEntity categorySports = CategoryEntity.create("운동", null);
+		categoryRepository.save(categorySports);
+		ProductEntity product = ProductEntity.create("상품", 1000L, 10L, categorySports);
+		productRepository.save(product);
+		adminProductService.inActivate(product.getId());
+
+		// when
+		adminProductService.toggleActive(product.getId());
+
+		// then
+		ProductEntity savedProduct = productRepository.findByIdOrThrow(product.getId());
+		assertThat(savedProduct.getStatus()).isEqualTo(ProductStatus.ACTIVATED);
+	}
+
+	@Test
+	void 상품_품절_토글__활성화에서_비활성화() {
+		// given
+		CategoryEntity categorySports = CategoryEntity.create("운동", null);
+		categoryRepository.save(categorySports);
+		ProductEntity product = ProductEntity.create("상품", 1000L, 10L, categorySports);
+		productRepository.save(product);
+		adminProductService.activate(product.getId());
+
+		// when
+		adminProductService.toggleActive(product.getId());
+
+		// then
+		ProductEntity savedProduct = productRepository.findByIdOrThrow(product.getId());
+		assertThat(savedProduct.getStatus()).isEqualTo(ProductStatus.IN_ACTIVATED);
+	}
+
+	@Test
+	void 상품_다중_품절() {
+		// when
+		CategoryEntity categorySports = CategoryEntity.create("운동", null);
+		categoryRepository.save(categorySports);
+		List<ProductEntity> products = new ArrayList<>();
+		for (int i = 0; i < 5; i++) {
+			ProductEntity product = ProductEntity.create(
+				"상품" + i,
+				1000L,
+				10L,
+				categorySports
+			);
+			products.add(product);
+		}
+		productRepository.saveAll(products);
+
+		// when
+		adminProductService.soldOutProducts(
+			products.stream().map(ProductEntity::getId).toList()
+		);
+
+		// then
+		assertThat(
+			productRepository.findAll()
+				.stream()
+				.allMatch(it -> it.getStatus() == ProductStatus.IN_ACTIVATED)
+		).isTrue();
+	}
+}

--- a/src/test/java/com/kt/service/admin/AdminReviewServiceTest.java
+++ b/src/test/java/com/kt/service/admin/AdminReviewServiceTest.java
@@ -1,0 +1,121 @@
+package com.kt.service.admin;
+
+import static com.kt.common.CategoryEntityCreator.*;
+import static com.kt.common.OrderEntityCreator.*;
+import static com.kt.common.OrderProductCreator.*;
+import static com.kt.common.ProductCreator.*;
+import static com.kt.common.UserEntityCreator.*;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kt.constant.ReviewStatus;
+import com.kt.domain.dto.response.ReviewResponse;
+import com.kt.domain.entity.CategoryEntity;
+import com.kt.domain.entity.OrderEntity;
+import com.kt.domain.entity.OrderProductEntity;
+import com.kt.domain.entity.ProductEntity;
+import com.kt.domain.entity.ReviewEntity;
+import com.kt.domain.entity.UserEntity;
+import com.kt.repository.CategoryRepository;
+import com.kt.repository.OrderRepository;
+import com.kt.repository.orderproduct.OrderProductRepository;
+import com.kt.repository.product.ProductRepository;
+import com.kt.repository.review.ReviewRepository;
+import com.kt.repository.user.UserRepository;
+
+@Transactional
+@SpringBootTest
+@ActiveProfiles("test")
+class AdminReviewServiceTest {
+
+	@Autowired
+	AdminReviewService adminReviewService;
+
+	@Autowired
+	ReviewRepository reviewRepository;
+	@Autowired
+	OrderProductRepository orderProductRepository;
+	@Autowired
+	ProductRepository productRepository;
+	@Autowired
+	UserRepository userRepository;
+	@Autowired
+	OrderRepository orderRepository;
+	@Autowired
+	CategoryRepository categoryRepository;
+
+	OrderProductEntity testOrderProduct;
+	UserEntity testUser;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		testUser = createMember();
+		userRepository.save(testUser);
+
+		CategoryEntity category = createCategory();
+		categoryRepository.save(category);
+
+		OrderEntity order = createOrderEntity(testUser);
+		orderRepository.save(order);
+
+		ProductEntity product = createProduct(category);
+		productRepository.save(product);
+
+		testOrderProduct = createOrderProduct(order, product);
+		orderProductRepository.save(testOrderProduct);
+
+		order.getOrderProducts().add(testOrderProduct);
+	}
+
+	@Test
+	void 리뷰삭제_성공_어드민() {
+		// given
+		ReviewEntity review = ReviewEntity.create("테스트리뷰내용");
+		review.mapToOrderProduct(testOrderProduct);
+		reviewRepository.save(review);
+
+		// when
+		adminReviewService.delete(testUser.getEmail(), review.getId());
+
+		// then
+		Assertions.assertEquals(ReviewStatus.REMOVED, review.getStatus());
+	}
+
+	@Test
+	void 리뷰조회_성공_어드민() {
+		ReviewEntity review = ReviewEntity.create("테스트리뷰내용");
+		review.mapToOrderProduct(testOrderProduct);
+		reviewRepository.save(review);
+
+		ReviewResponse.Search savedReviewDto = adminReviewService.getReview(testOrderProduct.getId());
+
+		Assertions.assertEquals(review.getId(), savedReviewDto.reviewId());
+	}
+
+	@Test
+	void 상품리뷰조회_성공_어드민() {
+		ReviewEntity review = ReviewEntity.create("테스트리뷰내용");
+		review.mapToOrderProduct(testOrderProduct);
+		reviewRepository.save(review);
+
+		PageRequest pageRequest = PageRequest.of(0, 10);
+		Page<ReviewResponse.Search> savedPage = adminReviewService.getReviewsByAdmin(pageRequest, null, null);
+
+		ReviewResponse.Search savedReviewResponse = savedPage
+			.stream()
+			.findFirst()
+			.orElse(null);
+
+		Assertions.assertNotNull(savedReviewResponse);
+		Assertions.assertEquals(review.getId(), savedReviewResponse.reviewId());
+	}
+
+}

--- a/src/test/java/com/kt/service/admin/AdminUserServiceImplTest.java
+++ b/src/test/java/com/kt/service/admin/AdminUserServiceImplTest.java
@@ -1,0 +1,331 @@
+package com.kt.service.admin;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kt.common.UserEntityCreator;
+import com.kt.constant.Gender;
+import com.kt.constant.OrderProductStatus;
+import com.kt.constant.OrderStatus;
+import com.kt.constant.UserRole;
+import com.kt.constant.UserStatus;
+import com.kt.constant.message.ErrorCode;
+import com.kt.domain.dto.request.SignupRequest;
+import com.kt.domain.dto.request.UserRequest;
+import com.kt.domain.dto.response.OrderProductResponse;
+import com.kt.domain.dto.response.UserResponse;
+import com.kt.domain.entity.CategoryEntity;
+import com.kt.domain.entity.OrderEntity;
+import com.kt.domain.entity.OrderProductEntity;
+import com.kt.domain.entity.ProductEntity;
+import com.kt.domain.entity.ReceiverVO;
+import com.kt.domain.entity.ReviewEntity;
+import com.kt.domain.entity.UserEntity;
+import com.kt.exception.CustomException;
+import com.kt.repository.CategoryRepository;
+import com.kt.repository.OrderRepository;
+import com.kt.repository.orderproduct.OrderProductRepository;
+import com.kt.repository.product.ProductRepository;
+import com.kt.repository.review.ReviewRepository;
+import com.kt.repository.user.UserRepository;
+import com.kt.service.UserService;
+
+@Transactional
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class AdminUserServiceImplTest {
+
+	@Autowired
+	AdminUserService adminUserService;
+	@Autowired
+	UserRepository userRepository;
+	@Autowired
+	OrderRepository orderRepository;
+	@Autowired
+	OrderProductRepository orderProductRepository;
+	@Autowired
+	ReviewRepository reviewRepository;
+	@Autowired
+	ProductRepository productRepository;
+	@Autowired
+	CategoryRepository categoryRepository;
+
+	UserEntity testUser;
+	UserEntity testUser2;
+	UserEntity testAdmin;
+	OrderEntity testOrder;
+	ProductEntity testProduct;
+	OrderProductEntity testOrderProduct;
+	UUID userId;
+	UUID AdminId;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		reviewRepository.deleteAll();
+		orderProductRepository.deleteAll();
+		orderRepository.deleteAll();
+		userRepository.deleteAll();
+		productRepository.deleteAll();
+		categoryRepository.deleteAll();
+
+		testUser = UserEntity.create(
+			"주문자테스터1",
+			"wjd123@naver.com",
+			"1234",
+			UserRole.MEMBER,
+			Gender.MALE,
+			LocalDate.of(1990, 1, 1),
+			"010-1234-5678"
+		);
+
+		testUser2 = UserEntity.create(
+			"주문자테스터2",
+			"dohyun@naver.com",
+			"1234",
+			UserRole.MEMBER,
+			Gender.MALE,
+			LocalDate.of(1990, 1, 1),
+			"010-1234-5678"
+		);
+
+		testAdmin = UserEntity.create(
+			"어드민테스터",
+			"dohyun@naver.com",
+			"1234",
+			UserRole.ADMIN,
+			Gender.MALE,
+			LocalDate.of(1990, 1, 1),
+			"010-1234-5678"
+		);
+
+		userRepository.save(testUser);
+		UserEntity savedUser = userRepository.save(testUser2);
+		UserEntity savedAdmin = userRepository.save(testAdmin);
+		userId = savedUser.getId();
+		AdminId = savedAdmin.getId();
+
+		ReceiverVO receiver = new ReceiverVO(
+			"수신자테스터1",
+			"010-1234-5678",
+			"강원도",
+			"원주시",
+			"행구로",
+			"주소설명"
+		);
+
+		testOrder = OrderEntity.create(
+			receiver,
+			testUser
+		);
+		orderRepository.save(testOrder);
+
+		CategoryEntity category = CategoryEntity.create("카테고리", null);
+		categoryRepository.save(category);
+
+		testProduct = ProductEntity.create(
+			"테스트상품명",
+			1000L,
+			5L,
+			category
+		);
+		productRepository.save(testProduct);
+
+		testOrderProduct = new OrderProductEntity(
+			5L,
+			5000L,
+			OrderProductStatus.CREATED,
+			testOrder,
+			testProduct
+		);
+		orderProductRepository.save(testOrderProduct);
+	}
+
+	@Test
+	void 내_주문_조회() {
+		UserEntity user = UserEntity.create(
+			"김도현",
+			"ddd",
+			"111",
+			UserRole.MEMBER,
+			Gender.MALE,
+			LocalDate.now(),
+			"0101010"
+		);
+
+		UserEntity savedUser = userRepository.save(user);
+
+		userId = savedUser.getId();
+
+		CategoryEntity category = CategoryEntity.create("카테고리", null);
+		categoryRepository.save(category);
+
+		ProductEntity product = ProductEntity.create(
+			"테스트물건",
+			3L,
+			3L,
+			category
+		);
+
+		ProductEntity savedProduct = productRepository.save(product);
+
+		OrderEntity order = OrderEntity.create(
+			ReceiverVO.create("이름", "번호", "도시", "시군구", "동", "상세"),
+			savedUser
+		);
+		orderRepository.save(order);
+		// when
+		UserResponse.Orders foundOrder = adminUserService.getOrdersByUserId(userId, userId);
+
+		// then
+		assertThat(foundOrder).isNotNull();
+		assertThat(foundOrder.userId()).isEqualTo(userId);
+		assertThat(foundOrder.orders()).isNotEmpty();
+	}
+
+	@Test
+	void 유저_리스트_조회() {
+
+		// when
+		Page<UserResponse.Search> result = adminUserService.getUsers(testAdmin.getId(), Pageable.ofSize(10), "테스터",
+			UserRole.MEMBER);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.getContent()).hasSize(2);
+	}
+
+	@Test
+	void 어드민_리스트_조회() {
+
+		// when
+		Page<UserResponse.Search> result = adminUserService.getUsers(testAdmin.getId(), Pageable.ofSize(10), "어드민",
+			UserRole.ADMIN);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.getContent()).hasSize(1);
+	}
+
+	@Test
+	void 유저_상세_본인조회() {
+		UserResponse.UserDetail savedUser = adminUserService.getUserDetail(userId, userId);
+
+		// then
+		assertThat(userId).isNotNull();
+		assertThat(savedUser.name()).isEqualTo("주문자테스터2");
+	}
+
+	@Test
+	void 유저_상세_조회__실패_다른사람조회() {
+		assertThatThrownBy(
+			() -> adminUserService.getUserDetail(userId, AdminId)
+		)
+			.isInstanceOf(CustomException.class)
+			.hasMessageContaining(ErrorCode.ACCOUNT_ACCESS_NOT_ALLOWED.name());
+	}
+
+	@Test
+	void 유저_상태_변경_disabled() {
+		// when
+		adminUserService.disableUser(testAdmin.getId(), testUser.getId());
+		UserEntity foundedUser = userRepository.findById(testUser.getId()).orElseThrow();
+
+		// then
+		assertThat(foundedUser).isNotNull();
+		assertThat(foundedUser.getStatus()).isEqualTo(UserStatus.DISABLED);
+	}
+
+	@Test
+	void 유저_상태_변경__실패_어드민아님() {
+		// then
+		assertThatThrownBy(
+			() -> adminUserService.disableUser(testUser2.getId(), testUser.getId())
+		)
+			.isInstanceOf(CustomException.class)
+			.hasMessageContaining(ErrorCode.ACCOUNT_ACCESS_NOT_ALLOWED.name());
+	}
+
+	@Test
+	void 유저_상태_변경_enabled() {
+
+		// when
+		adminUserService.disableUser(testAdmin.getId(), testUser.getId());
+		adminUserService.enableUser(testAdmin.getId(), testUser.getId());
+		UserEntity foundedUser = userRepository.findById(testUser.getId()).orElseThrow();
+
+		// then
+		assertThat(foundedUser).isNotNull();
+		assertThat(foundedUser.getStatus()).isEqualTo(UserStatus.ENABLED);
+
+	}
+
+	@Test
+	void 유저_상태_변경_retired() {
+
+		// when
+		adminUserService.retireUser(testAdmin.getId(), testUser.getId());
+		UserEntity foundedUser = userRepository.findById(testUser.getId()).orElseThrow();
+		// then
+		assertThat(foundedUser).isNotNull();
+		assertThat(foundedUser.getStatus()).isEqualTo(UserStatus.RETIRED);
+
+	}
+
+	@Test
+	void 유저_상태_변경_delete() {
+		// when
+		adminUserService.deleteUser(testUser.getId(), testUser.getId());
+		UserEntity foundedUser = userRepository.findById(testUser.getId()).orElseThrow();
+		// then
+		assertThat(foundedUser).isNotNull();
+		assertThat(foundedUser.getStatus()).isEqualTo(UserStatus.DELETED);
+	}
+
+	@Test
+	@Transactional(propagation = Propagation.NOT_SUPPORTED)
+	void 유저_하드_딜리트_성공() {
+		// given
+		UserEntity user = UserEntity.create(
+			"삭제",
+			"aaa",
+			"1234",
+			UserRole.MEMBER,
+			Gender.MALE,
+			LocalDate.of(1111, 1, 1),
+			"111"
+		);
+		UserEntity savedUser = userRepository.save(user);
+
+		OrderEntity order = OrderEntity.create(
+			ReceiverVO.create("이름", "번호", "도시", "시군구", "동", "상세"),
+			savedUser
+		);
+		OrderEntity savedOrder = orderRepository.save(order);
+
+		// when
+		adminUserService.deleteUserPermanently(testAdmin.getId(), savedUser.getId());
+
+		// then
+		assertThat(userRepository.existsById(savedUser.getId())).isFalse();
+		OrderEntity foundOrder = orderRepository.findById(savedOrder.getId()).orElse(null);
+		assertThat(foundOrder).isNotNull();
+	}
+
+}

--- a/src/test/java/com/kt/service/admin/AdminUserServiceTest.java
+++ b/src/test/java/com/kt/service/admin/AdminUserServiceTest.java
@@ -286,35 +286,35 @@ class AdminUserServiceTest {
 		assertThat(foundedUser).isNotNull();
 		assertThat(foundedUser.getStatus()).isEqualTo(UserStatus.DELETED);
 	}
-	//
-	// @Test
-	// @Transactional(propagation = Propagation.NOT_SUPPORTED)
-	// void 유저_하드_딜리트_성공() {
-	// 	// given
-	// 	UserEntity user = UserEntity.create(
-	// 		"삭제",
-	// 		"aaa",
-	// 		"1234",
-	// 		UserRole.MEMBER,
-	// 		Gender.MALE,
-	// 		LocalDate.of(1111, 1, 1),
-	// 		"111"
-	// 	);
-	// 	UserEntity savedUser = userRepository.save(user);
-	//
-	// 	OrderEntity order = OrderEntity.create(
-	// 		ReceiverVO.create("이름", "번호", "도시", "시군구", "동", "상세"),
-	// 		savedUser
-	// 	);
-	// 	OrderEntity savedOrder = orderRepository.save(order);
-	//
-	// 	// when
-	// 	adminUserService.deleteUserPermanently(testAdmin.getId(), savedUser.getId());
-	//
-	// 	// then
-	// 	assertThat(userRepository.existsById(savedUser.getId())).isFalse();
-	// 	OrderEntity foundOrder = orderRepository.findById(savedOrder.getId()).orElse(null);
-	// 	assertThat(foundOrder).isNotNull();
-	// }
+
+	@Test
+	@Transactional(propagation = Propagation.NOT_SUPPORTED)
+	void 유저_하드_딜리트_성공() {
+		// given
+		UserEntity user = UserEntity.create(
+			"삭제",
+			"aaa",
+			"1234",
+			UserRole.MEMBER,
+			Gender.MALE,
+			LocalDate.of(1111, 1, 1),
+			"111"
+		);
+		UserEntity savedUser = userRepository.save(user);
+
+		OrderEntity order = OrderEntity.create(
+			ReceiverVO.create("이름", "번호", "도시", "시군구", "동", "상세"),
+			savedUser
+		);
+		OrderEntity savedOrder = orderRepository.save(order);
+
+		// when
+		adminUserService.deleteUserPermanently(testAdmin.getId(), savedUser.getId());
+
+		// then
+		assertThat(userRepository.existsById(savedUser.getId())).isFalse();
+		OrderEntity foundOrder = orderRepository.findById(savedOrder.getId()).orElse(null);
+		assertThat(foundOrder).isNotNull();
+	}
 
 }

--- a/src/test/java/com/kt/service/admin/AdminUserServiceTest.java
+++ b/src/test/java/com/kt/service/admin/AdminUserServiceTest.java
@@ -1,42 +1,32 @@
 package com.kt.service.admin;
 
-import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.LocalDate;
 import java.util.UUID;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.kt.common.UserEntityCreator;
 import com.kt.constant.Gender;
 import com.kt.constant.OrderProductStatus;
-import com.kt.constant.OrderStatus;
 import com.kt.constant.UserRole;
 import com.kt.constant.UserStatus;
 import com.kt.constant.message.ErrorCode;
-import com.kt.domain.dto.request.SignupRequest;
-import com.kt.domain.dto.request.UserRequest;
-import com.kt.domain.dto.response.OrderProductResponse;
 import com.kt.domain.dto.response.UserResponse;
 import com.kt.domain.entity.CategoryEntity;
 import com.kt.domain.entity.OrderEntity;
 import com.kt.domain.entity.OrderProductEntity;
 import com.kt.domain.entity.ProductEntity;
 import com.kt.domain.entity.ReceiverVO;
-import com.kt.domain.entity.ReviewEntity;
 import com.kt.domain.entity.UserEntity;
 import com.kt.exception.CustomException;
 import com.kt.repository.CategoryRepository;
@@ -45,12 +35,11 @@ import com.kt.repository.orderproduct.OrderProductRepository;
 import com.kt.repository.product.ProductRepository;
 import com.kt.repository.review.ReviewRepository;
 import com.kt.repository.user.UserRepository;
-import com.kt.service.UserService;
 
 @Transactional
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
-class AdminUserServiceImplTest {
+class AdminUserServiceTest {
 
 	@Autowired
 	AdminUserService adminUserService;
@@ -297,35 +286,35 @@ class AdminUserServiceImplTest {
 		assertThat(foundedUser).isNotNull();
 		assertThat(foundedUser.getStatus()).isEqualTo(UserStatus.DELETED);
 	}
-
-	@Test
-	@Transactional(propagation = Propagation.NOT_SUPPORTED)
-	void 유저_하드_딜리트_성공() {
-		// given
-		UserEntity user = UserEntity.create(
-			"삭제",
-			"aaa",
-			"1234",
-			UserRole.MEMBER,
-			Gender.MALE,
-			LocalDate.of(1111, 1, 1),
-			"111"
-		);
-		UserEntity savedUser = userRepository.save(user);
-
-		OrderEntity order = OrderEntity.create(
-			ReceiverVO.create("이름", "번호", "도시", "시군구", "동", "상세"),
-			savedUser
-		);
-		OrderEntity savedOrder = orderRepository.save(order);
-
-		// when
-		adminUserService.deleteUserPermanently(testAdmin.getId(), savedUser.getId());
-
-		// then
-		assertThat(userRepository.existsById(savedUser.getId())).isFalse();
-		OrderEntity foundOrder = orderRepository.findById(savedOrder.getId()).orElse(null);
-		assertThat(foundOrder).isNotNull();
-	}
+	//
+	// @Test
+	// @Transactional(propagation = Propagation.NOT_SUPPORTED)
+	// void 유저_하드_딜리트_성공() {
+	// 	// given
+	// 	UserEntity user = UserEntity.create(
+	// 		"삭제",
+	// 		"aaa",
+	// 		"1234",
+	// 		UserRole.MEMBER,
+	// 		Gender.MALE,
+	// 		LocalDate.of(1111, 1, 1),
+	// 		"111"
+	// 	);
+	// 	UserEntity savedUser = userRepository.save(user);
+	//
+	// 	OrderEntity order = OrderEntity.create(
+	// 		ReceiverVO.create("이름", "번호", "도시", "시군구", "동", "상세"),
+	// 		savedUser
+	// 	);
+	// 	OrderEntity savedOrder = orderRepository.save(order);
+	//
+	// 	// when
+	// 	adminUserService.deleteUserPermanently(testAdmin.getId(), savedUser.getId());
+	//
+	// 	// then
+	// 	assertThat(userRepository.existsById(savedUser.getId())).isFalse();
+	// 	OrderEntity foundOrder = orderRepository.findById(savedOrder.getId()).orElse(null);
+	// 	assertThat(foundOrder).isNotNull();
+	// }
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- resolves: #이슈번호, #이슈번호 -->
resolves: #178 

## 📝작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

서비스 파일을 행위자 단위로 분리합니다.

완전하게 분리를 하면 중복 코드가 많아지긴 하는 단점이 있지만,
Admin이라는 엔드포인트를 타고 들어오는 요청들이 일반 Service 권한 검증이 한번 더 필요할까? 라는 관점에서 봐서
컨트롤러와 서비스를 1대1매칭하면 좋을 것 같습니다.
따라서 분리하면 권한 검증 시 본인만 체크가 가능해져서 명확해지고 서비스 파일의 책임이 명확해지리라 예상합니다.

기존 파일 내 메서드들은 우선 삭제하지 않고 유지했습니다.
차후 작업하면서 삭제 해주시면 좋을 것 같아요.

양이 워낙 많아서 저도 놓친 것들이 있을 수도 있는데 같이 확인해주시면 감사하겠습니다.
또한 저희 서비스 메서드는 존재하는데 api는 없는게 몇가지 있더라구요 저도 계속 체크해보겠습니다

기존 서비스 파일들 패키지구조도 serivce/user/UserCategoryService 등등으로 묶어가도 좋을 것 같아요!
컨플릭 때문에 이 작업은 진행하지 않았습니다.

**Service 내 지워야하는 메서드 목록**
CategoryService
- create
- update
- delete

AccountService
- searchAccounts
- deletAccountPermanently
- resetAccountPassword
- updateAccountPassword
- searchPasswordRequests
* getPendingPasswordRequest
- static getRandomPassword

CourierService
- getDetailForAmdin
- updateDetail
- verifyAccess

OrderService
- updateOrderStatus

ProductService
- create
- update
- delete
- activate
- inActivate
- soldOuProducts
- toggle

Reveiw
- getReviewsByAdmin


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->