### PR TITLE
[FIX] 어드민 테스트 유저와 동기화

### DIFF
--- a/src/test/java/com/kt/service/admin/AdminAdminServiceTest.java
+++ b/src/test/java/com/kt/service/admin/AdminAdminServiceTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.time.LocalDate;
 import java.util.UUID;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -39,7 +40,7 @@ import com.kt.repository.review.ReviewRepository;
 import com.kt.repository.user.UserRepository;
 
 @Transactional
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest
 @ActiveProfiles("test")
 class AdminAdminServiceTest {
 
@@ -67,15 +68,18 @@ class AdminAdminServiceTest {
 	UUID userId;
 	UUID AdminId;
 
-	@BeforeEach
-	void setUp() throws Exception {
+	@AfterEach
+	void clearUp() {
 		reviewRepository.deleteAll();
 		orderProductRepository.deleteAll();
 		orderRepository.deleteAll();
 		userRepository.deleteAll();
 		productRepository.deleteAll();
 		categoryRepository.deleteAll();
+	}
 
+	@BeforeEach
+	void setUp() throws Exception {
 		testUser = UserEntity.create(
 			"주문자테스터1",
 			"wjd123@naver.com",

--- a/src/test/java/com/kt/service/admin/AdminCategoryServiceTest.java
+++ b/src/test/java/com/kt/service/admin/AdminCategoryServiceTest.java
@@ -20,7 +20,7 @@ import com.kt.exception.CustomException;
 import com.kt.repository.CategoryRepository;
 import com.kt.repository.product.ProductRepository;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest
 @ActiveProfiles("test")
 @Transactional
 class AdminCategoryServiceTest {

--- a/src/test/java/com/kt/service/admin/AdminCourierServiceTest.java
+++ b/src/test/java/com/kt/service/admin/AdminCourierServiceTest.java
@@ -40,7 +40,6 @@ class AdminCourierServiceTest {
 
 	@BeforeEach
 	void setUp() throws Exception {
-		courierRepository.deleteAll();
 		testCourier = CourierEntityCreator.createCourierEntity();
 		courierRepository.save(testCourier);
 		testAdmin = UserEntityCreator.createAdmin();

--- a/src/test/java/com/kt/service/admin/AdminOrderServiceTest.java
+++ b/src/test/java/com/kt/service/admin/AdminOrderServiceTest.java
@@ -38,7 +38,7 @@ import com.kt.repository.user.UserRepository;
 
 @Transactional
 @ActiveProfiles("test")
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest
 class AdminOrderServiceTest {
 
 	@Autowired
@@ -62,14 +62,6 @@ class AdminOrderServiceTest {
 
 	@BeforeEach
 	void setup() {
-		reviewRepository.deleteAll();
-		orderProductRepository.deleteAll();
-		orderRepository.deleteAll();
-		productRepository.deleteAll();
-		userRepository.deleteAll();
-		categoryRepository.deleteAll();
-		addressRepository.deleteAll();
-
 		category = categoryRepository.save(CategoryEntityCreator.createCategory());
 	}
 

--- a/src/test/java/com/kt/service/admin/AdminProductServiceTest.java
+++ b/src/test/java/com/kt/service/admin/AdminProductServiceTest.java
@@ -28,7 +28,7 @@ import com.kt.repository.product.ProductRepository;
 import com.kt.service.ProductService;
 
 @ActiveProfiles("test")
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest
 @Transactional
 class AdminProductServiceTest {
 
@@ -47,13 +47,6 @@ class AdminProductServiceTest {
 		this.adminProductService = adminProductService;
 		this.productRepository = productRepository;
 		this.categoryRepository = categoryRepository;
-	}
-
-	@BeforeEach
-	void tearDown() {
-		orderProductRepository.deleteAll();
-		productRepository.deleteAll();
-		categoryRepository.deleteAll();
 	}
 
 	@Test

--- a/src/test/java/com/kt/service/admin/AdminUserServiceTest.java
+++ b/src/test/java/com/kt/service/admin/AdminUserServiceTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.time.LocalDate;
 import java.util.UUID;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,7 +38,7 @@ import com.kt.repository.review.ReviewRepository;
 import com.kt.repository.user.UserRepository;
 
 @Transactional
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest
 @ActiveProfiles("test")
 class AdminUserServiceTest {
 
@@ -65,15 +66,18 @@ class AdminUserServiceTest {
 	UUID userId;
 	UUID AdminId;
 
-	@BeforeEach
-	void setUp() throws Exception {
+	@AfterEach
+	void clearUp() {
 		reviewRepository.deleteAll();
 		orderProductRepository.deleteAll();
 		orderRepository.deleteAll();
 		userRepository.deleteAll();
 		productRepository.deleteAll();
 		categoryRepository.deleteAll();
+	}
 
+	@BeforeEach
+	void setUp() throws Exception {
 		testUser = UserEntity.create(
 			"주문자테스터1",
 			"wjd123@naver.com",


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- resolves: #이슈번호, #이슈번호 -->
resolves:

## 📝작업 내용

어드민 단 테스트 유저와 동기화 했습니다!
현재 브랜치 기준 전체 테스트 이상없이 작동합니다.

- deleteAll() 로직 AfterEach로 이동
- SpringBootTest RANDOM_PORT 제거

<img width="1208" height="663" alt="image" src="https://github.com/user-attachments/assets/c5262a72-40f0-41d2-8d3e-e711d650cdc0" />


<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->