### PR TITLE
[FEAT] Seller 엔티티 생성 #179

### DIFF
--- a/src/main/java/com/kt/constant/AccountRole.java
+++ b/src/main/java/com/kt/constant/AccountRole.java
@@ -7,7 +7,8 @@ public enum AccountRole {
 
 	ADMIN("관리자"),
 	MEMBER("회원"),
-	COURIER("기사");
+	COURIER("기사"),
+	SELLER("판매자");
 
 	private final String description;
 

--- a/src/main/java/com/kt/constant/message/ErrorCode.java
+++ b/src/main/java/com/kt/constant/message/ErrorCode.java
@@ -53,7 +53,7 @@ public enum ErrorCode {
 	COURIER_NOT_FOUND(HttpStatus.NOT_FOUND, "배송기사가 존재하지 않습니다."),
 	ORDER_ACCESS_NOT_ALLOWED(HttpStatus.FORBIDDEN, "주문에 대한 접근 권한이 없습니다."),
 	NOT_ADMIN(HttpStatus.BAD_REQUEST, "관리자 계정이 아닙니다."),
-	SELLER_NOT_FOUND(HttpStatus.NOT_FOUND, "판매가자 존재하지 않습니다."),
+	SELLER_NOT_FOUND(HttpStatus.NOT_FOUND, "판매자가 존재하지 않습니다."),
 	;
 
 	private final HttpStatus status;

--- a/src/main/java/com/kt/constant/message/ErrorCode.java
+++ b/src/main/java/com/kt/constant/message/ErrorCode.java
@@ -50,9 +50,11 @@ public enum ErrorCode {
 	REVIEW_ACCESS_NOT_ALLOWED(HttpStatus.FORBIDDEN, "리뷰에 대한 접근 권한이 없습니다."),
 	REVIEW_ALREADY_EXISTS(HttpStatus.CONFLICT, "해당 주문상품에 대한 리뷰가 이미 존재합니다."),
 	ACCOUNT_ACCESS_NOT_ALLOWED(HttpStatus.FORBIDDEN, "계정에 대한 접근 권한이 없습니다."),
-	Courier_NOT_FOUND(HttpStatus.NOT_FOUND, "배송기사가 존재하지 않습니다."),
+	COURIER_NOT_FOUND(HttpStatus.NOT_FOUND, "배송기사가 존재하지 않습니다."),
 	ORDER_ACCESS_NOT_ALLOWED(HttpStatus.FORBIDDEN, "주문에 대한 접근 권한이 없습니다."),
-	NOT_ADMIN(HttpStatus.BAD_REQUEST, "관리자 계정이 아닙니다.");
+	NOT_ADMIN(HttpStatus.BAD_REQUEST, "관리자 계정이 아닙니다."),
+	SELLER_NOT_FOUND(HttpStatus.NOT_FOUND, "판매가자 존재하지 않습니다."),
+	;
 
 	private final HttpStatus status;
 	private final String message;

--- a/src/main/java/com/kt/controller/admin/management/AdminManagementController.java
+++ b/src/main/java/com/kt/controller/admin/management/AdminManagementController.java
@@ -38,7 +38,7 @@ import static com.kt.common.api.ApiResult.*;
 @RestController
 @RequestMapping("/api/admin")
 @RequiredArgsConstructor
-public class AdminManagementManagementController implements AdminManagementSwaggerSupporter {
+public class AdminManagementController implements AdminManagementSwaggerSupporter {
 
 	private final AdminManagementService adminManagementService;
 	private final AccountService accountService;

--- a/src/main/java/com/kt/controller/admin/management/AdminManagementManagementController.java
+++ b/src/main/java/com/kt/controller/admin/management/AdminManagementManagementController.java
@@ -1,4 +1,4 @@
-package com.kt.controller.admin;
+package com.kt.controller.admin.management;
 
 import java.util.UUID;
 
@@ -28,8 +28,7 @@ import com.kt.domain.dto.request.UserRequest;
 import com.kt.domain.dto.response.UserResponse;
 import com.kt.security.DefaultCurrentUser;
 import com.kt.service.AccountService;
-import com.kt.service.UserService;
-import com.kt.service.admin.AdminAdminService;
+import com.kt.service.admin.AdminManagementService;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -39,9 +38,9 @@ import static com.kt.common.api.ApiResult.*;
 @RestController
 @RequestMapping("/api/admin")
 @RequiredArgsConstructor
-public class AdminController implements AdminSwaggerSupporter {
+public class AdminManagementManagementController implements AdminManagementSwaggerSupporter {
 
-	private final AdminAdminService adminAdminService;
+	private final AdminManagementService adminManagementService;
 	private final AccountService accountService;
 
 	@Override
@@ -65,7 +64,7 @@ public class AdminController implements AdminSwaggerSupporter {
 		@PathVariable UUID adminId
 	) {
 		return wrap(
-			adminAdminService.getAdminDetail(currentUser.getId(), adminId)
+			adminManagementService.getAdminDetail(currentUser.getId(), adminId)
 		);
 	}
 
@@ -73,9 +72,9 @@ public class AdminController implements AdminSwaggerSupporter {
 	@PostMapping
 	public ResponseEntity<ApiResult<Void>> createAdmin(
 		@AuthenticationPrincipal DefaultCurrentUser currentUser,
- 		@RequestBody @Valid SignupRequest.SignupUser request
+		@RequestBody @Valid SignupRequest.SignupUser request
 	) {
-		adminAdminService.createAdmin(currentUser.getId(), request);
+		adminManagementService.createAdmin(currentUser.getId(), request);
 		return empty();
 	}
 
@@ -86,7 +85,7 @@ public class AdminController implements AdminSwaggerSupporter {
 		@RequestBody @Valid UserRequest.UpdateDetails request,
 		@PathVariable UUID adminId
 	) {
-		adminAdminService.updateDetail(currentUser.getId(), adminId, request);
+		adminManagementService.updateDetail(currentUser.getId(), adminId, request);
 		return empty();
 	}
 
@@ -96,7 +95,7 @@ public class AdminController implements AdminSwaggerSupporter {
 		@AuthenticationPrincipal DefaultCurrentUser defaultCurrentUser,
 		@PathVariable UUID adminId
 	) {
-		adminAdminService.deleteAdmin(defaultCurrentUser.getId(), adminId);
+		adminManagementService.deleteAdmin(defaultCurrentUser.getId(), adminId);
 		return empty();
 	}
 

--- a/src/main/java/com/kt/controller/admin/management/AdminManagementSwaggerSupporter.java
+++ b/src/main/java/com/kt/controller/admin/management/AdminManagementSwaggerSupporter.java
@@ -1,10 +1,9 @@
-package com.kt.controller.admin;
+package com.kt.controller.admin.management;
 
 import java.util.UUID;
 
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -25,7 +24,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 
 @Tag(name = "Admin", description = "관리자 관리 관련 API")
-public interface AdminSwaggerSupporter {
+public interface AdminManagementSwaggerSupporter {
 	@Operation(
 		summary = "관리자 검색", description = "관리자를 검색"
 	)

--- a/src/main/java/com/kt/controller/admin/product/AdminProductController.java
+++ b/src/main/java/com/kt/controller/admin/product/AdminProductController.java
@@ -24,7 +24,6 @@ import com.kt.constant.searchtype.ProductSearchType;
 import com.kt.domain.dto.request.AdminProductRequest;
 import com.kt.domain.dto.response.ProductResponse;
 import com.kt.security.CurrentUser;
-import com.kt.service.ProductService;
 import com.kt.service.admin.AdminProductService;
 
 import jakarta.validation.Valid;
@@ -45,7 +44,8 @@ public class AdminProductController implements AdminProductSwaggerSupporter {
 			request.name(),
 			request.price(),
 			request.stock(),
-			request.categoryId()
+			request.categoryId(),
+			request.sellerId()
 		);
 		return empty();
 	}

--- a/src/main/java/com/kt/domain/dto/request/AdminProductRequest.java
+++ b/src/main/java/com/kt/domain/dto/request/AdminProductRequest.java
@@ -27,7 +27,9 @@ public class AdminProductRequest {
 		@NotNull(message = "상품 재고는 필수 항목입니다.")
 		Long stock,
 		@NotNull(message = "카테고리 ID는 필수 항목입니다.")
-		UUID categoryId
+		UUID categoryId,
+		@NotNull(message = "판매자 ID는 필수 항목입니다.")
+		UUID sellerId
 	) {
 	}
 

--- a/src/main/java/com/kt/domain/dto/request/OrderRequest.java
+++ b/src/main/java/com/kt/domain/dto/request/OrderRequest.java
@@ -25,7 +25,10 @@ public record OrderRequest(
 
 		@NotNull
 		@Min(1)
-		Long quantity
+		Long quantity,
+
+		@NotNull
+		UUID sellerId
 	) {
 	}
 

--- a/src/main/java/com/kt/domain/dto/request/ProductRequest.java
+++ b/src/main/java/com/kt/domain/dto/request/ProductRequest.java
@@ -16,7 +16,11 @@ public class ProductRequest {
 		Long price,
 		@NotNull(message = "상품 재고는 필수 항목입니다.")
 		@Positive(message = "상품 재고는 0보다 작을 수 없습니다.")
-		Long stock
+		Long stock,
+		@NotNull(message = "카테고리 ID는 필수 항목입니다.")
+		UUID categoryId,
+		@NotNull(message = "판매자 ID는 필수 항목입니다.")
+		UUID sellerId
 	) {
 	}
 

--- a/src/main/java/com/kt/domain/entity/BankAccountEntity.java
+++ b/src/main/java/com/kt/domain/entity/BankAccountEntity.java
@@ -26,19 +26,19 @@ public class BankAccountEntity extends BaseEntity {
 
 	@OneToOne(fetch = FetchType.LAZY)
 	@JoinColumn(
-		name = "user_id",
+		name = "account_id",
 		nullable = false,
 		unique = true
 	)
-	private UserEntity user;
+	private AbstractAccountEntity account;
 
-	protected BankAccountEntity(UserEntity user) {
+	protected BankAccountEntity(AbstractAccountEntity account) {
 		this.balance = 0L;
-		this.user = user;
+		this.account = account;
 	}
 
-	public static BankAccountEntity create(final UserEntity user) {
-		return new BankAccountEntity(user);
+	public static BankAccountEntity create(final AbstractAccountEntity account) {
+		return new BankAccountEntity(account);
 	}
 
 }

--- a/src/main/java/com/kt/domain/entity/OrderProductEntity.java
+++ b/src/main/java/com/kt/domain/entity/OrderProductEntity.java
@@ -29,19 +29,14 @@ public class OrderProductEntity extends BaseEntity {
 	@JoinColumn(name = "product_id", nullable = false)
 	private ProductEntity product;
 
-	@ManyToOne
-	@JoinColumn(name = "seller_id", nullable = false)
-	private SellerEntity seller;
-
 	public static OrderProductEntity create(
 		Long quantity,
 		Long unitPrice,
 		OrderProductStatus status,
 		OrderEntity order,
-		ProductEntity product,
-		SellerEntity seller
+		ProductEntity product
 	) {
-		return new OrderProductEntity(quantity, unitPrice, status, order, product, seller);
+		return new OrderProductEntity(quantity, unitPrice, status, order, product);
 	}
 
 	public void updateStatus(OrderProductStatus newStatus) {

--- a/src/main/java/com/kt/domain/entity/OrderProductEntity.java
+++ b/src/main/java/com/kt/domain/entity/OrderProductEntity.java
@@ -29,14 +29,19 @@ public class OrderProductEntity extends BaseEntity {
 	@JoinColumn(name = "product_id", nullable = false)
 	private ProductEntity product;
 
+	@ManyToOne
+	@JoinColumn(name = "seller_id", nullable = false)
+	private SellerEntity seller;
+
 	public static OrderProductEntity create(
 		Long quantity,
 		Long unitPrice,
 		OrderProductStatus status,
 		OrderEntity order,
-		ProductEntity product
+		ProductEntity product,
+		SellerEntity seller
 	) {
-		return new OrderProductEntity(quantity, unitPrice, status, order, product);
+		return new OrderProductEntity(quantity, unitPrice, status, order, product, seller);
 	}
 
 	public void updateStatus(OrderProductStatus newStatus) {

--- a/src/main/java/com/kt/domain/entity/ProductEntity.java
+++ b/src/main/java/com/kt/domain/entity/ProductEntity.java
@@ -2,6 +2,8 @@ package com.kt.domain.entity;
 
 import static lombok.AccessLevel.*;
 
+import java.util.UUID;
+
 import com.kt.constant.ProductStatus;
 import com.kt.domain.entity.common.BaseEntity;
 
@@ -11,6 +13,7 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -36,32 +39,40 @@ public class ProductEntity extends BaseEntity {
 	@JoinColumn(name = "category_id", nullable = false)
 	private CategoryEntity category;
 
+	@ManyToOne
+	@JoinColumn(name = "seller_id", nullable = false)
+	private SellerEntity seller;
+
 	protected ProductEntity(
 		String name,
 		Long price,
 		Long stock,
 		ProductStatus status,
-		CategoryEntity category
+		CategoryEntity category,
+		SellerEntity seller
 	) {
 		this.name = name;
 		this.price = price;
 		this.stock = stock;
 		this.status = status;
 		this.category = category;
+		this.seller = seller;
 	}
 
 	public static ProductEntity create(
 		final String name,
 		final Long price,
 		final Long stock,
-		final CategoryEntity category
+		final CategoryEntity category,
+		final SellerEntity seller
 	) {
 		return new ProductEntity(
 			name,
 			price,
 			stock,
 			ProductStatus.ACTIVATED,
-			category
+			category,
+			seller
 		);
 	}
 
@@ -70,14 +81,16 @@ public class ProductEntity extends BaseEntity {
 		final Long price,
 		final Long stock,
 		final ProductStatus status,
-		final CategoryEntity category
+		final CategoryEntity category,
+		final SellerEntity seller
 	) {
 		return new ProductEntity(
 			name,
 			price,
 			stock,
 			status,
-			category
+			category,
+			seller
 		);
 	}
 
@@ -110,7 +123,6 @@ public class ProductEntity extends BaseEntity {
 			activate();
 		}
 	}
-
 
 	public void addStock(Long quantity) {
 		this.stock += quantity;

--- a/src/main/java/com/kt/domain/entity/SellerEntity.java
+++ b/src/main/java/com/kt/domain/entity/SellerEntity.java
@@ -1,14 +1,17 @@
 package com.kt.domain.entity;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.OneToOne;
 import jakarta.validation.constraints.Email;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import com.kt.constant.Gender;
-import com.kt.constant.UserRole;
+import com.kt.constant.AccountRole;
 import com.kt.constant.UserStatus;
 
 @Entity
@@ -26,6 +29,17 @@ public class SellerEntity extends AbstractAccountEntity {
 	@Email
 	private String contactEmail;
 
+	@OneToOne(
+		mappedBy = "account",
+		cascade = {
+			CascadeType.PERSIST,
+			CascadeType.REMOVE
+		},
+		orphanRemoval = true,
+		fetch = FetchType.LAZY
+	)
+	private BankAccountEntity bankAccount;
+
 	// TODO: 사업자등록번호, 결제용 판매자 계좌번호, 예금주 등
 
 	protected SellerEntity(String name, String email, String password, String storeName, String contactMobile,
@@ -36,9 +50,10 @@ public class SellerEntity extends AbstractAccountEntity {
 		this.storeName = storeName;
 		this.contactMobile = contactMobile;
 		this.contactEmail = contactEmail;
-		this.role = UserRole.SELLER;
+		this.role = AccountRole.SELLER;
 		this.status = UserStatus.ENABLED;
 		this.gender = gender;
+		this.bankAccount = BankAccountEntity.create(this);
 	}
 
 	public static SellerEntity create(String name, String email, String password, String storeName, String contactMobile,

--- a/src/main/java/com/kt/domain/entity/SellerEntity.java
+++ b/src/main/java/com/kt/domain/entity/SellerEntity.java
@@ -1,0 +1,48 @@
+package com.kt.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.validation.constraints.Email;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import com.kt.constant.Gender;
+import com.kt.constant.UserRole;
+import com.kt.constant.UserStatus;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class SellerEntity extends AbstractAccountEntity {
+
+	@Column(nullable = false)
+	private String storeName;
+
+	@Column(nullable = false)
+	private String contactMobile;
+
+	@Column(nullable = false)
+	@Email
+	private String contactEmail;
+
+	// TODO: 사업자등록번호, 결제용 판매자 계좌번호, 예금주 등
+
+	protected SellerEntity(String name, String email, String password, String storeName, String contactMobile,
+		String contactEmail, Gender gender) {
+		this.name = name;
+		this.email = email;
+		this.password = password;
+		this.storeName = storeName;
+		this.contactMobile = contactMobile;
+		this.contactEmail = contactEmail;
+		this.role = UserRole.SELLER;
+		this.status = UserStatus.ENABLED;
+		this.gender = gender;
+	}
+
+	public static SellerEntity create(String name, String email, String password, String storeName, String contactMobile,
+		String contactEmail, Gender gender) {
+		return new SellerEntity(name, email, password, storeName, contactMobile, contactEmail, gender);
+	}
+}

--- a/src/main/java/com/kt/domain/entity/UserEntity.java
+++ b/src/main/java/com/kt/domain/entity/UserEntity.java
@@ -45,9 +45,8 @@ public class UserEntity extends AbstractAccountEntity {
 	)
 	private PayEntity pay;
 
-
 	@OneToOne(
-		mappedBy = "user",
+		mappedBy = "account",
 		cascade = {
 			CascadeType.PERSIST,
 			CascadeType.REMOVE
@@ -97,14 +96,16 @@ public class UserEntity extends AbstractAccountEntity {
 		);
 	}
 
-	public void delete(){ this.status = UserStatus.DELETED; }
+	public void delete() {
+		this.status = UserStatus.DELETED;
+	}
 
 	public void updateDetails(
 		String name,
 		String mobile,
 		LocalDate birth,
 		Gender gender
-	){
+	) {
 		this.name = name;
 		this.mobile = mobile;
 		this.birth = birth;

--- a/src/main/java/com/kt/infra/mail/EmailClient.java
+++ b/src/main/java/com/kt/infra/mail/EmailClient.java
@@ -51,13 +51,13 @@ public class EmailClient {
 					case MailTemplate.UPDATE_PASSWORD -> content = "<div> 변경된 비밀번호 : " + velue + "</div>";
 				}
 			}
-			String sender = ((JavaMailSenderImpl) mailSender).getUsername();
+			String sender = ((JavaMailSenderImpl)mailSender).getUsername();
 			helper.setFrom(sender);
 			helper.setTo(email);
 			helper.setSubject(template.getSubject());
 			helper.setText(content, true);
-			mailSender.send(message);
-		} catch(MessagingException exception) {
+			// mailSender.send(message);
+		} catch (MessagingException exception) {
 			throw new CustomException(ErrorCode.EMAIL_SEND_FAILED);
 		}
 

--- a/src/main/java/com/kt/infra/mail/EmailClient.java
+++ b/src/main/java/com/kt/infra/mail/EmailClient.java
@@ -56,7 +56,7 @@ public class EmailClient {
 			helper.setTo(email);
 			helper.setSubject(template.getSubject());
 			helper.setText(content, true);
-			// mailSender.send(message);
+			mailSender.send(message);
 		} catch (MessagingException exception) {
 			throw new CustomException(ErrorCode.EMAIL_SEND_FAILED);
 		}

--- a/src/main/java/com/kt/repository/courier/CourierRepository.java
+++ b/src/main/java/com/kt/repository/courier/CourierRepository.java
@@ -21,7 +21,7 @@ public interface CourierRepository extends JpaRepository<CourierEntity, UUID>, C
 	}
 
 	default CourierEntity findByIdOrThrow(UUID courierId) {
-		return findById(courierId).orElseThrow(() -> new CustomException(ErrorCode.Courier_NOT_FOUND));
+		return findById(courierId).orElseThrow(() -> new CustomException(ErrorCode.COURIER_NOT_FOUND));
 	}
 
 }

--- a/src/main/java/com/kt/repository/seller/SellerRepository.java
+++ b/src/main/java/com/kt/repository/seller/SellerRepository.java
@@ -1,0 +1,17 @@
+package com.kt.repository.seller;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.kt.constant.message.ErrorCode;
+import com.kt.domain.entity.SellerEntity;
+import com.kt.exception.CustomException;
+
+public interface SellerRepository extends JpaRepository<SellerEntity, UUID> {
+	default SellerEntity findByIdOrThrow(UUID id) {
+		return findById(id).orElseThrow(
+			() -> new CustomException(ErrorCode.SELLER_NOT_FOUND)
+		);
+	}
+}

--- a/src/main/java/com/kt/service/OrderServiceImpl.java
+++ b/src/main/java/com/kt/service/OrderServiceImpl.java
@@ -102,7 +102,7 @@ public class OrderServiceImpl implements OrderService {
 
 			product.decreaseStock(quantity);
 
-			OrderProductEntity orderProduct = new OrderProductEntity(
+			OrderProductEntity orderProduct = OrderProductEntity.create(
 				quantity,
 				product.getPrice(),
 				OrderProductStatus.CREATED,
@@ -114,7 +114,7 @@ public class OrderServiceImpl implements OrderService {
 			order.addOrderProduct(orderProduct);
 			orderProductRepository.save(orderProduct);
 		}
-	  return order;
+		return order;
 
 	}
 

--- a/src/main/java/com/kt/service/OrderServiceImpl.java
+++ b/src/main/java/com/kt/service/OrderServiceImpl.java
@@ -96,13 +96,7 @@ public class OrderServiceImpl implements OrderService {
 			ProductEntity product = productRepository.findByIdOrThrow(productId);
 			SellerEntity seller = sellerRepository.findByIdOrThrow(sellerId);
 
-			if (product.getStock() < quantity) {
-				throw new CustomException(ErrorCode.STOCK_NOT_ENOUGH);
-			}
-
-			product.decreaseStock(quantity);
-
-			OrderProductEntity orderProduct = OrderProductEntity.create(
+			OrderProductEntity orderProduct = new OrderProductEntity(
 				quantity,
 				product.getPrice(),
 				OrderProductStatus.CREATED,
@@ -115,7 +109,6 @@ public class OrderServiceImpl implements OrderService {
 			orderProductRepository.save(orderProduct);
 		}
 		return order;
-
 	}
 
 	@Transactional

--- a/src/main/java/com/kt/service/OrderServiceImpl.java
+++ b/src/main/java/com/kt/service/OrderServiceImpl.java
@@ -20,7 +20,6 @@ import com.kt.domain.entity.OrderEntity;
 import com.kt.domain.entity.OrderProductEntity;
 import com.kt.domain.entity.ProductEntity;
 import com.kt.domain.entity.ReceiverVO;
-import com.kt.domain.entity.SellerEntity;
 import com.kt.domain.entity.ShippingDetailEntity;
 import com.kt.domain.entity.UserEntity;
 import com.kt.exception.CustomException;
@@ -94,15 +93,13 @@ public class OrderServiceImpl implements OrderService {
 			UUID sellerId = item.sellerId();
 
 			ProductEntity product = productRepository.findByIdOrThrow(productId);
-			SellerEntity seller = sellerRepository.findByIdOrThrow(sellerId);
 
 			OrderProductEntity orderProduct = new OrderProductEntity(
 				quantity,
 				product.getPrice(),
 				OrderProductStatus.CREATED,
 				order,
-				product,
-				seller
+				product
 			);
 
 			order.addOrderProduct(orderProduct);

--- a/src/main/java/com/kt/service/OrderServiceImpl.java
+++ b/src/main/java/com/kt/service/OrderServiceImpl.java
@@ -27,9 +27,9 @@ import com.kt.exception.CustomException;
 import com.kt.repository.AddressRepository;
 import com.kt.repository.order.OrderRepository;
 import com.kt.repository.ShippingDetailRepository;
-import com.kt.repository.account.AccountRepository;
 import com.kt.repository.orderproduct.OrderProductRepository;
 import com.kt.repository.product.ProductRepository;
+import com.kt.repository.seller.SellerRepository;
 import com.kt.repository.user.UserRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -45,7 +45,7 @@ public class OrderServiceImpl implements OrderService {
 	private final OrderProductRepository orderProductRepository;
 	private final ShippingDetailRepository shippingDetailRepository;
 	private final AddressRepository addressRepository;
-	private final AccountRepository accountRepository;
+	private final SellerRepository sellerRepository;
 
 	@Override
 	public OrderResponse.OrderProducts getOrderProducts(UUID orderId) {
@@ -94,7 +94,7 @@ public class OrderServiceImpl implements OrderService {
 			UUID sellerId = item.sellerId();
 
 			ProductEntity product = productRepository.findByIdOrThrow(productId);
-			SellerEntity seller = (SellerEntity)accountRepository.findByIdOrThrow(sellerId);
+			SellerEntity seller = sellerRepository.findByIdOrThrow(sellerId);
 
 			if (product.getStock() < quantity) {
 				throw new CustomException(ErrorCode.STOCK_NOT_ENOUGH);

--- a/src/main/java/com/kt/service/ProductService.java
+++ b/src/main/java/com/kt/service/ProductService.java
@@ -13,7 +13,7 @@ import com.kt.domain.dto.response.ProductResponse;
 
 public interface ProductService {
 
-	void create(String name, Long price, Long stock, UUID categoryId);
+	void create(String name, Long price, Long stock, UUID categoryId, UUID sellerId);
 
 	void update(UUID productId, String name, Long price, Long stock, UUID categoryId);
 

--- a/src/main/java/com/kt/service/ProductServiceImpl.java
+++ b/src/main/java/com/kt/service/ProductServiceImpl.java
@@ -15,14 +15,14 @@ import com.kt.constant.searchtype.ProductSearchType;
 import com.kt.domain.dto.response.ProductResponse;
 import com.kt.domain.entity.CategoryEntity;
 import com.kt.domain.entity.ProductEntity;
+import com.kt.domain.entity.SellerEntity;
 import com.kt.exception.CustomException;
 import com.kt.repository.CategoryRepository;
 import com.kt.repository.product.ProductRepository;
 
 import lombok.RequiredArgsConstructor;
 
-import com.kt.domain.entity.SellerEntity;
-import com.kt.repository.account.AccountRepository;
+import com.kt.repository.seller.SellerRepository;
 
 @Service
 @RequiredArgsConstructor
@@ -31,7 +31,7 @@ public class ProductServiceImpl implements ProductService {
 
 	private final ProductRepository productRepository;
 	private final CategoryRepository categoryRepository;
-	private final AccountRepository accountRepository;
+	private final SellerRepository sellerRepository;
 
 	@Override
 	public void create(
@@ -44,7 +44,7 @@ public class ProductServiceImpl implements ProductService {
 		CategoryEntity category = categoryRepository.findById(categoryId).orElseThrow(
 			() -> new CustomException(ErrorCode.CATEGORY_NOT_FOUND)
 		);
-		SellerEntity seller = (SellerEntity) accountRepository.findByIdOrThrow(sellerId);
+		SellerEntity seller = sellerRepository.findByIdOrThrow(sellerId);
 		ProductEntity product = ProductEntity.create(name, price, stock, category, seller);
 		productRepository.save(product);
 	}

--- a/src/main/java/com/kt/service/ProductServiceImpl.java
+++ b/src/main/java/com/kt/service/ProductServiceImpl.java
@@ -21,6 +21,9 @@ import com.kt.repository.product.ProductRepository;
 
 import lombok.RequiredArgsConstructor;
 
+import com.kt.domain.entity.SellerEntity;
+import com.kt.repository.account.AccountRepository;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -28,18 +31,21 @@ public class ProductServiceImpl implements ProductService {
 
 	private final ProductRepository productRepository;
 	private final CategoryRepository categoryRepository;
+	private final AccountRepository accountRepository;
 
 	@Override
 	public void create(
 		String name,
 		Long price,
 		Long stock,
-		UUID categoryId
+		UUID categoryId,
+		UUID sellerId
 	) {
 		CategoryEntity category = categoryRepository.findById(categoryId).orElseThrow(
 			() -> new CustomException(ErrorCode.CATEGORY_NOT_FOUND)
 		);
-		ProductEntity product = ProductEntity.create(name, price, stock, category);
+		SellerEntity seller = (SellerEntity) accountRepository.findByIdOrThrow(sellerId);
+		ProductEntity product = ProductEntity.create(name, price, stock, category, seller);
 		productRepository.save(product);
 	}
 

--- a/src/main/java/com/kt/service/admin/AdminManagementService.java
+++ b/src/main/java/com/kt/service/admin/AdminManagementService.java
@@ -6,7 +6,7 @@ import com.kt.domain.dto.request.SignupRequest;
 import com.kt.domain.dto.request.UserRequest;
 import com.kt.domain.dto.response.UserResponse;
 
-public interface AdminAdminService {
+public interface AdminManagementService {
 	void createAdmin(UUID userId, SignupRequest.SignupUser request);
 
 	void deleteAdmin(UUID currentId, UUID adminId);

--- a/src/main/java/com/kt/service/admin/AdminManagementServiceImpl.java
+++ b/src/main/java/com/kt/service/admin/AdminManagementServiceImpl.java
@@ -21,7 +21,7 @@ import lombok.RequiredArgsConstructor;
 @Service
 @Transactional
 @RequiredArgsConstructor
-public class AdminAdminServiceImpl implements AdminAdminService {
+public class AdminManagementServiceImpl implements AdminManagementService {
 
 	private final UserRepository userRepository;
 	private final PasswordEncoder passwordEncoder;

--- a/src/main/java/com/kt/service/admin/AdminProductService.java
+++ b/src/main/java/com/kt/service/admin/AdminProductService.java
@@ -12,7 +12,7 @@ import com.kt.domain.dto.response.ProductResponse;
 
 public interface AdminProductService {
 
-	void create(String name, Long price, Long stock, UUID categoryId);
+	void create(String name, Long price, Long stock, UUID categoryId, UUID sellerId);
 
 	void update(UUID productId, String name, Long price, Long stock, UUID categoryId);
 

--- a/src/main/java/com/kt/service/admin/AdminProductServiceImpl.java
+++ b/src/main/java/com/kt/service/admin/AdminProductServiceImpl.java
@@ -21,6 +21,9 @@ import com.kt.repository.product.ProductRepository;
 
 import lombok.RequiredArgsConstructor;
 
+import com.kt.domain.entity.SellerEntity;
+import com.kt.repository.account.AccountRepository;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -28,6 +31,7 @@ public class AdminProductServiceImpl implements AdminProductService {
 
 	private final ProductRepository productRepository;
 	private final CategoryRepository categoryRepository;
+	private final AccountRepository accountRepository;
 
 	// TODO: seller로 이전
 	@Override
@@ -35,12 +39,14 @@ public class AdminProductServiceImpl implements AdminProductService {
 		String name,
 		Long price,
 		Long stock,
-		UUID categoryId
+		UUID categoryId,
+		UUID sellerId
 	) {
 		CategoryEntity category = categoryRepository.findById(categoryId).orElseThrow(
 			() -> new CustomException(ErrorCode.CATEGORY_NOT_FOUND)
 		);
-		ProductEntity product = ProductEntity.create(name, price, stock, category);
+		SellerEntity seller = (SellerEntity)accountRepository.findByIdOrThrow(sellerId);
+		ProductEntity product = ProductEntity.create(name, price, stock, category, seller);
 		productRepository.save(product);
 	}
 

--- a/src/main/java/com/kt/service/admin/AdminProductServiceImpl.java
+++ b/src/main/java/com/kt/service/admin/AdminProductServiceImpl.java
@@ -23,6 +23,7 @@ import lombok.RequiredArgsConstructor;
 
 import com.kt.domain.entity.SellerEntity;
 import com.kt.repository.account.AccountRepository;
+import com.kt.repository.seller.SellerRepository;
 
 @Service
 @RequiredArgsConstructor
@@ -31,7 +32,7 @@ public class AdminProductServiceImpl implements AdminProductService {
 
 	private final ProductRepository productRepository;
 	private final CategoryRepository categoryRepository;
-	private final AccountRepository accountRepository;
+	private final SellerRepository sellerRepository;
 
 	// TODO: seller로 이전
 	@Override
@@ -45,7 +46,7 @@ public class AdminProductServiceImpl implements AdminProductService {
 		CategoryEntity category = categoryRepository.findById(categoryId).orElseThrow(
 			() -> new CustomException(ErrorCode.CATEGORY_NOT_FOUND)
 		);
-		SellerEntity seller = (SellerEntity)accountRepository.findByIdOrThrow(sellerId);
+		SellerEntity seller = sellerRepository.findByIdOrThrow(sellerId);
 		ProductEntity product = ProductEntity.create(name, price, stock, category, seller);
 		productRepository.save(product);
 	}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,7 +11,7 @@ spring:
     password: ${SPRING_DATASOURCE_PASSWORD}
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create-drop
     properties:
       hibernate:
         format_sql: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,7 +11,7 @@ spring:
     password: ${SPRING_DATASOURCE_PASSWORD}
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true

--- a/src/test/java/com/kt/api/admin/order/OrderCancelTest.java
+++ b/src/test/java/com/kt/api/admin/order/OrderCancelTest.java
@@ -87,8 +87,7 @@ public class OrderCancelTest extends MockMvcTest {
 				product.getPrice(),
 				OrderProductStatus.SHIPPING_READY,
 				order,
-				product,
-				seller
+				product
 			)
 		);
 		// when & then

--- a/src/test/java/com/kt/api/admin/order/OrderCancelTest.java
+++ b/src/test/java/com/kt/api/admin/order/OrderCancelTest.java
@@ -18,6 +18,7 @@ import com.kt.common.CategoryEntityCreator;
 import com.kt.common.MockMvcTest;
 import com.kt.common.OrderEntityCreator;
 import com.kt.common.ProductEntityCreator;
+import com.kt.common.SellerEntityCreator;
 import com.kt.common.UserEntityCreator;
 import com.kt.constant.OrderProductStatus;
 import com.kt.constant.AccountRole;
@@ -25,11 +26,13 @@ import com.kt.domain.entity.CategoryEntity;
 import com.kt.domain.entity.OrderEntity;
 import com.kt.domain.entity.OrderProductEntity;
 import com.kt.domain.entity.ProductEntity;
+import com.kt.domain.entity.SellerEntity;
 import com.kt.domain.entity.UserEntity;
 import com.kt.repository.CategoryRepository;
 import com.kt.repository.order.OrderRepository;
 import com.kt.repository.orderproduct.OrderProductRepository;
 import com.kt.repository.product.ProductRepository;
+import com.kt.repository.seller.SellerRepository;
 import com.kt.repository.user.UserRepository;
 import com.kt.security.DefaultCurrentUser;
 
@@ -38,6 +41,7 @@ public class OrderCancelTest extends MockMvcTest {
 
 	OrderEntity savedOrder;
 	UserEntity savedUser;
+	SellerEntity savedSeller;
 	DefaultCurrentUser userDetails = new DefaultCurrentUser(
 		UUID.randomUUID(),
 		"test@example.com",
@@ -54,6 +58,8 @@ public class OrderCancelTest extends MockMvcTest {
 	private OrderProductRepository orderProductRepository;
 	@Autowired
 	private CategoryRepository categoryRepository;
+	@Autowired
+	private SellerRepository sellerRepository;
 
 	@Test
 	void 주문상품_취소__성공_200() throws Exception {
@@ -64,12 +70,15 @@ public class OrderCancelTest extends MockMvcTest {
 		OrderEntity order = OrderEntityCreator.createOrderEntity(savedUser);
 		savedOrder = orderRepository.save(order);
 
+		SellerEntity seller = SellerEntityCreator.createSeller();
+		savedSeller = sellerRepository.save(seller);
+
 		CategoryEntity category = categoryRepository.save(
 			CategoryEntityCreator.createCategory()
 		);
 
 		ProductEntity product = productRepository.save(
-			ProductEntityCreator.createProduct(category)
+			ProductEntityCreator.createProduct(category, seller)
 		);
 
 		OrderProductEntity orderProduct = orderProductRepository.save(
@@ -78,7 +87,8 @@ public class OrderCancelTest extends MockMvcTest {
 				product.getPrice(),
 				OrderProductStatus.SHIPPING_READY,
 				order,
-				product
+				product,
+				seller
 			)
 		);
 		// when & then

--- a/src/test/java/com/kt/api/admin/product/ProductActivateTest.java
+++ b/src/test/java/com/kt/api/admin/product/ProductActivateTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import com.kt.common.SellerEntityCreator;
 import com.kt.domain.entity.SellerEntity;
-import com.kt.repository.account.AccountRepository;
+import com.kt.repository.seller.SellerRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.web.servlet.ResultActions;
@@ -36,7 +36,7 @@ public class ProductActivateTest extends MockMvcTest {
 	@Autowired
 	ProductRepository productRepository;
 	@Autowired
-	AccountRepository accountRepository;
+	SellerRepository sellerRepository;
 
 	CategoryEntity testCategory;
 	SellerEntity testSeller;
@@ -55,7 +55,7 @@ public class ProductActivateTest extends MockMvcTest {
 		categoryRepository.save(testCategory);
 
 		testSeller = SellerEntityCreator.createSeller();
-		accountRepository.save(testSeller);
+		sellerRepository.save(testSeller);
 
 		testProduct = createProduct(testCategory, testSeller);
 		testProduct.inActivate();

--- a/src/test/java/com/kt/api/admin/product/ProductActivateTest.java
+++ b/src/test/java/com/kt/api/admin/product/ProductActivateTest.java
@@ -11,6 +11,9 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import com.kt.common.SellerEntityCreator;
+import com.kt.domain.entity.SellerEntity;
+import com.kt.repository.account.AccountRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.web.servlet.ResultActions;
@@ -32,8 +35,11 @@ public class ProductActivateTest extends MockMvcTest {
 
 	@Autowired
 	ProductRepository productRepository;
+	@Autowired
+	AccountRepository accountRepository;
 
 	CategoryEntity testCategory;
+	SellerEntity testSeller;
 
 	DefaultCurrentUser userDetails = new DefaultCurrentUser(
 		UUID.randomUUID(),
@@ -48,7 +54,10 @@ public class ProductActivateTest extends MockMvcTest {
 		testCategory = createCategory();
 		categoryRepository.save(testCategory);
 
-		testProduct = createProduct(testCategory);
+		testSeller = SellerEntityCreator.createSeller();
+		accountRepository.save(testSeller);
+
+		testProduct = createProduct(testCategory, testSeller);
 		testProduct.inActivate();
 		productRepository.save(testProduct);
 	}

--- a/src/test/java/com/kt/api/admin/product/ProductCreateTest.java
+++ b/src/test/java/com/kt/api/admin/product/ProductCreateTest.java
@@ -24,7 +24,7 @@ import com.kt.domain.dto.request.AdminProductRequest;
 import com.kt.domain.entity.CategoryEntity;
 import com.kt.domain.entity.SellerEntity;
 import com.kt.repository.CategoryRepository;
-import com.kt.repository.account.AccountRepository;
+import com.kt.repository.seller.SellerRepository;
 import com.kt.security.DefaultCurrentUser;
 
 @DisplayName("상품 생성 (어드민) - POST /api/admin/products")
@@ -42,14 +42,14 @@ class ProductCreateTest extends MockMvcTest {
 		AccountRole.ADMIN
 	);
 	@Autowired
-	private AccountRepository accountRepository;
+	SellerRepository sellerRepository;
 
 	@BeforeEach
 	void setUp() {
 		testCategory = createCategory();
 		categoryRepository.save(testCategory);
 		testSeller = createSeller();
-		accountRepository.save(testSeller);
+		sellerRepository.save(testSeller);
 	}
 
 	@ParameterizedTest

--- a/src/test/java/com/kt/api/admin/product/ProductCreateTest.java
+++ b/src/test/java/com/kt/api/admin/product/ProductCreateTest.java
@@ -1,6 +1,7 @@
 package com.kt.api.admin.product;
 
 import static com.kt.common.CategoryEntityCreator.*;
+import static com.kt.common.SellerEntityCreator.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -21,7 +22,9 @@ import com.kt.common.MockMvcTest;
 import com.kt.constant.AccountRole;
 import com.kt.domain.dto.request.AdminProductRequest;
 import com.kt.domain.entity.CategoryEntity;
+import com.kt.domain.entity.SellerEntity;
 import com.kt.repository.CategoryRepository;
+import com.kt.repository.account.AccountRepository;
 import com.kt.security.DefaultCurrentUser;
 
 @DisplayName("상품 생성 (어드민) - POST /api/admin/products")
@@ -31,17 +34,22 @@ class ProductCreateTest extends MockMvcTest {
 	CategoryRepository categoryRepository;
 
 	CategoryEntity testCategory;
+	SellerEntity testSeller;
 
 	DefaultCurrentUser userDetails = new DefaultCurrentUser(
 		UUID.randomUUID(),
 		"test@test.com",
 		AccountRole.ADMIN
 	);
+	@Autowired
+	private AccountRepository accountRepository;
 
 	@BeforeEach
 	void setUp() {
 		testCategory = createCategory();
 		categoryRepository.save(testCategory);
+		testSeller = createSeller();
+		accountRepository.save(testSeller);
 	}
 
 	@ParameterizedTest
@@ -53,7 +61,8 @@ class ProductCreateTest extends MockMvcTest {
 			invalidName,
 			1000L,
 			100000L,
-			testCategory.getId()
+			testCategory.getId(),
+			testSeller.getId()
 		);
 
 		mockMvc.perform(post("/api/admin/products")
@@ -73,7 +82,8 @@ class ProductCreateTest extends MockMvcTest {
 			"상품명",
 			price,
 			100000L,
-			testCategory.getId()
+			testCategory.getId(),
+			testSeller.getId()
 		);
 
 		mockMvc.perform(post("/api/admin/products")
@@ -93,7 +103,8 @@ class ProductCreateTest extends MockMvcTest {
 			"상품명",
 			1000L,
 			stock,
-			testCategory.getId()
+			testCategory.getId(),
+			testSeller.getId()
 		);
 
 		mockMvc.perform(post("/api/admin/products")
@@ -113,7 +124,8 @@ class ProductCreateTest extends MockMvcTest {
 			"상품명",
 			1000L,
 			1000L,
-			categoryId
+			categoryId,
+			testSeller.getId()
 		);
 
 		mockMvc.perform(post("/api/admin/products")
@@ -130,7 +142,8 @@ class ProductCreateTest extends MockMvcTest {
 			"상품명",
 			1000L,
 			100000L,
-			testCategory.getId()
+			testCategory.getId(),
+			testSeller.getId()
 		);
 
 		mockMvc.perform(post("/api/admin/products")

--- a/src/test/java/com/kt/api/admin/product/ProductDeleteTest.java
+++ b/src/test/java/com/kt/api/admin/product/ProductDeleteTest.java
@@ -11,9 +11,10 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
 import com.kt.common.SellerEntityCreator;
 import com.kt.domain.entity.SellerEntity;
-import com.kt.repository.account.AccountRepository;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.web.servlet.ResultActions;
@@ -25,6 +26,7 @@ import com.kt.domain.entity.CategoryEntity;
 import com.kt.domain.entity.ProductEntity;
 import com.kt.repository.CategoryRepository;
 import com.kt.repository.product.ProductRepository;
+import com.kt.repository.seller.SellerRepository;
 import com.kt.security.DefaultCurrentUser;
 
 @DisplayName("상품 삭제 (어드민) - DELETE /api/admin/products/{productId}")
@@ -36,7 +38,7 @@ public class ProductDeleteTest extends MockMvcTest {
 	@Autowired
 	ProductRepository productRepository;
 	@Autowired
-	AccountRepository accountRepository;
+	SellerRepository sellerRepository;
 
 	CategoryEntity testCategory;
 	SellerEntity testSeller;
@@ -55,7 +57,7 @@ public class ProductDeleteTest extends MockMvcTest {
 		categoryRepository.save(testCategory);
 
 		testSeller = SellerEntityCreator.createSeller();
-		accountRepository.save(testSeller);
+		sellerRepository.save(testSeller);
 
 		testProduct = createProduct(testCategory, testSeller);
 		productRepository.save(testProduct);

--- a/src/test/java/com/kt/api/admin/product/ProductDeleteTest.java
+++ b/src/test/java/com/kt/api/admin/product/ProductDeleteTest.java
@@ -11,6 +11,9 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import com.kt.common.SellerEntityCreator;
+import com.kt.domain.entity.SellerEntity;
+import com.kt.repository.account.AccountRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.web.servlet.ResultActions;
@@ -32,8 +35,11 @@ public class ProductDeleteTest extends MockMvcTest {
 
 	@Autowired
 	ProductRepository productRepository;
+	@Autowired
+	AccountRepository accountRepository;
 
 	CategoryEntity testCategory;
+	SellerEntity testSeller;
 
 	DefaultCurrentUser userDetails = new DefaultCurrentUser(
 		UUID.randomUUID(),
@@ -48,7 +54,10 @@ public class ProductDeleteTest extends MockMvcTest {
 		testCategory = createCategory();
 		categoryRepository.save(testCategory);
 
-		testProduct = createProduct(testCategory);
+		testSeller = SellerEntityCreator.createSeller();
+		accountRepository.save(testSeller);
+
+		testProduct = createProduct(testCategory, testSeller);
 		productRepository.save(testProduct);
 	}
 

--- a/src/test/java/com/kt/api/admin/product/ProductInActivateTest.java
+++ b/src/test/java/com/kt/api/admin/product/ProductInActivateTest.java
@@ -12,6 +12,9 @@ import com.kt.constant.AccountRole;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import com.kt.common.SellerEntityCreator;
+import com.kt.domain.entity.SellerEntity;
+import com.kt.repository.account.AccountRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.web.servlet.ResultActions;
@@ -32,8 +35,11 @@ public class ProductInActivateTest extends MockMvcTest {
 
 	@Autowired
 	ProductRepository productRepository;
+	@Autowired
+	AccountRepository accountRepository;
 
 	CategoryEntity testCategory;
+	SellerEntity testSeller;
 
 	DefaultCurrentUser userDetails = new DefaultCurrentUser(
 		UUID.randomUUID(),
@@ -48,7 +54,10 @@ public class ProductInActivateTest extends MockMvcTest {
 		testCategory = createCategory();
 		categoryRepository.save(testCategory);
 
-		testProduct = createProduct(testCategory);
+		testSeller = SellerEntityCreator.createSeller();
+		accountRepository.save(testSeller);
+
+		testProduct = createProduct(testCategory, testSeller);
 		productRepository.save(testProduct);
 	}
 

--- a/src/test/java/com/kt/api/admin/product/ProductInActivateTest.java
+++ b/src/test/java/com/kt/api/admin/product/ProductInActivateTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import com.kt.common.SellerEntityCreator;
 import com.kt.domain.entity.SellerEntity;
-import com.kt.repository.account.AccountRepository;
+import com.kt.repository.seller.SellerRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.web.servlet.ResultActions;
@@ -36,7 +36,7 @@ public class ProductInActivateTest extends MockMvcTest {
 	@Autowired
 	ProductRepository productRepository;
 	@Autowired
-	AccountRepository accountRepository;
+	SellerRepository sellerRepository;
 
 	CategoryEntity testCategory;
 	SellerEntity testSeller;
@@ -55,7 +55,7 @@ public class ProductInActivateTest extends MockMvcTest {
 		categoryRepository.save(testCategory);
 
 		testSeller = SellerEntityCreator.createSeller();
-		accountRepository.save(testSeller);
+		sellerRepository.save(testSeller);
 
 		testProduct = createProduct(testCategory, testSeller);
 		productRepository.save(testProduct);

--- a/src/test/java/com/kt/api/admin/product/ProductSearchTest.java
+++ b/src/test/java/com/kt/api/admin/product/ProductSearchTest.java
@@ -13,6 +13,9 @@ import com.kt.constant.AccountRole;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import com.kt.common.SellerEntityCreator;
+import com.kt.domain.entity.SellerEntity;
+import com.kt.repository.account.AccountRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.web.servlet.ResultActions;
@@ -31,8 +34,11 @@ public class ProductSearchTest extends MockMvcTest {
 
 	@Autowired
 	ProductRepository productRepository;
+	@Autowired
+	AccountRepository accountRepository;
 
 	CategoryEntity testCategory;
+	SellerEntity testSeller;
 
 	DefaultCurrentUser userDetails = new DefaultCurrentUser(
 		UUID.randomUUID(),
@@ -47,13 +53,16 @@ public class ProductSearchTest extends MockMvcTest {
 		testCategory = createCategory();
 		categoryRepository.save(testCategory);
 
+		testSeller = SellerEntityCreator.createSeller();
+		accountRepository.save(testSeller);
+
 		products = new ArrayList<>();
 		for (int i = 0; i < 5; i++) {
-			products.add(createProduct(testCategory));
+			products.add(createProduct(testCategory, testSeller));
 		}
 
 		for (int i = 0; i < 5; i++) {
-			ProductEntity product = createProduct(testCategory);
+			ProductEntity product = createProduct(testCategory, testSeller);
 			product.inActivate();
 			products.add(product);
 		}

--- a/src/test/java/com/kt/api/admin/product/ProductSearchTest.java
+++ b/src/test/java/com/kt/api/admin/product/ProductSearchTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import com.kt.common.SellerEntityCreator;
 import com.kt.domain.entity.SellerEntity;
-import com.kt.repository.account.AccountRepository;
+import com.kt.repository.seller.SellerRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.web.servlet.ResultActions;
@@ -35,7 +35,7 @@ public class ProductSearchTest extends MockMvcTest {
 	@Autowired
 	ProductRepository productRepository;
 	@Autowired
-	AccountRepository accountRepository;
+	SellerRepository sellerRepository;
 
 	CategoryEntity testCategory;
 	SellerEntity testSeller;
@@ -54,7 +54,7 @@ public class ProductSearchTest extends MockMvcTest {
 		categoryRepository.save(testCategory);
 
 		testSeller = SellerEntityCreator.createSeller();
-		accountRepository.save(testSeller);
+		sellerRepository.save(testSeller);
 
 		products = new ArrayList<>();
 		for (int i = 0; i < 5; i++) {

--- a/src/test/java/com/kt/api/admin/product/ProductSoldOutTest.java
+++ b/src/test/java/com/kt/api/admin/product/ProductSoldOutTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import com.kt.common.SellerEntityCreator;
 import com.kt.domain.entity.SellerEntity;
-import com.kt.repository.account.AccountRepository;
+import com.kt.repository.seller.SellerRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
@@ -39,7 +39,7 @@ public class ProductSoldOutTest extends MockMvcTest {
 	@Autowired
 	ProductRepository productRepository;
 	@Autowired
-	AccountRepository accountRepository;
+	SellerRepository sellerRepository;
 
 	CategoryEntity testCategory;
 	SellerEntity testSeller;
@@ -58,7 +58,7 @@ public class ProductSoldOutTest extends MockMvcTest {
 		categoryRepository.save(testCategory);
 
 		testSeller = SellerEntityCreator.createSeller();
-		accountRepository.save(testSeller);
+		sellerRepository.save(testSeller);
 
 		products = new ArrayList<>();
 		for (int i = 0; i < 5; i++) {

--- a/src/test/java/com/kt/api/admin/product/ProductSoldOutTest.java
+++ b/src/test/java/com/kt/api/admin/product/ProductSoldOutTest.java
@@ -12,6 +12,9 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import com.kt.common.SellerEntityCreator;
+import com.kt.domain.entity.SellerEntity;
+import com.kt.repository.account.AccountRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
@@ -35,8 +38,11 @@ public class ProductSoldOutTest extends MockMvcTest {
 
 	@Autowired
 	ProductRepository productRepository;
+	@Autowired
+	AccountRepository accountRepository;
 
 	CategoryEntity testCategory;
+	SellerEntity testSeller;
 
 	DefaultCurrentUser userDetails = new DefaultCurrentUser(
 		UUID.randomUUID(),
@@ -51,9 +57,12 @@ public class ProductSoldOutTest extends MockMvcTest {
 		testCategory = createCategory();
 		categoryRepository.save(testCategory);
 
+		testSeller = SellerEntityCreator.createSeller();
+		accountRepository.save(testSeller);
+
 		products = new ArrayList<>();
 		for (int i = 0; i < 5; i++) {
-			products.add(createProduct(testCategory));
+			products.add(createProduct(testCategory, testSeller));
 		}
 		productRepository.saveAll(products);
 	}

--- a/src/test/java/com/kt/api/admin/product/ProductToggleSoldOutTest.java
+++ b/src/test/java/com/kt/api/admin/product/ProductToggleSoldOutTest.java
@@ -11,6 +11,9 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import com.kt.common.SellerEntityCreator;
+import com.kt.domain.entity.SellerEntity;
+import com.kt.repository.account.AccountRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.web.servlet.ResultActions;
@@ -32,8 +35,11 @@ public class ProductToggleSoldOutTest extends MockMvcTest {
 
 	@Autowired
 	ProductRepository productRepository;
+	@Autowired
+	AccountRepository accountRepository;
 
 	CategoryEntity testCategory;
+	SellerEntity testSeller;
 
 	DefaultCurrentUser userDetails = new DefaultCurrentUser(
 		UUID.randomUUID(),
@@ -48,7 +54,10 @@ public class ProductToggleSoldOutTest extends MockMvcTest {
 		testCategory = createCategory();
 		categoryRepository.save(testCategory);
 
-		testProduct = createProduct(testCategory);
+		testSeller = SellerEntityCreator.createSeller();
+		accountRepository.save(testSeller);
+
+		testProduct = createProduct(testCategory, testSeller);
 		productRepository.save(testProduct);
 	}
 

--- a/src/test/java/com/kt/api/admin/product/ProductToggleSoldOutTest.java
+++ b/src/test/java/com/kt/api/admin/product/ProductToggleSoldOutTest.java
@@ -11,9 +11,10 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
 import com.kt.common.SellerEntityCreator;
 import com.kt.domain.entity.SellerEntity;
-import com.kt.repository.account.AccountRepository;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.web.servlet.ResultActions;
@@ -25,6 +26,7 @@ import com.kt.domain.entity.CategoryEntity;
 import com.kt.domain.entity.ProductEntity;
 import com.kt.repository.CategoryRepository;
 import com.kt.repository.product.ProductRepository;
+import com.kt.repository.seller.SellerRepository;
 import com.kt.security.DefaultCurrentUser;
 
 @DisplayName("상품 품절 토글 (어드민) - PUT /api/admin/products/{productId}/toggle-sold-out")
@@ -36,7 +38,7 @@ public class ProductToggleSoldOutTest extends MockMvcTest {
 	@Autowired
 	ProductRepository productRepository;
 	@Autowired
-	AccountRepository accountRepository;
+	SellerRepository sellerRepository;
 
 	CategoryEntity testCategory;
 	SellerEntity testSeller;
@@ -55,7 +57,7 @@ public class ProductToggleSoldOutTest extends MockMvcTest {
 		categoryRepository.save(testCategory);
 
 		testSeller = SellerEntityCreator.createSeller();
-		accountRepository.save(testSeller);
+		sellerRepository.save(testSeller);
 
 		testProduct = createProduct(testCategory, testSeller);
 		productRepository.save(testProduct);

--- a/src/test/java/com/kt/api/admin/product/ProductUpdateTest.java
+++ b/src/test/java/com/kt/api/admin/product/ProductUpdateTest.java
@@ -11,6 +11,9 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import com.kt.common.SellerEntityCreator;
+import com.kt.domain.entity.SellerEntity;
+import com.kt.repository.account.AccountRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.web.servlet.ResultActions;
@@ -32,8 +35,11 @@ public class ProductUpdateTest extends MockMvcTest {
 
 	@Autowired
 	ProductRepository productRepository;
+	@Autowired
+	AccountRepository accountRepository;
 
 	CategoryEntity testCategory;
+	SellerEntity testSeller;
 
 	DefaultCurrentUser userDetails = new DefaultCurrentUser(
 		UUID.randomUUID(),
@@ -48,7 +54,10 @@ public class ProductUpdateTest extends MockMvcTest {
 		testCategory = createCategory();
 		categoryRepository.save(testCategory);
 
-		testProduct = createProduct(testCategory);
+		testSeller = SellerEntityCreator.createSeller();
+		accountRepository.save(testSeller);
+
+		testProduct = createProduct(testCategory, testSeller);
 		productRepository.save(testProduct);
 	}
 

--- a/src/test/java/com/kt/api/admin/product/ProductUpdateTest.java
+++ b/src/test/java/com/kt/api/admin/product/ProductUpdateTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import com.kt.common.SellerEntityCreator;
 import com.kt.domain.entity.SellerEntity;
-import com.kt.repository.account.AccountRepository;
+import com.kt.repository.seller.SellerRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.web.servlet.ResultActions;
@@ -36,7 +36,7 @@ public class ProductUpdateTest extends MockMvcTest {
 	@Autowired
 	ProductRepository productRepository;
 	@Autowired
-	AccountRepository accountRepository;
+	SellerRepository sellerRepository;
 
 	CategoryEntity testCategory;
 	SellerEntity testSeller;
@@ -55,7 +55,7 @@ public class ProductUpdateTest extends MockMvcTest {
 		categoryRepository.save(testCategory);
 
 		testSeller = SellerEntityCreator.createSeller();
-		accountRepository.save(testSeller);
+		sellerRepository.save(testSeller);
 
 		testProduct = createProduct(testCategory, testSeller);
 		productRepository.save(testProduct);

--- a/src/test/java/com/kt/api/order/OrderCancelTest.java
+++ b/src/test/java/com/kt/api/order/OrderCancelTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import com.kt.common.SellerEntityCreator;
 import com.kt.domain.entity.SellerEntity;
-import com.kt.repository.account.AccountRepository;
+import com.kt.repository.seller.SellerRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -60,7 +60,7 @@ public class OrderCancelTest extends MockMvcTest {
 	@Autowired
 	AddressRepository addressRepository;
 	@Autowired
-	AccountRepository accountRepository;
+	SellerRepository sellerRepository;
 
 	UserEntity testMember;
 
@@ -78,7 +78,7 @@ public class OrderCancelTest extends MockMvcTest {
 		categoryRepository.save(category);
 
 		testSeller = SellerEntityCreator.createSeller();
-		accountRepository.save(testSeller);
+		sellerRepository.save(testSeller);
 
 		testProduct = createProduct(category, testSeller);
 		productRepository.save(testProduct);

--- a/src/test/java/com/kt/api/order/OrderCancelTest.java
+++ b/src/test/java/com/kt/api/order/OrderCancelTest.java
@@ -15,6 +15,12 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import com.kt.common.SellerEntityCreator;
+import com.kt.domain.entity.SellerEntity;
+import com.kt.repository.account.AccountRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.web.servlet.ResultActions;
 
@@ -53,12 +59,15 @@ public class OrderCancelTest extends MockMvcTest {
 	OrderProductRepository orderProductRepository;
 	@Autowired
 	AddressRepository addressRepository;
+	@Autowired
+	AccountRepository accountRepository;
 
 	UserEntity testMember;
 
 	ProductEntity testProduct;
 
 	AddressEntity testAddress;
+	SellerEntity testSeller;
 
 	@BeforeEach
 	void setUp() {
@@ -68,13 +77,16 @@ public class OrderCancelTest extends MockMvcTest {
 		CategoryEntity category = createCategory();
 		categoryRepository.save(category);
 
-		testProduct = createProduct(category);
+		testSeller = SellerEntityCreator.createSeller();
+		accountRepository.save(testSeller);
+
+		testProduct = createProduct(category, testSeller);
 		productRepository.save(testProduct);
 
 		testAddress = addressRepository.save(AddressCreator.createAddress(testMember));
 
 		List<OrderRequest.Item> items = List.of(
-			new OrderRequest.Item(testProduct.getId(), 1L)
+			new OrderRequest.Item(testProduct.getId(), 1L, testSeller.getId())
 		);
 		orderService.createOrder(testMember.getEmail(), items, testAddress.getId());
 	}

--- a/src/test/java/com/kt/api/order/OrderCreateTest.java
+++ b/src/test/java/com/kt/api/order/OrderCreateTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import com.kt.common.SellerEntityCreator;
 import com.kt.domain.entity.SellerEntity;
-import com.kt.repository.account.AccountRepository;
+import com.kt.repository.seller.SellerRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -53,7 +53,7 @@ public class OrderCreateTest extends MockMvcTest {
 	@Autowired
 	OrderRepository orderRepository;
 	@Autowired
-	AccountRepository accountRepository;
+	SellerRepository sellerRepository;
 
 	ArrayList<ProductEntity> products = new ArrayList<>();
 
@@ -74,7 +74,7 @@ public class OrderCreateTest extends MockMvcTest {
 		categoryRepository.save(category);
 
 		testSeller = SellerEntityCreator.createSeller();
-		accountRepository.save(testSeller);
+		sellerRepository.save(testSeller);
 
 		testProduct1 = createProduct(category, testSeller);
 		productRepository.save(testProduct1);

--- a/src/test/java/com/kt/api/order/OrderCreateTest.java
+++ b/src/test/java/com/kt/api/order/OrderCreateTest.java
@@ -15,6 +15,9 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import com.kt.common.SellerEntityCreator;
+import com.kt.domain.entity.SellerEntity;
+import com.kt.repository.account.AccountRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -49,6 +52,8 @@ public class OrderCreateTest extends MockMvcTest {
 	UserRepository userRepository;
 	@Autowired
 	OrderRepository orderRepository;
+	@Autowired
+	AccountRepository accountRepository;
 
 	ArrayList<ProductEntity> products = new ArrayList<>();
 
@@ -56,6 +61,7 @@ public class OrderCreateTest extends MockMvcTest {
 	AddressEntity address;
 	ProductEntity testProduct1;
 	ProductEntity testProduct2;
+	SellerEntity testSeller;
 	@Autowired
 	private AddressRepository addressRepository;
 
@@ -67,10 +73,13 @@ public class OrderCreateTest extends MockMvcTest {
 		CategoryEntity category = createCategory();
 		categoryRepository.save(category);
 
-		testProduct1 = createProduct(category);
+		testSeller = SellerEntityCreator.createSeller();
+		accountRepository.save(testSeller);
+
+		testProduct1 = createProduct(category, testSeller);
 		productRepository.save(testProduct1);
 
-		testProduct2 = createProduct(category);
+		testProduct2 = createProduct(category, testSeller);
 		productRepository.save(testProduct2);
 
 		products.add(testProduct1);
@@ -83,7 +92,7 @@ public class OrderCreateTest extends MockMvcTest {
 	void 주문_생성_성공__200_OK() throws Exception {
 		// when
 		OrderRequest request = new OrderRequest(
-			List.of(new OrderRequest.Item(testProduct1.getId(), 1L)), address.getId()
+			List.of(new OrderRequest.Item(testProduct1.getId(), 1L, testSeller.getId())), address.getId()
 		);
 
 		ResultActions actions = mockMvc.perform(
@@ -104,8 +113,8 @@ public class OrderCreateTest extends MockMvcTest {
 		// when
 		OrderRequest request = new OrderRequest(
 			List.of(
-				new OrderRequest.Item(testProduct1.getId(), 1L),
-				new OrderRequest.Item(testProduct2.getId(), 2L)),
+				new OrderRequest.Item(testProduct1.getId(), 1L, testSeller.getId()),
+				new OrderRequest.Item(testProduct2.getId(), 2L, testSeller.getId())),
 			address.getId()
 		);
 

--- a/src/test/java/com/kt/api/order/OrderDetailTest.java
+++ b/src/test/java/com/kt/api/order/OrderDetailTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import com.kt.common.SellerEntityCreator;
 import com.kt.domain.entity.SellerEntity;
-import com.kt.repository.account.AccountRepository;
+import com.kt.repository.seller.SellerRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.web.servlet.ResultActions;
@@ -50,7 +50,7 @@ public class OrderDetailTest extends MockMvcTest {
 	@Autowired
 	AddressRepository addressRepository;
 	@Autowired
-	AccountRepository accountRepository;
+	SellerRepository sellerRepository;
 
 	UserEntity testMember;
 
@@ -68,7 +68,7 @@ public class OrderDetailTest extends MockMvcTest {
 		categoryRepository.save(category);
 
 		testSeller = SellerEntityCreator.createSeller();
-		accountRepository.save(testSeller);
+		sellerRepository.save(testSeller);
 
 		testProduct = createProduct(category, testSeller);
 		productRepository.save(testProduct);

--- a/src/test/java/com/kt/api/order/OrderDetailTest.java
+++ b/src/test/java/com/kt/api/order/OrderDetailTest.java
@@ -12,6 +12,9 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import com.kt.common.SellerEntityCreator;
+import com.kt.domain.entity.SellerEntity;
+import com.kt.repository.account.AccountRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.web.servlet.ResultActions;
@@ -46,12 +49,15 @@ public class OrderDetailTest extends MockMvcTest {
 	OrderRepository orderRepository;
 	@Autowired
 	AddressRepository addressRepository;
+	@Autowired
+	AccountRepository accountRepository;
 
 	UserEntity testMember;
 
 	ProductEntity testProduct;
 
 	AddressEntity testAddress;
+	SellerEntity testSeller;
 
 	@BeforeEach
 	void setUp() {
@@ -61,13 +67,16 @@ public class OrderDetailTest extends MockMvcTest {
 		CategoryEntity category = createCategory();
 		categoryRepository.save(category);
 
-		testProduct = createProduct(category);
+		testSeller = SellerEntityCreator.createSeller();
+		accountRepository.save(testSeller);
+
+		testProduct = createProduct(category, testSeller);
 		productRepository.save(testProduct);
 
 		testAddress = addressRepository.save(AddressCreator.createAddress(testMember));
 
 		List<OrderRequest.Item> items = List.of(
-			new OrderRequest.Item(testProduct.getId(), 1L)
+			new OrderRequest.Item(testProduct.getId(), 1L, testSeller.getId())
 		);
 		orderService.createOrder(testMember.getEmail(), items, testAddress.getId());
 	}

--- a/src/test/java/com/kt/api/order/OrderSearchTest.java
+++ b/src/test/java/com/kt/api/order/OrderSearchTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import com.kt.common.SellerEntityCreator;
 import com.kt.domain.entity.SellerEntity;
-import com.kt.repository.account.AccountRepository;
+import com.kt.repository.seller.SellerRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -51,7 +51,7 @@ public class OrderSearchTest extends MockMvcTest {
 	@Autowired
 	AddressRepository addressRepository;
 	@Autowired
-	AccountRepository accountRepository;
+	SellerRepository sellerRepository;
 
 	UserEntity testMember;
 
@@ -69,7 +69,7 @@ public class OrderSearchTest extends MockMvcTest {
 		categoryRepository.save(category);
 
 		testSeller = SellerEntityCreator.createSeller();
-		accountRepository.save(testSeller);
+		sellerRepository.save(testSeller);
 
 		testProduct = createProduct(category, testSeller);
 		productRepository.save(testProduct);

--- a/src/test/java/com/kt/api/order/OrderSearchTest.java
+++ b/src/test/java/com/kt/api/order/OrderSearchTest.java
@@ -12,6 +12,9 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import com.kt.common.SellerEntityCreator;
+import com.kt.domain.entity.SellerEntity;
+import com.kt.repository.account.AccountRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -47,12 +50,15 @@ public class OrderSearchTest extends MockMvcTest {
 	UserRepository userRepository;
 	@Autowired
 	AddressRepository addressRepository;
+	@Autowired
+	AccountRepository accountRepository;
 
 	UserEntity testMember;
 
 	ProductEntity testProduct;
 
 	AddressEntity testAddress;
+	SellerEntity testSeller;
 
 	@BeforeEach
 	void setUp() {
@@ -62,14 +68,17 @@ public class OrderSearchTest extends MockMvcTest {
 		CategoryEntity category = createCategory();
 		categoryRepository.save(category);
 
-		testProduct = createProduct(category);
+		testSeller = SellerEntityCreator.createSeller();
+		accountRepository.save(testSeller);
+
+		testProduct = createProduct(category, testSeller);
 		productRepository.save(testProduct);
 
 		testAddress = addressRepository.save(AddressCreator.createAddress(testMember));
 
 		for (int i = 0; i < 2; i++) {
 			List<OrderRequest.Item> items = List.of(
-				new OrderRequest.Item(testProduct.getId(), 1L)
+				new OrderRequest.Item(testProduct.getId(), 1L, testSeller.getId())
 			);
 			orderService.createOrder(testMember.getEmail(), items, testAddress.getId());
 		}

--- a/src/test/java/com/kt/api/order/OrderUpdateTest.java
+++ b/src/test/java/com/kt/api/order/OrderUpdateTest.java
@@ -15,6 +15,19 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import com.kt.common.SellerEntityCreator;
+import com.kt.domain.entity.SellerEntity;
+import com.kt.repository.account.AccountRepository;
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
@@ -49,12 +62,15 @@ public class OrderUpdateTest extends MockMvcTest {
 	OrderRepository orderRepository;
 	@Autowired
 	AddressRepository addressRepository;
+	@Autowired
+	AccountRepository accountRepository;
 
 	UserEntity testMember;
 
 	ProductEntity testProduct;
 
 	AddressEntity testAddress;
+	SellerEntity testSeller;
 
 	@BeforeEach
 	void setUp() {
@@ -64,13 +80,16 @@ public class OrderUpdateTest extends MockMvcTest {
 		CategoryEntity category = createCategory();
 		categoryRepository.save(category);
 
-		testProduct = createProduct(category);
+		testSeller = SellerEntityCreator.createSeller();
+		accountRepository.save(testSeller);
+
+		testProduct = createProduct(category, testSeller);
 		productRepository.save(testProduct);
 
 		testAddress = addressRepository.save(AddressCreator.createAddress(testMember));
 
 		List<OrderRequest.Item> items = List.of(
-			new OrderRequest.Item(testProduct.getId(), 1L)
+			new OrderRequest.Item(testProduct.getId(), 1L, testSeller.getId())
 		);
 		orderService.createOrder(testMember.getEmail(), items, testAddress.getId());
 	}

--- a/src/test/java/com/kt/api/order/OrderUpdateTest.java
+++ b/src/test/java/com/kt/api/order/OrderUpdateTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import com.kt.common.SellerEntityCreator;
 import com.kt.domain.entity.SellerEntity;
-import com.kt.repository.account.AccountRepository;
+import com.kt.repository.seller.SellerRepository;
 import static org.assertj.core.api.Assertions.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
@@ -63,7 +63,7 @@ public class OrderUpdateTest extends MockMvcTest {
 	@Autowired
 	AddressRepository addressRepository;
 	@Autowired
-	AccountRepository accountRepository;
+	SellerRepository sellerRepository;
 
 	UserEntity testMember;
 
@@ -81,7 +81,7 @@ public class OrderUpdateTest extends MockMvcTest {
 		categoryRepository.save(category);
 
 		testSeller = SellerEntityCreator.createSeller();
-		accountRepository.save(testSeller);
+		sellerRepository.save(testSeller);
 
 		testProduct = createProduct(category, testSeller);
 		productRepository.save(testProduct);

--- a/src/test/java/com/kt/api/product/ProductDetailTest.java
+++ b/src/test/java/com/kt/api/product/ProductDetailTest.java
@@ -13,6 +13,9 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import com.kt.common.SellerEntityCreator;
+import com.kt.domain.entity.SellerEntity;
+import com.kt.repository.account.AccountRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.web.servlet.ResultActions;
 
@@ -30,8 +33,11 @@ public class ProductDetailTest extends MockMvcTest {
 
 	@Autowired
 	ProductRepository productRepository;
+	@Autowired
+	AccountRepository accountRepository;
 
 	CategoryEntity testCategory;
+	SellerEntity testSeller;
 
 	ProductEntity activatedProduct;
 	ProductEntity inActivatedProduct;
@@ -41,10 +47,13 @@ public class ProductDetailTest extends MockMvcTest {
 		testCategory = createCategory();
 		categoryRepository.save(testCategory);
 
-		activatedProduct = createProduct(testCategory);
+		testSeller = SellerEntityCreator.createSeller();
+		accountRepository.save(testSeller);
+
+		activatedProduct = createProduct(testCategory, testSeller);
 		productRepository.save(activatedProduct);
 
-		inActivatedProduct = createProduct(testCategory);
+		inActivatedProduct = createProduct(testCategory, testSeller);
 		inActivatedProduct.inActivate();
 		productRepository.save(inActivatedProduct);
 	}

--- a/src/test/java/com/kt/api/product/ProductDetailTest.java
+++ b/src/test/java/com/kt/api/product/ProductDetailTest.java
@@ -13,9 +13,10 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
 import com.kt.common.SellerEntityCreator;
 import com.kt.domain.entity.SellerEntity;
-import com.kt.repository.account.AccountRepository;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.web.servlet.ResultActions;
 
@@ -24,6 +25,7 @@ import com.kt.domain.entity.CategoryEntity;
 import com.kt.domain.entity.ProductEntity;
 import com.kt.repository.CategoryRepository;
 import com.kt.repository.product.ProductRepository;
+import com.kt.repository.seller.SellerRepository;
 
 @DisplayName("상품 상세 조회 - GET /api/products/{productId}")
 public class ProductDetailTest extends MockMvcTest {
@@ -34,7 +36,7 @@ public class ProductDetailTest extends MockMvcTest {
 	@Autowired
 	ProductRepository productRepository;
 	@Autowired
-	AccountRepository accountRepository;
+	SellerRepository sellerRepository;
 
 	CategoryEntity testCategory;
 	SellerEntity testSeller;
@@ -48,7 +50,7 @@ public class ProductDetailTest extends MockMvcTest {
 		categoryRepository.save(testCategory);
 
 		testSeller = SellerEntityCreator.createSeller();
-		accountRepository.save(testSeller);
+		sellerRepository.save(testSeller);
 
 		activatedProduct = createProduct(testCategory, testSeller);
 		productRepository.save(activatedProduct);

--- a/src/test/java/com/kt/api/product/ProductReviewTest.java
+++ b/src/test/java/com/kt/api/product/ProductReviewTest.java
@@ -14,7 +14,6 @@ import com.kt.common.AddressCreator;
 import com.kt.common.MockMvcTest;
 import com.kt.constant.OrderProductStatus;
 import com.kt.common.SellerEntityCreator;
-import com.kt.constant.OrderStatus;
 import com.kt.domain.dto.request.OrderRequest;
 import com.kt.domain.entity.AddressEntity;
 import com.kt.domain.entity.CategoryEntity;
@@ -25,7 +24,7 @@ import com.kt.domain.entity.UserEntity;
 import com.kt.repository.AddressRepository;
 import com.kt.repository.CategoryRepository;
 import com.kt.repository.order.OrderRepository;
-import com.kt.repository.account.AccountRepository;
+import com.kt.repository.seller.SellerRepository;
 import com.kt.repository.orderproduct.OrderProductRepository;
 import com.kt.repository.product.ProductRepository;
 import com.kt.repository.user.UserRepository;
@@ -47,7 +46,7 @@ public class ProductReviewTest extends MockMvcTest {
 	@Autowired
 	AddressRepository addressRepository;
 	@Autowired
-	AccountRepository accountRepository;
+	SellerRepository sellerRepository;
 
 	@Autowired
 	OrderService orderService;
@@ -76,7 +75,7 @@ public class ProductReviewTest extends MockMvcTest {
 		categoryRepository.save(testCategory);
 
 		testSeller = SellerEntityCreator.createSeller();
-		accountRepository.save(testSeller);
+		sellerRepository.save(testSeller);
 
 		testProduct = createProduct(testCategory, testSeller);
 
@@ -90,7 +89,8 @@ public class ProductReviewTest extends MockMvcTest {
 			orderService.createOrder(testMember.getEmail(), items, address.getId());
 		}
 
-		orderProductRepository.findAll().forEach(orderProduct -> orderProduct.updateStatus(OrderProductStatus.PURCHASE_CONFIRMED));
+		orderProductRepository.findAll()
+			.forEach(orderProduct -> orderProduct.updateStatus(OrderProductStatus.PURCHASE_CONFIRMED));
 
 		List<OrderProductEntity> list = orderProductRepository.findAll().stream().toList();
 		for (int i = 0; i < 3; i++) {

--- a/src/test/java/com/kt/api/product/ProductReviewTest.java
+++ b/src/test/java/com/kt/api/product/ProductReviewTest.java
@@ -13,15 +13,19 @@ import org.springframework.beans.factory.annotation.Autowired;
 import com.kt.common.AddressCreator;
 import com.kt.common.MockMvcTest;
 import com.kt.constant.OrderProductStatus;
+import com.kt.common.SellerEntityCreator;
+import com.kt.constant.OrderStatus;
 import com.kt.domain.dto.request.OrderRequest;
 import com.kt.domain.entity.AddressEntity;
 import com.kt.domain.entity.CategoryEntity;
 import com.kt.domain.entity.OrderProductEntity;
 import com.kt.domain.entity.ProductEntity;
+import com.kt.domain.entity.SellerEntity;
 import com.kt.domain.entity.UserEntity;
 import com.kt.repository.AddressRepository;
 import com.kt.repository.CategoryRepository;
 import com.kt.repository.order.OrderRepository;
+import com.kt.repository.account.AccountRepository;
 import com.kt.repository.orderproduct.OrderProductRepository;
 import com.kt.repository.product.ProductRepository;
 import com.kt.repository.user.UserRepository;
@@ -42,6 +46,8 @@ public class ProductReviewTest extends MockMvcTest {
 
 	@Autowired
 	AddressRepository addressRepository;
+	@Autowired
+	AccountRepository accountRepository;
 
 	@Autowired
 	OrderService orderService;
@@ -53,6 +59,7 @@ public class ProductReviewTest extends MockMvcTest {
 	CategoryEntity testCategory;
 	ProductEntity testProduct;
 	AddressEntity address;
+	SellerEntity testSeller;
 
 	@Autowired
 	OrderProductRepository orderProductRepository;
@@ -68,14 +75,17 @@ public class ProductReviewTest extends MockMvcTest {
 		testCategory = createCategory();
 		categoryRepository.save(testCategory);
 
-		testProduct = createProduct(testCategory);
+		testSeller = SellerEntityCreator.createSeller();
+		accountRepository.save(testSeller);
+
+		testProduct = createProduct(testCategory, testSeller);
 
 		address = addressRepository.save(AddressCreator.createAddress(testMember));
 
 		productRepository.save(testProduct);
 		for (int i = 0; i < 3; i++) {
 			List<OrderRequest.Item> items = List.of(
-				new OrderRequest.Item(testProduct.getId(), 1L)
+				new OrderRequest.Item(testProduct.getId(), 1L, testSeller.getId())
 			);
 			orderService.createOrder(testMember.getEmail(), items, address.getId());
 		}

--- a/src/test/java/com/kt/api/product/ProductSearchTest.java
+++ b/src/test/java/com/kt/api/product/ProductSearchTest.java
@@ -14,9 +14,10 @@ import java.util.ArrayList;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
 import com.kt.common.SellerEntityCreator;
 import com.kt.domain.entity.SellerEntity;
-import com.kt.repository.account.AccountRepository;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.web.servlet.ResultActions;
 
@@ -26,6 +27,7 @@ import com.kt.domain.entity.CategoryEntity;
 import com.kt.domain.entity.ProductEntity;
 import com.kt.repository.CategoryRepository;
 import com.kt.repository.product.ProductRepository;
+import com.kt.repository.seller.SellerRepository;
 
 @DisplayName("상품 목록 조회 - GET /api/products")
 public class ProductSearchTest extends MockMvcTest {
@@ -36,7 +38,7 @@ public class ProductSearchTest extends MockMvcTest {
 	@Autowired
 	ProductRepository productRepository;
 	@Autowired
-	AccountRepository accountRepository;
+	SellerRepository sellerRepository;
 
 	CategoryEntity testCategory;
 	SellerEntity testSeller;
@@ -49,7 +51,7 @@ public class ProductSearchTest extends MockMvcTest {
 		categoryRepository.save(testCategory);
 
 		testSeller = SellerEntityCreator.createSeller();
-		accountRepository.save(testSeller);
+		sellerRepository.save(testSeller);
 
 		products = new ArrayList<>();
 		for (int i = 0; i < 5; i++) {

--- a/src/test/java/com/kt/api/product/ProductSearchTest.java
+++ b/src/test/java/com/kt/api/product/ProductSearchTest.java
@@ -14,6 +14,9 @@ import java.util.ArrayList;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import com.kt.common.SellerEntityCreator;
+import com.kt.domain.entity.SellerEntity;
+import com.kt.repository.account.AccountRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.web.servlet.ResultActions;
 
@@ -32,8 +35,11 @@ public class ProductSearchTest extends MockMvcTest {
 
 	@Autowired
 	ProductRepository productRepository;
+	@Autowired
+	AccountRepository accountRepository;
 
 	CategoryEntity testCategory;
+	SellerEntity testSeller;
 
 	ArrayList<ProductEntity> products;
 
@@ -42,14 +48,17 @@ public class ProductSearchTest extends MockMvcTest {
 		testCategory = createCategory();
 		categoryRepository.save(testCategory);
 
+		testSeller = SellerEntityCreator.createSeller();
+		accountRepository.save(testSeller);
+
 		products = new ArrayList<>();
 		for (int i = 0; i < 5; i++) {
-			products.add(createProduct(testCategory));
+			products.add(createProduct(testCategory, testSeller));
 		}
 
 		// 비활성화 상품 추가
 		for (int i = 0; i < 5; i++) {
-			ProductEntity product = createProduct(testCategory);
+			ProductEntity product = createProduct(testCategory, testSeller);
 			product.inActivate();
 			products.add(product);
 		}

--- a/src/test/java/com/kt/api/review/ReviewCreateTest.java
+++ b/src/test/java/com/kt/api/review/ReviewCreateTest.java
@@ -2,13 +2,12 @@ package com.kt.api.review;
 
 import com.kt.common.SellerEntityCreator;
 import com.kt.domain.entity.SellerEntity;
-import com.kt.repository.account.AccountRepository;
+import com.kt.repository.seller.SellerRepository;
 
 import static com.kt.common.CurrentUserCreator.getMemberUserDetails;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -56,7 +55,7 @@ public class ReviewCreateTest extends MockMvcTest {
 	@Autowired
 	CategoryRepository categoryRepository;
 	@Autowired
-	AccountRepository accountRepository;
+	SellerRepository sellerRepository;
 
 	OrderProductEntity testOrderProduct;
 	ProductEntity testProduct;
@@ -77,7 +76,7 @@ public class ReviewCreateTest extends MockMvcTest {
 		categoryRepository.save(category);
 
 		testSeller = SellerEntityCreator.createSeller();
-		accountRepository.save(testSeller);
+		sellerRepository.save(testSeller);
 
 		testProduct = ProductCreator.createProduct(category, testSeller);
 		productRepository.save(testProduct);

--- a/src/test/java/com/kt/api/review/ReviewCreateTest.java
+++ b/src/test/java/com/kt/api/review/ReviewCreateTest.java
@@ -1,9 +1,14 @@
 package com.kt.api.review;
 
-import static com.kt.common.CurrentUserCreator.*;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import com.kt.common.SellerEntityCreator;
+import com.kt.domain.entity.SellerEntity;
+import com.kt.repository.account.AccountRepository;
+
+import static com.kt.common.CurrentUserCreator.getMemberUserDetails;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -50,11 +55,13 @@ public class ReviewCreateTest extends MockMvcTest {
 	OrderRepository orderRepository;
 	@Autowired
 	CategoryRepository categoryRepository;
+	@Autowired
+	AccountRepository accountRepository;
 
 	OrderProductEntity testOrderProduct;
 	ProductEntity testProduct;
-
 	UserEntity testMember;
+	SellerEntity testSeller;
 
 	@BeforeEach
 	void setUp() throws Exception {
@@ -69,10 +76,13 @@ public class ReviewCreateTest extends MockMvcTest {
 		CategoryEntity category = CategoryEntityCreator.createCategory();
 		categoryRepository.save(category);
 
-		testProduct = ProductCreator.createProduct(category);
+		testSeller = SellerEntityCreator.createSeller();
+		accountRepository.save(testSeller);
+
+		testProduct = ProductCreator.createProduct(category, testSeller);
 		productRepository.save(testProduct);
 
-		testOrderProduct = OrderProductCreator.createOrderProduct(order, testProduct);
+		testOrderProduct = OrderProductCreator.createOrderProduct(order, testProduct, testSeller);
 		orderProductRepository.save(testOrderProduct);
 
 		order.getOrderProducts().add(testOrderProduct);

--- a/src/test/java/com/kt/api/review/ReviewDeleteTest.java
+++ b/src/test/java/com/kt/api/review/ReviewDeleteTest.java
@@ -2,13 +2,12 @@ package com.kt.api.review;
 
 import com.kt.common.SellerEntityCreator;
 import com.kt.domain.entity.SellerEntity;
-import com.kt.repository.account.AccountRepository;
+
 import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static com.kt.common.CurrentUserCreator.*;
-
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -35,6 +34,7 @@ import com.kt.repository.order.OrderRepository;
 import com.kt.repository.orderproduct.OrderProductRepository;
 import com.kt.repository.product.ProductRepository;
 import com.kt.repository.review.ReviewRepository;
+import com.kt.repository.seller.SellerRepository;
 import com.kt.repository.user.UserRepository;
 
 @DisplayName("상품 리뷰 삭제 - DELETE /api/reviews/{reviewId}")
@@ -53,7 +53,7 @@ public class ReviewDeleteTest extends MockMvcTest {
 	@Autowired
 	CategoryRepository categoryRepository;
 	@Autowired
-	AccountRepository accountRepository;
+	SellerRepository sellerRepository;
 
 	OrderProductEntity testOrderProduct;
 	ProductEntity testProduct;
@@ -75,7 +75,7 @@ public class ReviewDeleteTest extends MockMvcTest {
 		categoryRepository.save(category);
 
 		testSeller = SellerEntityCreator.createSeller();
-		accountRepository.save(testSeller);
+		sellerRepository.save(testSeller);
 
 		testProduct = ProductCreator.createProduct(category, testSeller);
 		productRepository.save(testProduct);

--- a/src/test/java/com/kt/api/review/ReviewDeleteTest.java
+++ b/src/test/java/com/kt/api/review/ReviewDeleteTest.java
@@ -1,10 +1,14 @@
 package com.kt.api.review;
 
-import static com.kt.common.CurrentUserCreator.*;
+import com.kt.common.SellerEntityCreator;
+import com.kt.domain.entity.SellerEntity;
+import com.kt.repository.account.AccountRepository;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static com.kt.common.CurrentUserCreator.*;
+
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -48,11 +52,14 @@ public class ReviewDeleteTest extends MockMvcTest {
 	OrderRepository orderRepository;
 	@Autowired
 	CategoryRepository categoryRepository;
+	@Autowired
+	AccountRepository accountRepository;
 
 	OrderProductEntity testOrderProduct;
 	ProductEntity testProduct;
 
 	UserEntity testMember;
+	SellerEntity testSeller;
 
 	@BeforeEach
 	void setUp() throws Exception {
@@ -67,10 +74,13 @@ public class ReviewDeleteTest extends MockMvcTest {
 		CategoryEntity category = CategoryEntityCreator.createCategory();
 		categoryRepository.save(category);
 
-		testProduct = ProductCreator.createProduct(category);
+		testSeller = SellerEntityCreator.createSeller();
+		accountRepository.save(testSeller);
+
+		testProduct = ProductCreator.createProduct(category, testSeller);
 		productRepository.save(testProduct);
 
-		testOrderProduct = OrderProductCreator.createOrderProduct(order, testProduct);
+		testOrderProduct = OrderProductCreator.createOrderProduct(order, testProduct, testSeller);
 		orderProductRepository.save(testOrderProduct);
 	}
 

--- a/src/test/java/com/kt/api/review/ReviewSearchTest.java
+++ b/src/test/java/com/kt/api/review/ReviewSearchTest.java
@@ -33,6 +33,7 @@ import com.kt.repository.order.OrderRepository;
 import com.kt.repository.orderproduct.OrderProductRepository;
 import com.kt.repository.product.ProductRepository;
 import com.kt.repository.review.ReviewRepository;
+import com.kt.repository.seller.SellerRepository;
 import com.kt.repository.user.UserRepository;
 
 @DisplayName("상품 리뷰 조회 - GET /api/reviews?productId")
@@ -51,7 +52,7 @@ public class ReviewSearchTest extends MockMvcTest {
 	@Autowired
 	CategoryRepository categoryRepository;
 	@Autowired
-	AccountRepository accountRepository;
+	SellerRepository sellerRepository;
 
 	OrderProductEntity testOrderProduct;
 	ProductEntity testProduct;
@@ -71,7 +72,7 @@ public class ReviewSearchTest extends MockMvcTest {
 		categoryRepository.save(category);
 
 		testSeller = SellerEntityCreator.createSeller();
-		accountRepository.save(testSeller);
+		sellerRepository.save(testSeller);
 
 		testProduct = ProductCreator.createProduct(category, testSeller);
 		productRepository.save(testProduct);

--- a/src/test/java/com/kt/api/review/ReviewSearchTest.java
+++ b/src/test/java/com/kt/api/review/ReviewSearchTest.java
@@ -1,5 +1,9 @@
 package com.kt.api.review;
 
+import com.kt.common.SellerEntityCreator;
+import com.kt.domain.entity.SellerEntity;
+import com.kt.repository.account.AccountRepository;
+
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -46,9 +50,12 @@ public class ReviewSearchTest extends MockMvcTest {
 	OrderRepository orderRepository;
 	@Autowired
 	CategoryRepository categoryRepository;
+	@Autowired
+	AccountRepository accountRepository;
 
 	OrderProductEntity testOrderProduct;
 	ProductEntity testProduct;
+	SellerEntity testSeller;
 
 	@BeforeEach
 	void setUp() throws Exception {
@@ -63,13 +70,15 @@ public class ReviewSearchTest extends MockMvcTest {
 		CategoryEntity category = CategoryEntityCreator.createCategory();
 		categoryRepository.save(category);
 
-		testProduct = ProductCreator.createProduct(category);
+		testSeller = SellerEntityCreator.createSeller();
+		accountRepository.save(testSeller);
+
+		testProduct = ProductCreator.createProduct(category, testSeller);
 		productRepository.save(testProduct);
 
-		testOrderProduct = OrderProductCreator.createOrderProduct(order, testProduct);
+		testOrderProduct = OrderProductCreator.createOrderProduct(order, testProduct, testSeller);
 		orderProductRepository.save(testOrderProduct);
 	}
-
 
 	@Test
 	void 상품리뷰조회_성공__200_OK() throws Exception {
@@ -80,15 +89,15 @@ public class ReviewSearchTest extends MockMvcTest {
 
 		// when
 		ResultActions actions = mockMvc.perform(get("/api/reviews")
-				.with(user("테스트용임다"))
-				.param("productId", testOrderProduct.getProduct().getId().toString())
-				.param("page", "1")
-				.param("size", "10")
+			.with(user("테스트용임다"))
+			.param("productId", testOrderProduct.getProduct().getId().toString())
+			.param("page", "1")
+			.param("size", "10")
 		);
 
 		// then
 		actions.andExpect(status().isOk())
-		.andExpect(jsonPath("$.data.list[0].reviewId").value(review.getId().toString()))
-		.andExpect(jsonPath("$.data.list[0].content").value(review.getContent()));
+			.andExpect(jsonPath("$.data.list[0].reviewId").value(review.getId().toString()))
+			.andExpect(jsonPath("$.data.list[0].content").value(review.getContent()));
 	}
 }

--- a/src/test/java/com/kt/api/review/ReviewUpdateTest.java
+++ b/src/test/java/com/kt/api/review/ReviewUpdateTest.java
@@ -1,10 +1,14 @@
 package com.kt.api.review;
 
-import static com.kt.common.CurrentUserCreator.*;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import com.kt.common.SellerEntityCreator;
+import com.kt.domain.entity.SellerEntity;
+import com.kt.repository.account.AccountRepository;
+
+import static com.kt.common.CurrentUserCreator.getMemberUserDetails;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -49,11 +53,13 @@ public class ReviewUpdateTest extends MockMvcTest {
 	OrderRepository orderRepository;
 	@Autowired
 	CategoryRepository categoryRepository;
+	@Autowired
+	AccountRepository accountRepository;
 
 	UserEntity testMember;
-
 	OrderProductEntity testOrderProduct;
 	ProductEntity testProduct;
+	SellerEntity testSeller;
 
 	@BeforeEach
 	void setUp() throws Exception {
@@ -68,10 +74,13 @@ public class ReviewUpdateTest extends MockMvcTest {
 		CategoryEntity category = CategoryEntityCreator.createCategory();
 		categoryRepository.save(category);
 
-		testProduct = ProductCreator.createProduct(category);
+		testSeller = SellerEntityCreator.createSeller();
+		accountRepository.save(testSeller);
+
+		testProduct = ProductCreator.createProduct(category, testSeller);
 		productRepository.save(testProduct);
 
-		testOrderProduct = OrderProductCreator.createOrderProduct(order, testProduct);
+		testOrderProduct = OrderProductCreator.createOrderProduct(order, testProduct, testSeller);
 		orderProductRepository.save(testOrderProduct);
 	}
 

--- a/src/test/java/com/kt/api/review/ReviewUpdateTest.java
+++ b/src/test/java/com/kt/api/review/ReviewUpdateTest.java
@@ -2,7 +2,6 @@ package com.kt.api.review;
 
 import com.kt.common.SellerEntityCreator;
 import com.kt.domain.entity.SellerEntity;
-import com.kt.repository.account.AccountRepository;
 
 import static com.kt.common.CurrentUserCreator.getMemberUserDetails;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -36,6 +35,7 @@ import com.kt.repository.order.OrderRepository;
 import com.kt.repository.orderproduct.OrderProductRepository;
 import com.kt.repository.product.ProductRepository;
 import com.kt.repository.review.ReviewRepository;
+import com.kt.repository.seller.SellerRepository;
 import com.kt.repository.user.UserRepository;
 
 @DisplayName("상품 리뷰 수정 - PATCH /api/reviews/{reviewId}")
@@ -54,7 +54,7 @@ public class ReviewUpdateTest extends MockMvcTest {
 	@Autowired
 	CategoryRepository categoryRepository;
 	@Autowired
-	AccountRepository accountRepository;
+	SellerRepository sellerRepository;
 
 	UserEntity testMember;
 	OrderProductEntity testOrderProduct;
@@ -75,7 +75,7 @@ public class ReviewUpdateTest extends MockMvcTest {
 		categoryRepository.save(category);
 
 		testSeller = SellerEntityCreator.createSeller();
-		accountRepository.save(testSeller);
+		sellerRepository.save(testSeller);
 
 		testProduct = ProductCreator.createProduct(category, testSeller);
 		productRepository.save(testProduct);

--- a/src/test/java/com/kt/api/review/admin/ReviewDeleteTest.java
+++ b/src/test/java/com/kt/api/review/admin/ReviewDeleteTest.java
@@ -1,5 +1,9 @@
 package com.kt.api.review.admin;
 
+import com.kt.common.SellerEntityCreator;
+import com.kt.domain.entity.SellerEntity;
+import com.kt.repository.account.AccountRepository;
+
 import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -49,11 +53,14 @@ public class ReviewDeleteTest extends MockMvcTest {
 	OrderRepository orderRepository;
 	@Autowired
 	CategoryRepository categoryRepository;
+	@Autowired
+	AccountRepository accountRepository;
 
 	OrderProductEntity testOrderProduct;
 	ProductEntity testProduct;
 
 	UserEntity testAdmin;
+	SellerEntity testSeller;
 
 	@BeforeEach
 	void setUp() throws Exception {
@@ -68,10 +75,13 @@ public class ReviewDeleteTest extends MockMvcTest {
 		CategoryEntity category = CategoryEntityCreator.createCategory();
 		categoryRepository.save(category);
 
-		testProduct = ProductCreator.createProduct(category);
+		testSeller = SellerEntityCreator.createSeller();
+		accountRepository.save(testSeller);
+
+		testProduct = ProductCreator.createProduct(category, testSeller);
 		productRepository.save(testProduct);
 
-		testOrderProduct = OrderProductCreator.createOrderProduct(order, testProduct);
+		testOrderProduct = OrderProductCreator.createOrderProduct(order, testProduct, testSeller);
 		orderProductRepository.save(testOrderProduct);
 	}
 

--- a/src/test/java/com/kt/api/review/admin/ReviewDeleteTest.java
+++ b/src/test/java/com/kt/api/review/admin/ReviewDeleteTest.java
@@ -2,7 +2,7 @@ package com.kt.api.review.admin;
 
 import com.kt.common.SellerEntityCreator;
 import com.kt.domain.entity.SellerEntity;
-import com.kt.repository.account.AccountRepository;
+import com.kt.repository.seller.SellerRepository;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
@@ -54,7 +54,7 @@ public class ReviewDeleteTest extends MockMvcTest {
 	@Autowired
 	CategoryRepository categoryRepository;
 	@Autowired
-	AccountRepository accountRepository;
+	SellerRepository sellerRepository;
 
 	OrderProductEntity testOrderProduct;
 	ProductEntity testProduct;
@@ -76,7 +76,7 @@ public class ReviewDeleteTest extends MockMvcTest {
 		categoryRepository.save(category);
 
 		testSeller = SellerEntityCreator.createSeller();
-		accountRepository.save(testSeller);
+		sellerRepository.save(testSeller);
 
 		testProduct = ProductCreator.createProduct(category, testSeller);
 		productRepository.save(testProduct);

--- a/src/test/java/com/kt/api/review/admin/ReviewSearchTest.java
+++ b/src/test/java/com/kt/api/review/admin/ReviewSearchTest.java
@@ -17,6 +17,7 @@ import com.kt.common.MockMvcTest;
 import com.kt.common.OrderProductCreator;
 import com.kt.common.ProductCreator;
 import com.kt.common.ReceiverCreator;
+import com.kt.common.SellerEntityCreator;
 import com.kt.common.UserEntityCreator;
 import com.kt.domain.entity.CategoryEntity;
 import com.kt.domain.entity.OrderEntity;
@@ -24,12 +25,14 @@ import com.kt.domain.entity.OrderProductEntity;
 import com.kt.domain.entity.ProductEntity;
 import com.kt.domain.entity.ReceiverVO;
 import com.kt.domain.entity.ReviewEntity;
+import com.kt.domain.entity.SellerEntity;
 import com.kt.domain.entity.UserEntity;
 import com.kt.repository.CategoryRepository;
 import com.kt.repository.order.OrderRepository;
 import com.kt.repository.orderproduct.OrderProductRepository;
 import com.kt.repository.product.ProductRepository;
 import com.kt.repository.review.ReviewRepository;
+import com.kt.repository.seller.SellerRepository;
 import com.kt.repository.user.UserRepository;
 
 @DisplayName("상품 리뷰 조회 (어드민) - GET /api/admin/reviews")
@@ -47,7 +50,10 @@ public class ReviewSearchTest extends MockMvcTest {
 	OrderRepository orderRepository;
 	@Autowired
 	CategoryRepository categoryRepository;
+	@Autowired
+	SellerRepository sellerRepository;
 
+	SellerEntity testSeller;
 	OrderProductEntity testOrderProduct;
 	ProductEntity testProduct;
 
@@ -64,10 +70,13 @@ public class ReviewSearchTest extends MockMvcTest {
 		CategoryEntity category = CategoryEntityCreator.createCategory();
 		categoryRepository.save(category);
 
-		testProduct = ProductCreator.createProduct(category);
+		SellerEntity seller = SellerEntityCreator.createSeller();
+		testSeller = sellerRepository.save(seller);
+
+		testProduct = ProductCreator.createProduct(category, testSeller);
 		productRepository.save(testProduct);
 
-		testOrderProduct = OrderProductCreator.createOrderProduct(order, testProduct);
+		testOrderProduct = OrderProductCreator.createOrderProduct(order, testProduct, testSeller);
 		orderProductRepository.save(testOrderProduct);
 	}
 
@@ -90,7 +99,7 @@ public class ReviewSearchTest extends MockMvcTest {
 
 		// then
 		actions.andExpect(status().isOk())
-		.andExpect(jsonPath("$.data.list[0].reviewId").value(review.getId().toString()))
-		.andExpect(jsonPath("$.data.list[0].content").value(review.getContent()));
+			.andExpect(jsonPath("$.data.list[0].reviewId").value(review.getId().toString()))
+			.andExpect(jsonPath("$.data.list[0].content").value(review.getContent()));
 	}
 }

--- a/src/test/java/com/kt/api/user/UserSearchReviewTest.java
+++ b/src/test/java/com/kt/api/user/UserSearchReviewTest.java
@@ -1,5 +1,9 @@
 package com.kt.api.user;
 
+import com.kt.common.SellerEntityCreator;
+import com.kt.domain.entity.SellerEntity;
+import com.kt.repository.account.AccountRepository;
+
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
@@ -47,15 +51,18 @@ public class UserSearchReviewTest extends MockMvcTest {
 	OrderRepository orderRepository;
 	@Autowired
 	CategoryRepository categoryRepository;
+	@Autowired
+	AccountRepository accountRepository;
 
 	OrderEntity testOrder;
 	OrderProductEntity testOrderProduct;
 	ProductEntity testProduct;
 	UserEntity testUser;
+	SellerEntity testSeller;
 
 	@BeforeEach
 	void setUp() throws Exception {
-		testUser  = UserEntityCreator.createMember();
+		testUser = UserEntityCreator.createMember();
 		userRepository.save(testUser);
 
 		ReceiverVO receiver = ReceiverCreator.createReceiver();
@@ -66,10 +73,13 @@ public class UserSearchReviewTest extends MockMvcTest {
 		CategoryEntity category = CategoryEntityCreator.createCategory();
 		categoryRepository.save(category);
 
-		testProduct = ProductCreator.createProduct(category);
+		testSeller = SellerEntityCreator.createSeller();
+		accountRepository.save(testSeller);
+
+		testProduct = ProductCreator.createProduct(category, testSeller);
 		productRepository.save(testProduct);
 
-		testOrderProduct = OrderProductCreator.createOrderProduct(testOrder, testProduct);
+		testOrderProduct = OrderProductCreator.createOrderProduct(testOrder, testProduct, testSeller);
 		orderProductRepository.save(testOrderProduct);
 	}
 
@@ -83,8 +93,8 @@ public class UserSearchReviewTest extends MockMvcTest {
 		ResultActions Actions = mockMvc.perform(
 			get("/api/reviews/mine")
 				.with(user(CurrentUserCreator.getMemberUserDetails(testUser.getId())))
-				.param("page","1")
-				.param("size","10")
+				.param("page", "1")
+				.param("size", "10")
 		).andDo(print());
 
 		// then
@@ -105,8 +115,8 @@ public class UserSearchReviewTest extends MockMvcTest {
 		ResultActions Actions = mockMvc.perform(
 			get("/api/reviews/mine")
 				.with(user(CurrentUserCreator.getMemberUserDetails()))
-				.param("page","1")
-				.param("size","10")
+				.param("page", "1")
+				.param("size", "10")
 		).andDo(print());
 
 		// then

--- a/src/test/java/com/kt/api/user/UserSearchReviewTest.java
+++ b/src/test/java/com/kt/api/user/UserSearchReviewTest.java
@@ -2,7 +2,7 @@ package com.kt.api.user;
 
 import com.kt.common.SellerEntityCreator;
 import com.kt.domain.entity.SellerEntity;
-import com.kt.repository.account.AccountRepository;
+import com.kt.repository.seller.SellerRepository;
 
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -52,7 +52,7 @@ public class UserSearchReviewTest extends MockMvcTest {
 	@Autowired
 	CategoryRepository categoryRepository;
 	@Autowired
-	AccountRepository accountRepository;
+	SellerRepository sellerRepository;
 
 	OrderEntity testOrder;
 	OrderProductEntity testOrderProduct;
@@ -74,7 +74,7 @@ public class UserSearchReviewTest extends MockMvcTest {
 		categoryRepository.save(category);
 
 		testSeller = SellerEntityCreator.createSeller();
-		accountRepository.save(testSeller);
+		sellerRepository.save(testSeller);
 
 		testProduct = ProductCreator.createProduct(category, testSeller);
 		productRepository.save(testProduct);

--- a/src/test/java/com/kt/api/user/UserSearchReviewableTest.java
+++ b/src/test/java/com/kt/api/user/UserSearchReviewableTest.java
@@ -1,5 +1,9 @@
 package com.kt.api.user;
 
+import com.kt.common.SellerEntityCreator;
+import com.kt.domain.entity.SellerEntity;
+import com.kt.repository.account.AccountRepository;
+
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
@@ -47,11 +51,14 @@ public class UserSearchReviewableTest extends MockMvcTest {
 	OrderRepository orderRepository;
 	@Autowired
 	CategoryRepository categoryRepository;
+	@Autowired
+	AccountRepository accountRepository;
 
 	OrderEntity testOrder;
 	OrderProductEntity testOrderProduct;
 	ProductEntity testProduct;
 	UserEntity testUser;
+	SellerEntity testSeller;
 
 	@BeforeEach
 	void setUp() throws Exception {
@@ -66,13 +73,15 @@ public class UserSearchReviewableTest extends MockMvcTest {
 		CategoryEntity category = CategoryEntityCreator.createCategory();
 		categoryRepository.save(category);
 
-		testProduct = ProductCreator.createProduct(category);
+		testSeller = SellerEntityCreator.createSeller();
+		accountRepository.save(testSeller);
+
+		testProduct = ProductCreator.createProduct(category, testSeller);
 		productRepository.save(testProduct);
 
-		testOrderProduct = OrderProductCreator.createOrderProduct(testOrder, testProduct);
+		testOrderProduct = OrderProductCreator.createOrderProduct(testOrder, testProduct, testSeller);
 		orderProductRepository.save(testOrderProduct);
 	}
-
 
 	@Test
 	void 주문상품조회_성공__200_OK() throws Exception {
@@ -84,8 +93,8 @@ public class UserSearchReviewableTest extends MockMvcTest {
 		ResultActions Actions = mockMvc.perform(
 			get("/api/users/reviewable-products")
 				.with(user(CurrentUserCreator.getMemberUserDetails(testUser.getId())))
-				.param("page","1")
-				.param("size","10")
+				.param("page", "1")
+				.param("size", "10")
 		).andDo(print());
 
 		// then
@@ -94,7 +103,6 @@ public class UserSearchReviewableTest extends MockMvcTest {
 			.andExpect(jsonPath("$.data.totalCount").value(1))
 			.andExpect(jsonPath("$.data.list[0].orderProductId").value(testOrderProduct.getId().toString()));
 	}
-
 
 	@Test
 	void 주문상품조회_실패__작성된리뷰존재_주문상품없음() throws Exception {
@@ -108,8 +116,8 @@ public class UserSearchReviewableTest extends MockMvcTest {
 		ResultActions Actions = mockMvc.perform(
 			get("/api/users/reviewable-products")
 				.with(user(CurrentUserCreator.getMemberUserDetails(testUser.getId())))
-				.param("page","1")
-				.param("size","10")
+				.param("page", "1")
+				.param("size", "10")
 		).andDo(print());
 
 		// then
@@ -128,8 +136,8 @@ public class UserSearchReviewableTest extends MockMvcTest {
 		ResultActions Actions = mockMvc.perform(
 			get("/api/users/reviewable-products")
 				.with(user(CurrentUserCreator.getMemberUserDetails(testUser.getId())))
-				.param("page","1")
-				.param("size","10")
+				.param("page", "1")
+				.param("size", "10")
 		).andDo(print());
 
 		// then

--- a/src/test/java/com/kt/api/user/UserSearchReviewableTest.java
+++ b/src/test/java/com/kt/api/user/UserSearchReviewableTest.java
@@ -2,7 +2,7 @@ package com.kt.api.user;
 
 import com.kt.common.SellerEntityCreator;
 import com.kt.domain.entity.SellerEntity;
-import com.kt.repository.account.AccountRepository;
+import com.kt.repository.seller.SellerRepository;
 
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -52,7 +52,7 @@ public class UserSearchReviewableTest extends MockMvcTest {
 	@Autowired
 	CategoryRepository categoryRepository;
 	@Autowired
-	AccountRepository accountRepository;
+	SellerRepository sellerRepository;
 
 	OrderEntity testOrder;
 	OrderProductEntity testOrderProduct;
@@ -74,7 +74,7 @@ public class UserSearchReviewableTest extends MockMvcTest {
 		categoryRepository.save(category);
 
 		testSeller = SellerEntityCreator.createSeller();
-		accountRepository.save(testSeller);
+		sellerRepository.save(testSeller);
 
 		testProduct = ProductCreator.createProduct(category, testSeller);
 		productRepository.save(testProduct);

--- a/src/test/java/com/kt/common/OrderProductCreator.java
+++ b/src/test/java/com/kt/common/OrderProductCreator.java
@@ -12,14 +12,13 @@ public class OrderProductCreator {
 		OrderEntity order,
 		ProductEntity product,
 		SellerEntity seller
-	){
+	) {
 		return OrderProductEntity.create(
 			5L,
 			5000L,
 			OrderProductStatus.CREATED,
 			order,
-			product,
-			seller
+			product
 		);
 	}
 }

--- a/src/test/java/com/kt/common/OrderProductCreator.java
+++ b/src/test/java/com/kt/common/OrderProductCreator.java
@@ -5,17 +5,21 @@ import com.kt.domain.entity.OrderEntity;
 import com.kt.domain.entity.OrderProductEntity;
 import com.kt.domain.entity.ProductEntity;
 
+import com.kt.domain.entity.SellerEntity;
+
 public class OrderProductCreator {
 	public static OrderProductEntity createOrderProduct(
 		OrderEntity order,
-		ProductEntity product
+		ProductEntity product,
+		SellerEntity seller
 	){
-		return new OrderProductEntity(
+		return OrderProductEntity.create(
 			5L,
 			5000L,
 			OrderProductStatus.CREATED,
 			order,
-			product
+			product,
+			seller
 		);
 	}
 }

--- a/src/test/java/com/kt/common/ProductCreator.java
+++ b/src/test/java/com/kt/common/ProductCreator.java
@@ -3,13 +3,16 @@ package com.kt.common;
 import com.kt.domain.entity.CategoryEntity;
 import com.kt.domain.entity.ProductEntity;
 
+import com.kt.domain.entity.SellerEntity;
+
 public class ProductCreator {
-	public static ProductEntity createProduct(CategoryEntity category){
+	public static ProductEntity createProduct(CategoryEntity category, SellerEntity seller){
 		return ProductEntity.create(
 			"테스트상품명",
 			1000L,
 			5L,
-			category
+			category,
+			seller
 		);
 	}
 }

--- a/src/test/java/com/kt/common/ProductEntityCreator.java
+++ b/src/test/java/com/kt/common/ProductEntityCreator.java
@@ -5,14 +5,17 @@ import java.util.UUID;
 import com.kt.domain.entity.CategoryEntity;
 import com.kt.domain.entity.ProductEntity;
 
+import com.kt.domain.entity.SellerEntity;
+
 public class ProductEntityCreator {
 
-	public static ProductEntity createProduct(CategoryEntity category) {
+	public static ProductEntity createProduct(CategoryEntity category, SellerEntity seller) {
 		return ProductEntity.create(
 			"상품" + UUID.randomUUID(),
 			1000L,
 			1000L,
-			category
+			category,
+			seller
 		);
 	}
 }

--- a/src/test/java/com/kt/common/SellerEntityCreator.java
+++ b/src/test/java/com/kt/common/SellerEntityCreator.java
@@ -1,0 +1,31 @@
+package com.kt.common;
+
+import com.kt.constant.Gender;
+import com.kt.domain.entity.SellerEntity;
+
+public class SellerEntityCreator {
+
+    public static SellerEntity createSeller(String email, String password) {
+        return SellerEntity.create(
+                "판매자1",
+                email,
+                password,
+                "상점1",
+                "010-1234-5678",
+                "seller@test.com",
+                Gender.MALE
+        );
+    }
+
+    public static SellerEntity createSeller() {
+        return SellerEntity.create(
+                "판매자1",
+                "seller@test.com",
+                "1234",
+                "상점1",
+                "010-1234-5678",
+                "seller@test.com",
+                Gender.MALE
+        );
+    }
+}

--- a/src/test/java/com/kt/domain/entity/BankAccountEntityTest.java
+++ b/src/test/java/com/kt/domain/entity/BankAccountEntityTest.java
@@ -18,6 +18,6 @@ public class BankAccountEntityTest {
 
 		assertNotNull(bankAccount);
 		assertEquals(0L, bankAccount.getBalance());
-		assertEquals(bankAccount.getUser(), testUser);
+		assertEquals(bankAccount.getAccount(), testUser);
 	}
 }

--- a/src/test/java/com/kt/domain/entity/CartEntityTest.java
+++ b/src/test/java/com/kt/domain/entity/CartEntityTest.java
@@ -32,11 +32,21 @@ class CartEntityTest {
 		);
 
 		testCategory = CategoryEntity.create("테스트 카테고리", null);
+		SellerEntity testSeller = SellerEntity.create(
+			"판매자1",
+			"seller@test.com",
+			"1234",
+			"상점1",
+			"010-1234-5678",
+			"seller@test.com",
+			Gender.MALE
+		);
 		testProduct = ProductEntity.create(
 			"테스트상품명",
 			1000L,
 			5L,
-			testCategory
+			testCategory,
+			testSeller
 		);
 	}
 

--- a/src/test/java/com/kt/domain/entity/PaymentEntityTest.java
+++ b/src/test/java/com/kt/domain/entity/PaymentEntityTest.java
@@ -48,11 +48,22 @@ class PaymentEntityTest {
 			user
 		);
 
+		SellerEntity testSeller = SellerEntity.create(
+			"판매자1",
+			"seller@test.com",
+			"1234",
+			"상점1",
+			"010-1234-5678",
+			"seller@test.com",
+			Gender.MALE
+		);
+
 		ProductEntity product= ProductEntity.create(
 			"테스트상품명",
 			1000L,
 			5L,
-			testCategory
+			testCategory,
+			testSeller
 		);
 
 		orderProductEntity = new OrderProductEntity(
@@ -60,7 +71,8 @@ class PaymentEntityTest {
 		5000L,
 			OrderProductStatus.CREATED,
 			order,
-			product
+			product,
+			testSeller
 		);
 	}
 

--- a/src/test/java/com/kt/domain/entity/PaymentEntityTest.java
+++ b/src/test/java/com/kt/domain/entity/PaymentEntityTest.java
@@ -32,7 +32,7 @@ class PaymentEntityTest {
 			Gender.MALE,
 			LocalDate.now(),
 			"010-1234-5678"
-		)	;
+		);
 
 		ReceiverVO receiver = new ReceiverVO(
 			"수신자테스터1",
@@ -58,7 +58,7 @@ class PaymentEntityTest {
 			Gender.MALE
 		);
 
-		ProductEntity product= ProductEntity.create(
+		ProductEntity product = ProductEntity.create(
 			"테스트상품명",
 			1000L,
 			5L,
@@ -67,17 +67,16 @@ class PaymentEntityTest {
 		);
 
 		orderProductEntity = new OrderProductEntity(
-		5L,
-		5000L,
+			5L,
+			5000L,
 			OrderProductStatus.CREATED,
 			order,
-			product,
-			testSeller
+			product
 		);
 	}
 
 	@Test
-	void 객체생성_성공(){
+	void 객체생성_성공() {
 		PaymentEntity comparisonProduct = PaymentEntity.create(
 			50000L,
 			3000L,

--- a/src/test/java/com/kt/domain/entity/ProductEntityTest.java
+++ b/src/test/java/com/kt/domain/entity/ProductEntityTest.java
@@ -2,6 +2,7 @@ package com.kt.domain.entity;
 
 import static org.assertj.core.api.Assertions.*;
 
+import com.kt.constant.Gender;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ActiveProfiles;
 
@@ -17,18 +18,30 @@ class ProductEntityTest {
 			null
 		);
 
+		SellerEntity testSeller = SellerEntity.create(
+			"판매자1",
+			"seller@test.com",
+			"1234",
+			"상점1",
+			"010-1234-5678",
+			"seller@test.com",
+			Gender.MALE
+		);
+
 		ProductEntity comparisonProduct = ProductEntity.create(
 			"테스트상품명",
 			1000L,
 			5L,
-			testCategory
+			testCategory,
+			testSeller
 		);
 
 		ProductEntity subjectProduct = ProductEntity.create(
 			"테스트상품명",
 			1000L,
 			5L,
-			testCategory
+			testCategory,
+			testSeller
 		);
 
 		assertThat(subjectProduct).isNotNull();

--- a/src/test/java/com/kt/domain/entity/ShippingDetailEntityTest.java
+++ b/src/test/java/com/kt/domain/entity/ShippingDetailEntityTest.java
@@ -71,8 +71,7 @@ class ShippingDetailEntityTest {
 			5000L,
 			OrderProductStatus.CREATED,
 			order,
-			product,
-			testSeller
+			product
 		);
 
 		testCourier = CourierEntity.create(

--- a/src/test/java/com/kt/domain/entity/ShippingDetailEntityTest.java
+++ b/src/test/java/com/kt/domain/entity/ShippingDetailEntityTest.java
@@ -1,6 +1,5 @@
 package com.kt.domain.entity;
 
-
 import java.time.LocalDate;
 
 import org.junit.jupiter.api.Assertions;
@@ -49,11 +48,22 @@ class ShippingDetailEntityTest {
 			null
 		);
 
-		ProductEntity product= ProductEntity.create(
+		SellerEntity testSeller = SellerEntity.create(
+			"판매자1",
+			"seller@test.com",
+			"1234",
+			"상점1",
+			"010-1234-5678",
+			"seller@test.com",
+			Gender.MALE
+		);
+
+		ProductEntity product = ProductEntity.create(
 			"테스트상품명",
 			1000L,
 			5L,
-			tempCategory
+			tempCategory,
+			testSeller
 		);
 
 		testOrderProduct = new OrderProductEntity(
@@ -61,7 +71,8 @@ class ShippingDetailEntityTest {
 			5000L,
 			OrderProductStatus.CREATED,
 			order,
-			product
+			product,
+			testSeller
 		);
 
 		testCourier = CourierEntity.create(
@@ -73,7 +84,7 @@ class ShippingDetailEntityTest {
 	}
 
 	@Test
-	void 객체생성_성공(){
+	void 객체생성_성공() {
 		ShippingDetailEntity shippingDetailEntity = ShippingDetailEntity.create(
 			testCourier,
 			testOrderProduct

--- a/src/test/java/com/kt/service/OrderServiceTest.java
+++ b/src/test/java/com/kt/service/OrderServiceTest.java
@@ -47,6 +47,7 @@ import com.kt.repository.order.OrderRepository;
 import com.kt.repository.orderproduct.OrderProductRepository;
 import com.kt.repository.product.ProductRepository;
 import com.kt.repository.review.ReviewRepository;
+import com.kt.repository.seller.SellerRepository;
 import com.kt.repository.user.UserRepository;
 
 @Transactional
@@ -71,11 +72,11 @@ class OrderServiceTest {
 	@Autowired
 	AddressRepository addressRepository;
 	@Autowired
-	AccountRepository accountRepository;
-	@Autowired
 	ShippingDetailRepository shippingDetailRepository;
 	@Autowired
 	CourierRepository courierRepository;
+	@Autowired
+	SellerRepository sellerRepository;
 
 	CategoryEntity category;
 	SellerEntity testSeller;
@@ -83,7 +84,7 @@ class OrderServiceTest {
 	@BeforeEach
 	void setup() {
 		category = categoryRepository.save(CategoryEntityCreator.createCategory());
-		testSeller = (SellerEntity)accountRepository.save(SellerEntityCreator.createSeller());
+		testSeller = sellerRepository.save(SellerEntityCreator.createSeller());
 	}
 
 	OrderEntity createOrder(UserEntity user) {
@@ -98,7 +99,7 @@ class OrderServiceTest {
 	OrderProductEntity createOrderWithProducts(OrderEntity order, long quantity) {
 
 		ProductEntity product = productRepository.save(
-			ProductEntityCreator.createProduct(category)
+			ProductEntityCreator.createProduct(category, testSeller)
 		);
 
 		OrderProductEntity orderProduct = OrderProductEntity.create(
@@ -114,7 +115,6 @@ class OrderServiceTest {
 
 		return orderProductRepository.save(orderProduct);
 	}
-
 
 	@Test
 	void 주문_생성_성공() {
@@ -321,6 +321,5 @@ class OrderServiceTest {
 			.isInstanceOf(CustomException.class)
 			.hasMessageContaining(ErrorCode.ORDER_ALREADY_SHIPPED.name());
 	}
-
 
 }

--- a/src/test/java/com/kt/service/OrderServiceTest.java
+++ b/src/test/java/com/kt/service/OrderServiceTest.java
@@ -107,8 +107,7 @@ class OrderServiceTest {
 			product.getPrice(),
 			OrderProductStatus.CREATED,
 			order,
-			product,
-			testSeller
+			product
 		);
 
 		order.addOrderProduct(orderProduct);

--- a/src/test/java/com/kt/service/OrderServiceTest.java
+++ b/src/test/java/com/kt/service/OrderServiceTest.java
@@ -5,6 +5,10 @@ import static org.assertj.core.api.Assertions.*;
 import java.util.List;
 import java.util.UUID;
 
+import com.kt.common.SellerEntityCreator;
+import com.kt.domain.entity.SellerEntity;
+import com.kt.repository.account.AccountRepository;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -67,15 +71,19 @@ class OrderServiceTest {
 	@Autowired
 	AddressRepository addressRepository;
 	@Autowired
+	AccountRepository accountRepository;
+	@Autowired
 	ShippingDetailRepository shippingDetailRepository;
 	@Autowired
 	CourierRepository courierRepository;
 
 	CategoryEntity category;
+	SellerEntity testSeller;
 
 	@BeforeEach
 	void setup() {
 		category = categoryRepository.save(CategoryEntityCreator.createCategory());
+		testSeller = (SellerEntity)accountRepository.save(SellerEntityCreator.createSeller());
 	}
 
 	OrderEntity createOrder(UserEntity user) {
@@ -98,7 +106,8 @@ class OrderServiceTest {
 			product.getPrice(),
 			OrderProductStatus.CREATED,
 			order,
-			product
+			product,
+			testSeller
 		);
 
 		order.addOrderProduct(orderProduct);
@@ -113,12 +122,12 @@ class OrderServiceTest {
 		UserEntity user = userRepository.save(UserEntityCreator.createMember());
 		AddressEntity address = addressRepository.save(AddressCreator.createAddress(user));
 
-		ProductEntity product1 = productRepository.save(ProductEntityCreator.createProduct(category));
-		ProductEntity product2 = productRepository.save(ProductEntityCreator.createProduct(category));
+		ProductEntity product1 = productRepository.save(ProductEntityCreator.createProduct(category, testSeller));
+		ProductEntity product2 = productRepository.save(ProductEntityCreator.createProduct(category, testSeller));
 
 		List<OrderRequest.Item> items = List.of(
-			new OrderRequest.Item(product1.getId(), 2L),
-			new OrderRequest.Item(product2.getId(), 3L)
+			new OrderRequest.Item(product1.getId(), 2L, testSeller.getId()),
+			new OrderRequest.Item(product2.getId(), 3L, testSeller.getId())
 		);
 
 		// when
@@ -140,7 +149,7 @@ class OrderServiceTest {
 
 		UUID invalidId = UUID.fromString("11111111-2222-3333-4444-555555555555");
 		List<OrderRequest.Item> items = List.of(
-			new OrderRequest.Item(invalidId, 1L));
+			new OrderRequest.Item(invalidId, 1L, testSeller.getId()));
 
 		// when, then
 		assertThatThrownBy(() -> orderService.createOrder(user.getEmail(), items, address.getId()))
@@ -154,10 +163,10 @@ class OrderServiceTest {
 		// given
 		UserEntity user = userRepository.save(UserEntityCreator.createMember());
 		AddressEntity address = addressRepository.save(AddressCreator.createAddress(user));
-		ProductEntity product = productRepository.save(ProductEntityCreator.createProduct(category));
+		ProductEntity product = productRepository.save(ProductEntityCreator.createProduct(category, testSeller));
 
 		List<OrderRequest.Item> items = List.of(
-			new OrderRequest.Item(product.getId(), 99999999L)
+			new OrderRequest.Item(product.getId(), 99999999L, testSeller.getId())
 		);
 
 		// then

--- a/src/test/java/com/kt/service/ProductServiceTest.java
+++ b/src/test/java/com/kt/service/ProductServiceTest.java
@@ -5,6 +5,11 @@ import static org.assertj.core.api.Assertions.*;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.kt.common.SellerEntityCreator;
+import com.kt.domain.entity.SellerEntity;
+import com.kt.repository.account.AccountRepository;
+
+import org.junit.jupiter.api.BeforeEach;
 import com.kt.constant.AccountRole;
 
 import org.junit.jupiter.api.Test;
@@ -30,17 +35,24 @@ import com.kt.repository.product.ProductRepository;
 class ProductServiceTest {
 
 	private final ProductService productService;
-
 	private final ProductRepository productRepository;
-
 	private final CategoryRepository categoryRepository;
+	private final AccountRepository accountRepository;
+	private SellerEntity testSeller;
 
 	@Autowired
 	ProductServiceTest(ProductService productService, ProductRepository productRepository,
-		CategoryRepository categoryRepository) {
+		CategoryRepository categoryRepository, AccountRepository accountRepository) {
 		this.productService = productService;
 		this.productRepository = productRepository;
 		this.categoryRepository = categoryRepository;
+		this.accountRepository = accountRepository;
+	}
+
+	@BeforeEach
+	void setUp() {
+		this.testSeller = SellerEntityCreator.createSeller();
+		this.accountRepository.save(testSeller);
 	}
 
 	@Test
@@ -54,11 +66,13 @@ class ProductServiceTest {
 		ProductRequest.Create request = new ProductRequest.Create(
 			productName,
 			productPrice,
-			10L
+			10L,
+			category.getId(),
+			testSeller.getId()
 		);
 
 		// when
-		productService.create(request.name(), request.price(), request.stock(), category.getId());
+		productService.create(request.name(), request.price(), request.stock(), request.categoryId(), request.sellerId());
 
 		// then
 		ProductEntity product = productRepository.findAll()
@@ -68,6 +82,7 @@ class ProductServiceTest {
 			.orElseThrow();
 
 		assertThat(product.getPrice()).isEqualTo(productPrice);
+		assertThat(product.getSeller().getId()).isEqualTo(testSeller.getId());
 	}
 
 	@Test
@@ -83,7 +98,8 @@ class ProductServiceTest {
 			"상품1",
 			1000L,
 			10L,
-			category
+			category,
+			testSeller
 		);
 
 		productRepository.save(product);
@@ -120,7 +136,8 @@ class ProductServiceTest {
 			"상품1",
 			1000L,
 			10L,
-			category
+			category,
+			testSeller
 		);
 		productRepository.save(product);
 
@@ -144,7 +161,8 @@ class ProductServiceTest {
 				"상품" + i,
 				1000L,
 				10L,
-				category
+				category,
+				testSeller
 			);
 			products.add(product);
 		}
@@ -174,7 +192,8 @@ class ProductServiceTest {
 				"상품" + i,
 				1000L,
 				10L,
-				categoryDog
+				categoryDog,
+				testSeller
 			);
 			products.add(product);
 		}
@@ -184,7 +203,8 @@ class ProductServiceTest {
 				"상품" + i,
 				1000L,
 				10L,
-				categorySports
+				categorySports,
+				testSeller
 			);
 			products.add(product);
 		}
@@ -216,7 +236,8 @@ class ProductServiceTest {
 				"상품" + i,
 				1000L,
 				10L,
-				categorySports
+				categorySports,
+				testSeller
 			);
 			productRepository.save(product);
 		}
@@ -241,7 +262,7 @@ class ProductServiceTest {
 		// given
 		CategoryEntity categorySports = CategoryEntity.create("운동", null);
 		categoryRepository.save(categorySports);
-		ProductEntity product = ProductEntity.create("상품", 1000L, 10L, categorySports);
+		ProductEntity product = ProductEntity.create("상품", 1000L, 10L, categorySports, testSeller);
 		productRepository.save(product);
 
 		// when
@@ -257,7 +278,7 @@ class ProductServiceTest {
 		// given
 		CategoryEntity categorySports = CategoryEntity.create("운동", null);
 		categoryRepository.save(categorySports);
-		ProductEntity product = ProductEntity.create("상품", 1000L, 10L, categorySports);
+		ProductEntity product = ProductEntity.create("상품", 1000L, 10L, categorySports, testSeller);
 		productRepository.save(product);
 
 		// when
@@ -273,7 +294,7 @@ class ProductServiceTest {
 		// given
 		CategoryEntity categorySports = CategoryEntity.create("운동", null);
 		categoryRepository.save(categorySports);
-		ProductEntity product = ProductEntity.create("상품", 1000L, 10L, categorySports);
+		ProductEntity product = ProductEntity.create("상품", 1000L, 10L, categorySports, testSeller);
 		productRepository.save(product);
 
 		// when
@@ -289,7 +310,7 @@ class ProductServiceTest {
 		// given
 		CategoryEntity categorySports = CategoryEntity.create("운동", null);
 		categoryRepository.save(categorySports);
-		ProductEntity product = ProductEntity.create("상품", 1000L, 10L, categorySports);
+		ProductEntity product = ProductEntity.create("상품", 1000L, 10L, categorySports, testSeller);
 		productRepository.save(product);
 		productService.inActivate(product.getId());
 
@@ -306,7 +327,7 @@ class ProductServiceTest {
 		// given
 		CategoryEntity categorySports = CategoryEntity.create("운동", null);
 		categoryRepository.save(categorySports);
-		ProductEntity product = ProductEntity.create("상품", 1000L, 10L, categorySports);
+		ProductEntity product = ProductEntity.create("상품", 1000L, 10L, categorySports, testSeller);
 		productRepository.save(product);
 		productService.activate(product.getId());
 
@@ -329,7 +350,8 @@ class ProductServiceTest {
 				"상품" + i,
 				1000L,
 				10L,
-				categorySports
+				categorySports,
+				testSeller
 			);
 			products.add(product);
 		}

--- a/src/test/java/com/kt/service/ProductServiceTest.java
+++ b/src/test/java/com/kt/service/ProductServiceTest.java
@@ -28,6 +28,7 @@ import com.kt.domain.entity.CategoryEntity;
 import com.kt.domain.entity.ProductEntity;
 import com.kt.repository.CategoryRepository;
 import com.kt.repository.product.ProductRepository;
+import com.kt.repository.seller.SellerRepository;
 
 @ActiveProfiles("test")
 @SpringBootTest
@@ -37,22 +38,22 @@ class ProductServiceTest {
 	private final ProductService productService;
 	private final ProductRepository productRepository;
 	private final CategoryRepository categoryRepository;
-	private final AccountRepository accountRepository;
+	private final SellerRepository sellerRepository;
 	private SellerEntity testSeller;
 
 	@Autowired
 	ProductServiceTest(ProductService productService, ProductRepository productRepository,
-		CategoryRepository categoryRepository, AccountRepository accountRepository) {
+		CategoryRepository categoryRepository, AccountRepository accountRepository, SellerRepository sellerRepository) {
 		this.productService = productService;
 		this.productRepository = productRepository;
 		this.categoryRepository = categoryRepository;
-		this.accountRepository = accountRepository;
+		this.sellerRepository = sellerRepository;
 	}
 
 	@BeforeEach
 	void setUp() {
 		this.testSeller = SellerEntityCreator.createSeller();
-		this.accountRepository.save(testSeller);
+		this.sellerRepository.save(testSeller);
 	}
 
 	@Test

--- a/src/test/java/com/kt/service/ReviewServiceTest.java
+++ b/src/test/java/com/kt/service/ReviewServiceTest.java
@@ -4,6 +4,7 @@ import static com.kt.common.CategoryEntityCreator.*;
 import static com.kt.common.OrderEntityCreator.*;
 import static com.kt.common.OrderProductCreator.*;
 import static com.kt.common.ProductCreator.*;
+import static com.kt.common.SellerEntityCreator.*;
 import static com.kt.common.UserEntityCreator.*;
 import static org.assertj.core.api.Assertions.*;
 
@@ -21,6 +22,8 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.kt.common.SellerEntityCreator;
+import com.kt.constant.OrderStatus;
 import com.kt.constant.OrderProductStatus;
 import com.kt.constant.ReviewStatus;
 import com.kt.constant.message.ErrorCode;
@@ -30,10 +33,12 @@ import com.kt.domain.entity.OrderEntity;
 import com.kt.domain.entity.OrderProductEntity;
 import com.kt.domain.entity.ProductEntity;
 import com.kt.domain.entity.ReviewEntity;
+import com.kt.domain.entity.SellerEntity;
 import com.kt.domain.entity.UserEntity;
 import com.kt.exception.CustomException;
 import com.kt.repository.CategoryRepository;
 import com.kt.repository.order.OrderRepository;
+import com.kt.repository.account.AccountRepository;
 import com.kt.repository.orderproduct.OrderProductRepository;
 import com.kt.repository.product.ProductRepository;
 import com.kt.repository.review.ReviewRepository;
@@ -59,14 +64,20 @@ class ReviewServiceTest {
 	OrderRepository orderRepository;
 	@Autowired
 	CategoryRepository categoryRepository;
+	@Autowired
+	AccountRepository accountRepository;
 
 	OrderProductEntity testOrderProduct;
 	UserEntity testUser;
+	SellerEntity testSeller;
 
 	@BeforeEach
 	void setUp() throws Exception {
 		testUser = createMember();
 		userRepository.save(testUser);
+
+		testSeller = createSeller();
+		accountRepository.save(testSeller);
 
 		CategoryEntity category = createCategory();
 		categoryRepository.save(category);
@@ -74,10 +85,10 @@ class ReviewServiceTest {
 		OrderEntity order = createOrderEntity(testUser);
 		orderRepository.save(order);
 
-		ProductEntity product = createProduct(category);
+		ProductEntity product = createProduct(category, testSeller);
 		productRepository.save(product);
 
-		testOrderProduct = createOrderProduct(order, product);
+		testOrderProduct = createOrderProduct(order, product, testSeller);
 		orderProductRepository.save(testOrderProduct);
 
 		order.getOrderProducts().add(testOrderProduct);

--- a/src/test/java/com/kt/service/ReviewServiceTest.java
+++ b/src/test/java/com/kt/service/ReviewServiceTest.java
@@ -22,8 +22,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.kt.common.SellerEntityCreator;
-import com.kt.constant.OrderStatus;
 import com.kt.constant.OrderProductStatus;
 import com.kt.constant.ReviewStatus;
 import com.kt.constant.message.ErrorCode;
@@ -38,10 +36,10 @@ import com.kt.domain.entity.UserEntity;
 import com.kt.exception.CustomException;
 import com.kt.repository.CategoryRepository;
 import com.kt.repository.order.OrderRepository;
-import com.kt.repository.account.AccountRepository;
 import com.kt.repository.orderproduct.OrderProductRepository;
 import com.kt.repository.product.ProductRepository;
 import com.kt.repository.review.ReviewRepository;
+import com.kt.repository.seller.SellerRepository;
 import com.kt.repository.user.UserRepository;
 
 @Transactional
@@ -65,7 +63,7 @@ class ReviewServiceTest {
 	@Autowired
 	CategoryRepository categoryRepository;
 	@Autowired
-	AccountRepository accountRepository;
+	SellerRepository sellerRepository;
 
 	OrderProductEntity testOrderProduct;
 	UserEntity testUser;
@@ -77,7 +75,7 @@ class ReviewServiceTest {
 		userRepository.save(testUser);
 
 		testSeller = createSeller();
-		accountRepository.save(testSeller);
+		sellerRepository.save(testSeller);
 
 		CategoryEntity category = createCategory();
 		categoryRepository.save(category);

--- a/src/test/java/com/kt/service/UserServiceTest.java
+++ b/src/test/java/com/kt/service/UserServiceTest.java
@@ -5,6 +5,9 @@ import static org.assertj.core.api.Assertions.*;
 import java.time.LocalDate;
 import java.util.UUID;
 
+import com.kt.common.SellerEntityCreator;
+import com.kt.domain.entity.SellerEntity;
+import com.kt.repository.account.AccountRepository;
 import com.kt.constant.AccountRole;
 
 import org.junit.jupiter.api.AfterEach;
@@ -63,6 +66,8 @@ class UserServiceTest {
 	ProductRepository productRepository;
 	@Autowired
 	CategoryRepository categoryRepository;
+	@Autowired
+	AccountRepository accountRepository;
 
 	UserEntity testUser;
 	UserEntity testUser2;
@@ -70,6 +75,7 @@ class UserServiceTest {
 	OrderEntity testOrder;
 	ProductEntity testProduct;
 	OrderProductEntity testOrderProduct;
+	SellerEntity testSeller;
 	UUID userId;
 	UUID AdminId;
 
@@ -81,6 +87,7 @@ class UserServiceTest {
 		userRepository.deleteAll();
 		productRepository.deleteAll();
 		categoryRepository.deleteAll();
+		accountRepository.deleteAll();
 	}
 
 	@BeforeEach
@@ -139,11 +146,15 @@ class UserServiceTest {
 		CategoryEntity category = CategoryEntity.create("카테고리", null);
 		categoryRepository.save(category);
 
+		testSeller = SellerEntityCreator.createSeller();
+		accountRepository.save(testSeller);
+
 		testProduct = ProductEntity.create(
 			"테스트상품명",
 			1000L,
 			5L,
-			category
+			category,
+			testSeller
 		);
 		productRepository.save(testProduct);
 
@@ -152,7 +163,8 @@ class UserServiceTest {
 			5000L,
 			OrderProductStatus.CREATED,
 			testOrder,
-			testProduct
+			testProduct,
+			testSeller
 		);
 		orderProductRepository.save(testOrderProduct);
 	}
@@ -180,7 +192,8 @@ class UserServiceTest {
 			"테스트물건",
 			3L,
 			3L,
-			category
+			category,
+			testSeller
 		);
 
 		ProductEntity savedProduct = productRepository.save(product);
@@ -447,11 +460,32 @@ class UserServiceTest {
 		);
 		UserEntity savedUser = userRepository.save(user);
 
+		CategoryEntity category = categoryRepository.save(CategoryEntity.create("카테고리", null));
+
+		ProductEntity product = ProductEntity.create(
+			"삭제상품",
+			1000L,
+			5L,
+			category,
+			testSeller
+		);
+		ProductEntity savedProduct = productRepository.save(product);
+
 		OrderEntity order = OrderEntity.create(
 			ReceiverVO.create("이름", "번호", "도시", "시군구", "동", "상세"),
 			savedUser
 		);
 		OrderEntity savedOrder = orderRepository.save(order);
+
+		OrderProductEntity orderProduct = OrderProductEntity.create(
+			1L,
+			1000L,
+			OrderProductStatus.CREATED,
+			savedOrder,
+			savedProduct,
+			testSeller
+		);
+		orderProductRepository.save(orderProduct);
 
 		// when
 		userService.deleteUserPermanently(testAdmin.getId(), savedUser.getId());

--- a/src/test/java/com/kt/service/UserServiceTest.java
+++ b/src/test/java/com/kt/service/UserServiceTest.java
@@ -168,8 +168,7 @@ class UserServiceTest {
 			5000L,
 			OrderProductStatus.CREATED,
 			testOrder,
-			testProduct,
-			testSeller
+			testProduct
 		);
 		orderProductRepository.save(testOrderProduct);
 	}
@@ -487,8 +486,7 @@ class UserServiceTest {
 			1000L,
 			OrderProductStatus.CREATED,
 			savedOrder,
-			savedProduct,
-			testSeller
+			savedProduct
 		);
 		orderProductRepository.save(orderProduct);
 

--- a/src/test/java/com/kt/service/UserServiceTest.java
+++ b/src/test/java/com/kt/service/UserServiceTest.java
@@ -47,6 +47,8 @@ import com.kt.repository.product.ProductRepository;
 import com.kt.repository.review.ReviewRepository;
 import com.kt.repository.user.UserRepository;
 
+import com.kt.repository.seller.SellerRepository;
+
 @Transactional
 @SpringBootTest
 @ActiveProfiles("test")
@@ -68,6 +70,8 @@ class UserServiceTest {
 	CategoryRepository categoryRepository;
 	@Autowired
 	AccountRepository accountRepository;
+	@Autowired
+	SellerRepository sellerRepository;
 
 	UserEntity testUser;
 	UserEntity testUser2;
@@ -88,6 +92,7 @@ class UserServiceTest {
 		productRepository.deleteAll();
 		categoryRepository.deleteAll();
 		accountRepository.deleteAll();
+		sellerRepository.deleteAll();
 	}
 
 	@BeforeEach
@@ -147,7 +152,7 @@ class UserServiceTest {
 		categoryRepository.save(category);
 
 		testSeller = SellerEntityCreator.createSeller();
-		accountRepository.save(testSeller);
+		sellerRepository.save(testSeller);
 
 		testProduct = ProductEntity.create(
 			"테스트상품명",

--- a/src/test/java/com/kt/service/admin/AdminManagementServiceTest.java
+++ b/src/test/java/com/kt/service/admin/AdminManagementServiceTest.java
@@ -6,6 +6,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.time.LocalDate;
 import java.util.UUID;
 
+import com.kt.common.SellerEntityCreator;
+import com.kt.domain.entity.SellerEntity;
+import com.kt.repository.account.AccountRepository;
+
 import org.junit.jupiter.api.AfterEach;
 import com.kt.constant.AccountRole;
 import org.junit.jupiter.api.BeforeEach;
@@ -40,7 +44,7 @@ import com.kt.repository.user.UserRepository;
 @Transactional
 @SpringBootTest
 @ActiveProfiles("test")
-class AdminAdminServiceTest {
+class AdminManagementServiceTest {
 
 	@Autowired
 	AdminUserService adminUserService;
@@ -56,6 +60,8 @@ class AdminAdminServiceTest {
 	ProductRepository productRepository;
 	@Autowired
 	CategoryRepository categoryRepository;
+	@Autowired
+	AccountRepository accountRepository;
 
 	UserEntity testUser;
 	UserEntity testUser2;
@@ -63,6 +69,7 @@ class AdminAdminServiceTest {
 	OrderEntity testOrder;
 	ProductEntity testProduct;
 	OrderProductEntity testOrderProduct;
+	SellerEntity testSeller;
 	UUID userId;
 	UUID AdminId;
 
@@ -74,6 +81,7 @@ class AdminAdminServiceTest {
 		userRepository.deleteAll();
 		productRepository.deleteAll();
 		categoryRepository.deleteAll();
+		accountRepository.deleteAll();
 	}
 
 	@BeforeEach
@@ -132,11 +140,15 @@ class AdminAdminServiceTest {
 		CategoryEntity category = CategoryEntity.create("카테고리", null);
 		categoryRepository.save(category);
 
+		testSeller = SellerEntityCreator.createSeller();
+		accountRepository.save(testSeller);
+
 		testProduct = ProductEntity.create(
 			"테스트상품명",
 			1000L,
 			5L,
-			category
+			category,
+			testSeller
 		);
 		productRepository.save(testProduct);
 
@@ -145,7 +157,8 @@ class AdminAdminServiceTest {
 			5000L,
 			OrderProductStatus.CREATED,
 			testOrder,
-			testProduct
+			testProduct,
+			testSeller
 		);
 		orderProductRepository.save(testOrderProduct);
 	}
@@ -173,7 +186,8 @@ class AdminAdminServiceTest {
 			"테스트물건",
 			3L,
 			3L,
-			category
+			category,
+			testSeller
 		);
 
 		ProductEntity savedProduct = productRepository.save(product);
@@ -306,11 +320,32 @@ class AdminAdminServiceTest {
 		);
 		UserEntity savedUser = userRepository.save(user);
 
+		CategoryEntity category = categoryRepository.save(CategoryEntity.create("카테고리", null));
+
+		ProductEntity product = ProductEntity.create(
+			"삭제상품",
+			1000L,
+			5L,
+			category,
+			testSeller
+		);
+		ProductEntity savedProduct = productRepository.save(product);
+
 		OrderEntity order = OrderEntity.create(
 			ReceiverVO.create("이름", "번호", "도시", "시군구", "동", "상세"),
 			savedUser
 		);
 		OrderEntity savedOrder = orderRepository.save(order);
+
+		OrderProductEntity orderProduct = OrderProductEntity.create(
+			1L,
+			1000L,
+			OrderProductStatus.CREATED,
+			savedOrder,
+			savedProduct,
+			testSeller
+		);
+		orderProductRepository.save(orderProduct);
 
 		// when
 		adminUserService.deleteUserPermanently(testAdmin.getId(), savedUser.getId());

--- a/src/test/java/com/kt/service/admin/AdminManagementServiceTest.java
+++ b/src/test/java/com/kt/service/admin/AdminManagementServiceTest.java
@@ -157,8 +157,7 @@ class AdminManagementServiceTest {
 			5000L,
 			OrderProductStatus.CREATED,
 			testOrder,
-			testProduct,
-			testSeller
+			testProduct
 		);
 		orderProductRepository.save(testOrderProduct);
 	}
@@ -342,8 +341,7 @@ class AdminManagementServiceTest {
 			1000L,
 			OrderProductStatus.CREATED,
 			savedOrder,
-			savedProduct,
-			testSeller
+			savedProduct
 		);
 		orderProductRepository.save(orderProduct);
 

--- a/src/test/java/com/kt/service/admin/AdminOrderServiceTest.java
+++ b/src/test/java/com/kt/service/admin/AdminOrderServiceTest.java
@@ -2,7 +2,7 @@ package com.kt.service.admin;
 
 import com.kt.common.SellerEntityCreator;
 import com.kt.domain.entity.SellerEntity;
-import com.kt.repository.account.AccountRepository;
+import com.kt.repository.seller.SellerRepository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -53,7 +53,7 @@ class AdminOrderServiceTest {
 	@Autowired
 	CategoryRepository categoryRepository;
 	@Autowired
-	AccountRepository accountRepository;
+	SellerRepository sellerRepository;
 
 	CategoryEntity category;
 	SellerEntity testSeller;
@@ -62,7 +62,7 @@ class AdminOrderServiceTest {
 	void setup() {
 		category = categoryRepository.save(CategoryEntityCreator.createCategory());
 		testSeller = SellerEntityCreator.createSeller();
-		accountRepository.save(testSeller);
+		sellerRepository.save(testSeller);
 	}
 
 	OrderEntity createOrder(UserEntity user) {

--- a/src/test/java/com/kt/service/admin/AdminOrderServiceTest.java
+++ b/src/test/java/com/kt/service/admin/AdminOrderServiceTest.java
@@ -86,8 +86,7 @@ class AdminOrderServiceTest {
 				product.getPrice(),
 				OrderProductStatus.CREATED,
 				order,
-				product,
-				testSeller
+				product
 			)
 		);
 	}

--- a/src/test/java/com/kt/service/admin/AdminOrderServiceTest.java
+++ b/src/test/java/com/kt/service/admin/AdminOrderServiceTest.java
@@ -1,5 +1,9 @@
 package com.kt.service.admin;
 
+import com.kt.common.SellerEntityCreator;
+import com.kt.domain.entity.SellerEntity;
+import com.kt.repository.account.AccountRepository;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -25,12 +29,10 @@ import com.kt.domain.entity.OrderProductEntity;
 import com.kt.domain.entity.ProductEntity;
 import com.kt.domain.entity.UserEntity;
 import com.kt.exception.CustomException;
-import com.kt.repository.AddressRepository;
 import com.kt.repository.CategoryRepository;
 import com.kt.repository.order.OrderRepository;
 import com.kt.repository.orderproduct.OrderProductRepository;
 import com.kt.repository.product.ProductRepository;
-import com.kt.repository.review.ReviewRepository;
 import com.kt.repository.user.UserRepository;
 
 @Transactional
@@ -49,17 +51,18 @@ class AdminOrderServiceTest {
 	@Autowired
 	OrderProductRepository orderProductRepository;
 	@Autowired
-	ReviewRepository reviewRepository;
-	@Autowired
 	CategoryRepository categoryRepository;
 	@Autowired
-	AddressRepository addressRepository;
+	AccountRepository accountRepository;
 
 	CategoryEntity category;
+	SellerEntity testSeller;
 
 	@BeforeEach
 	void setup() {
 		category = categoryRepository.save(CategoryEntityCreator.createCategory());
+		testSeller = SellerEntityCreator.createSeller();
+		accountRepository.save(testSeller);
 	}
 
 	OrderEntity createOrder(UserEntity user) {
@@ -73,7 +76,7 @@ class AdminOrderServiceTest {
 
 	OrderProductEntity createOrderWithProducts(OrderEntity order, long quantity) {
 
-		ProductEntity product = productRepository.save(ProductEntityCreator.createProduct(category));
+		ProductEntity product = productRepository.save(ProductEntityCreator.createProduct(category, testSeller));
 		product.decreaseStock(quantity);
 		productRepository.save(product);
 
@@ -83,7 +86,8 @@ class AdminOrderServiceTest {
 				product.getPrice(),
 				OrderProductStatus.CREATED,
 				order,
-				product
+				product,
+				testSeller
 			)
 		);
 	}

--- a/src/test/java/com/kt/service/admin/AdminProductServiceTest.java
+++ b/src/test/java/com/kt/service/admin/AdminProductServiceTest.java
@@ -1,9 +1,15 @@
 package com.kt.service.admin;
 
+import static com.kt.common.SellerEntityCreator.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import com.kt.common.SellerEntityCreator;
+import com.kt.domain.dto.request.AdminProductRequest;
+import com.kt.domain.entity.SellerEntity;
+import com.kt.repository.account.AccountRepository;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -25,26 +31,38 @@ import com.kt.repository.CategoryRepository;
 import com.kt.repository.orderproduct.OrderProductRepository;
 import com.kt.repository.product.ProductRepository;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+
 @ActiveProfiles("test")
 @SpringBootTest
 @Transactional
 class AdminProductServiceTest {
 
 	private final AdminProductService adminProductService;
-
 	private final ProductRepository productRepository;
-
 	private final CategoryRepository categoryRepository;
-
 	private final OrderProductRepository orderProductRepository;
+	private final AccountRepository accountRepository;
+	private SellerEntity testSeller;
 
 	@Autowired
 	AdminProductServiceTest(AdminProductService adminProductService, ProductRepository productRepository,
-		CategoryRepository categoryRepository, OrderProductRepository orderProductRepository) {
+		CategoryRepository categoryRepository, OrderProductRepository orderProductRepository,
+		AccountRepository accountRepository) {
 		this.orderProductRepository = orderProductRepository;
 		this.adminProductService = adminProductService;
 		this.productRepository = productRepository;
 		this.categoryRepository = categoryRepository;
+		this.accountRepository = accountRepository;
+	}
+
+	@BeforeEach
+	void setUp() {
+		testSeller = createSeller();
+		accountRepository.save(testSeller);
 	}
 
 	@Test
@@ -52,17 +70,19 @@ class AdminProductServiceTest {
 		// given
 		CategoryEntity category = CategoryEntity.create("카테고리", null);
 		categoryRepository.save(category);
-
 		String productName = "상품1";
 		long productPrice = 1000L;
-		ProductRequest.Create request = new ProductRequest.Create(
+		AdminProductRequest.Create request = new AdminProductRequest.Create(
 			productName,
 			productPrice,
-			10L
+			10L,
+			category.getId(),
+			testSeller.getId()
 		);
 
 		// when
-		adminProductService.create(request.name(), request.price(), request.stock(), category.getId());
+		adminProductService.create(request.name(), request.price(), request.stock(), request.categoryId(),
+			request.sellerId());
 
 		// then
 		ProductEntity product = productRepository.findAll()
@@ -72,6 +92,7 @@ class AdminProductServiceTest {
 			.orElseThrow();
 
 		assertThat(product.getPrice()).isEqualTo(productPrice);
+		assertThat(product.getSeller().getId()).isEqualTo(testSeller.getId());
 	}
 
 	@Test
@@ -87,13 +108,14 @@ class AdminProductServiceTest {
 			"상품1",
 			1000L,
 			10L,
-			category
+			category,
+			testSeller
 		);
 
 		productRepository.save(product);
 
 		// when
-		ProductRequest.Update request = new ProductRequest.Update(
+		AdminProductRequest.Update request = new AdminProductRequest.Update(
 			"수정된상품명",
 			2000L,
 			20L,
@@ -124,7 +146,8 @@ class AdminProductServiceTest {
 			"상품1",
 			1000L,
 			10L,
-			category
+			category,
+			testSeller
 		);
 		productRepository.save(product);
 
@@ -148,7 +171,8 @@ class AdminProductServiceTest {
 				"상품" + i,
 				1000L,
 				10L,
-				category
+				category,
+				testSeller
 			);
 			products.add(product);
 		}
@@ -178,7 +202,8 @@ class AdminProductServiceTest {
 				"상품" + i,
 				1000L,
 				10L,
-				categoryDog
+				categoryDog,
+				testSeller
 			);
 			products.add(product);
 		}
@@ -188,7 +213,8 @@ class AdminProductServiceTest {
 				"상품" + i,
 				1000L,
 				10L,
-				categorySports
+				categorySports,
+				testSeller
 			);
 			products.add(product);
 		}
@@ -220,7 +246,8 @@ class AdminProductServiceTest {
 				"상품" + i,
 				1000L,
 				10L,
-				categorySports
+				categorySports,
+				testSeller
 			);
 			productRepository.save(product);
 		}
@@ -245,7 +272,7 @@ class AdminProductServiceTest {
 		// given
 		CategoryEntity categorySports = CategoryEntity.create("운동", null);
 		categoryRepository.save(categorySports);
-		ProductEntity product = ProductEntity.create("상품", 1000L, 10L, categorySports);
+		ProductEntity product = ProductEntity.create("상품", 1000L, 10L, categorySports, testSeller);
 		productRepository.save(product);
 
 		// when
@@ -261,7 +288,7 @@ class AdminProductServiceTest {
 		// given
 		CategoryEntity categorySports = CategoryEntity.create("운동", null);
 		categoryRepository.save(categorySports);
-		ProductEntity product = ProductEntity.create("상품", 1000L, 10L, categorySports);
+		ProductEntity product = ProductEntity.create("상품", 1000L, 10L, categorySports, testSeller);
 		productRepository.save(product);
 
 		// when
@@ -277,7 +304,7 @@ class AdminProductServiceTest {
 		// given
 		CategoryEntity categorySports = CategoryEntity.create("운동", null);
 		categoryRepository.save(categorySports);
-		ProductEntity product = ProductEntity.create("상품", 1000L, 10L, categorySports);
+		ProductEntity product = ProductEntity.create("상품", 1000L, 10L, categorySports, testSeller);
 		productRepository.save(product);
 
 		// when
@@ -293,7 +320,7 @@ class AdminProductServiceTest {
 		// given
 		CategoryEntity categorySports = CategoryEntity.create("운동", null);
 		categoryRepository.save(categorySports);
-		ProductEntity product = ProductEntity.create("상품", 1000L, 10L, categorySports);
+		ProductEntity product = ProductEntity.create("상품", 1000L, 10L, categorySports, testSeller);
 		productRepository.save(product);
 		adminProductService.inActivate(product.getId());
 
@@ -310,7 +337,7 @@ class AdminProductServiceTest {
 		// given
 		CategoryEntity categorySports = CategoryEntity.create("운동", null);
 		categoryRepository.save(categorySports);
-		ProductEntity product = ProductEntity.create("상품", 1000L, 10L, categorySports);
+		ProductEntity product = ProductEntity.create("상품", 1000L, 10L, categorySports, testSeller);
 		productRepository.save(product);
 		adminProductService.activate(product.getId());
 
@@ -333,7 +360,8 @@ class AdminProductServiceTest {
 				"상품" + i,
 				1000L,
 				10L,
-				categorySports
+				categorySports,
+				testSeller
 			);
 			products.add(product);
 		}

--- a/src/test/java/com/kt/service/admin/AdminProductServiceTest.java
+++ b/src/test/java/com/kt/service/admin/AdminProductServiceTest.java
@@ -9,7 +9,7 @@ import java.util.List;
 import com.kt.common.SellerEntityCreator;
 import com.kt.domain.dto.request.AdminProductRequest;
 import com.kt.domain.entity.SellerEntity;
-import com.kt.repository.account.AccountRepository;
+import com.kt.repository.seller.SellerRepository;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -45,24 +45,24 @@ class AdminProductServiceTest {
 	private final ProductRepository productRepository;
 	private final CategoryRepository categoryRepository;
 	private final OrderProductRepository orderProductRepository;
-	private final AccountRepository accountRepository;
+	private final SellerRepository sellerRepository;
 	private SellerEntity testSeller;
 
 	@Autowired
 	AdminProductServiceTest(AdminProductService adminProductService, ProductRepository productRepository,
 		CategoryRepository categoryRepository, OrderProductRepository orderProductRepository,
-		AccountRepository accountRepository) {
+		SellerRepository sellerRepository) {
 		this.orderProductRepository = orderProductRepository;
 		this.adminProductService = adminProductService;
 		this.productRepository = productRepository;
 		this.categoryRepository = categoryRepository;
-		this.accountRepository = accountRepository;
+		this.sellerRepository = sellerRepository;
 	}
 
 	@BeforeEach
 	void setUp() {
 		testSeller = createSeller();
-		accountRepository.save(testSeller);
+		sellerRepository.save(testSeller);
 	}
 
 	@Test

--- a/src/test/java/com/kt/service/admin/AdminReviewServiceTest.java
+++ b/src/test/java/com/kt/service/admin/AdminReviewServiceTest.java
@@ -6,6 +6,9 @@ import static com.kt.common.OrderProductCreator.*;
 import static com.kt.common.ProductCreator.*;
 import static com.kt.common.UserEntityCreator.*;
 
+import com.kt.common.SellerEntityCreator;
+import com.kt.domain.entity.SellerEntity;
+import com.kt.repository.account.AccountRepository;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -51,9 +54,12 @@ class AdminReviewServiceTest {
 	OrderRepository orderRepository;
 	@Autowired
 	CategoryRepository categoryRepository;
+	@Autowired
+	AccountRepository accountRepository;
 
 	OrderProductEntity testOrderProduct;
 	UserEntity testUser;
+	SellerEntity testSeller;
 
 	@BeforeEach
 	void setUp() throws Exception {
@@ -63,13 +69,16 @@ class AdminReviewServiceTest {
 		CategoryEntity category = createCategory();
 		categoryRepository.save(category);
 
+		testSeller = SellerEntityCreator.createSeller();
+		accountRepository.save(testSeller);
+
 		OrderEntity order = createOrderEntity(testUser);
 		orderRepository.save(order);
 
-		ProductEntity product = createProduct(category);
+		ProductEntity product = createProduct(category, testSeller);
 		productRepository.save(product);
 
-		testOrderProduct = createOrderProduct(order, product);
+		testOrderProduct = createOrderProduct(order, product, testSeller);
 		orderProductRepository.save(testOrderProduct);
 
 		order.getOrderProducts().add(testOrderProduct);

--- a/src/test/java/com/kt/service/admin/AdminReviewServiceTest.java
+++ b/src/test/java/com/kt/service/admin/AdminReviewServiceTest.java
@@ -8,7 +8,7 @@ import static com.kt.common.UserEntityCreator.*;
 
 import com.kt.common.SellerEntityCreator;
 import com.kt.domain.entity.SellerEntity;
-import com.kt.repository.account.AccountRepository;
+import com.kt.repository.seller.SellerRepository;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -55,7 +55,7 @@ class AdminReviewServiceTest {
 	@Autowired
 	CategoryRepository categoryRepository;
 	@Autowired
-	AccountRepository accountRepository;
+	SellerRepository sellerRepository;
 
 	OrderProductEntity testOrderProduct;
 	UserEntity testUser;
@@ -70,7 +70,7 @@ class AdminReviewServiceTest {
 		categoryRepository.save(category);
 
 		testSeller = SellerEntityCreator.createSeller();
-		accountRepository.save(testSeller);
+		sellerRepository.save(testSeller);
 
 		OrderEntity order = createOrderEntity(testUser);
 		orderRepository.save(order);

--- a/src/test/java/com/kt/service/admin/AdminUserServiceTest.java
+++ b/src/test/java/com/kt/service/admin/AdminUserServiceTest.java
@@ -161,8 +161,7 @@ class AdminUserServiceTest {
 			5000L,
 			OrderProductStatus.CREATED,
 			testOrder,
-			testProduct,
-			testSeller
+			testProduct
 		);
 		orderProductRepository.save(testOrderProduct);
 	}
@@ -346,8 +345,7 @@ class AdminUserServiceTest {
 			1000L,
 			OrderProductStatus.CREATED,
 			savedOrder,
-			savedProduct,
-			testSeller
+			savedProduct
 		);
 		orderProductRepository.save(orderProduct);
 

--- a/src/test/java/com/kt/service/admin/AdminUserServiceTest.java
+++ b/src/test/java/com/kt/service/admin/AdminUserServiceTest.java
@@ -6,6 +6,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.time.LocalDate;
 import java.util.UUID;
 
+import com.kt.common.SellerEntityCreator;
+import com.kt.domain.entity.SellerEntity;
+import com.kt.repository.account.AccountRepository;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -56,6 +60,8 @@ class AdminUserServiceTest {
 	ProductRepository productRepository;
 	@Autowired
 	CategoryRepository categoryRepository;
+	@Autowired
+	AccountRepository accountRepository;
 
 	UserEntity testUser;
 	UserEntity testUser2;
@@ -63,6 +69,7 @@ class AdminUserServiceTest {
 	OrderEntity testOrder;
 	ProductEntity testProduct;
 	OrderProductEntity testOrderProduct;
+	SellerEntity testSeller;
 	UUID userId;
 	UUID AdminId;
 
@@ -74,6 +81,7 @@ class AdminUserServiceTest {
 		userRepository.deleteAll();
 		productRepository.deleteAll();
 		categoryRepository.deleteAll();
+		accountRepository.deleteAll();
 	}
 
 	@BeforeEach
@@ -132,11 +140,15 @@ class AdminUserServiceTest {
 		CategoryEntity category = CategoryEntity.create("카테고리", null);
 		categoryRepository.save(category);
 
+		testSeller = SellerEntityCreator.createSeller();
+		accountRepository.save(testSeller);
+
 		testProduct = ProductEntity.create(
 			"테스트상품명",
 			1000L,
 			5L,
-			category
+			category,
+			testSeller
 		);
 		productRepository.save(testProduct);
 
@@ -145,7 +157,8 @@ class AdminUserServiceTest {
 			5000L,
 			OrderProductStatus.CREATED,
 			testOrder,
-			testProduct
+			testProduct,
+			testSeller
 		);
 		orderProductRepository.save(testOrderProduct);
 	}
@@ -173,7 +186,8 @@ class AdminUserServiceTest {
 			"테스트물건",
 			3L,
 			3L,
-			category
+			category,
+			testSeller
 		);
 
 		ProductEntity savedProduct = productRepository.save(product);
@@ -306,11 +320,32 @@ class AdminUserServiceTest {
 		);
 		UserEntity savedUser = userRepository.save(user);
 
+		CategoryEntity category = categoryRepository.save(CategoryEntity.create("카테고리", null));
+
+		ProductEntity product = ProductEntity.create(
+			"삭제상품",
+			1000L,
+			5L,
+			category,
+			testSeller
+		);
+		ProductEntity savedProduct = productRepository.save(product);
+
 		OrderEntity order = OrderEntity.create(
 			ReceiverVO.create("이름", "번호", "도시", "시군구", "동", "상세"),
 			savedUser
 		);
 		OrderEntity savedOrder = orderRepository.save(order);
+
+		OrderProductEntity orderProduct = OrderProductEntity.create(
+			1L,
+			1000L,
+			OrderProductStatus.CREATED,
+			savedOrder,
+			savedProduct,
+			testSeller
+		);
+		orderProductRepository.save(orderProduct);
 
 		// when
 		adminUserService.deleteUserPermanently(testAdmin.getId(), savedUser.getId());

--- a/src/test/java/com/kt/service/admin/AdminUserServiceTest.java
+++ b/src/test/java/com/kt/service/admin/AdminUserServiceTest.java
@@ -39,6 +39,7 @@ import com.kt.repository.order.OrderRepository;
 import com.kt.repository.orderproduct.OrderProductRepository;
 import com.kt.repository.product.ProductRepository;
 import com.kt.repository.review.ReviewRepository;
+import com.kt.repository.seller.SellerRepository;
 import com.kt.repository.user.UserRepository;
 
 @Transactional
@@ -62,6 +63,8 @@ class AdminUserServiceTest {
 	CategoryRepository categoryRepository;
 	@Autowired
 	AccountRepository accountRepository;
+	@Autowired
+	SellerRepository sellerRepository;
 
 	UserEntity testUser;
 	UserEntity testUser2;
@@ -81,6 +84,7 @@ class AdminUserServiceTest {
 		userRepository.deleteAll();
 		productRepository.deleteAll();
 		categoryRepository.deleteAll();
+		sellerRepository.deleteAll();
 		accountRepository.deleteAll();
 	}
 
@@ -141,7 +145,7 @@ class AdminUserServiceTest {
 		categoryRepository.save(category);
 
 		testSeller = SellerEntityCreator.createSeller();
-		accountRepository.save(testSeller);
+		sellerRepository.save(testSeller);
 
 		testProduct = ProductEntity.create(
 			"테스트상품명",


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- resolves: #이슈번호, #이슈번호 -->
resolves: #179 

## 📝작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- AdminAdmin -> AdminManagement 변경
- Seller Entity 생성

```
		this.name = name;
		this.email = email;
		this.password = password;
		this.storeName = storeName;
		this.contactMobile = contactMobile;
		this.contactEmail = contactEmail;
		this.role = UserRole.SELLER;
		this.status = UserStatus.ENABLED;
		this.gender = gender;
```
Seller 엔티티는 가게 이름과 판매자 이름을 따로 생성해서, 
이름은 차후 사업자등록까지 디벨롭이 가능하다면 검증용으로 사용하고
주문목록 같은 경우에서는 스토어 이름이 보여지길 기대합니다.

현재 일단 OrderProduct, Product에서 판매자 id 묶어놨습니다.
한 주문에 여러 판매자가 존재할 수 있어서 Order에는 묶지 않았습니다.

OrderRequest를 받는 과정에서 변경이 필요하다고도 느껴집니다.
Product가 Seller의 Product인지 검증만 되면 괜찮다고 생각되는데, 한번 검토 부탁드려요!

우선 판매자가 행하는 로직도 Admin에서 다 진행했습니다.
다음 작업에서 분리 진행할게요!

도메인 테스트는 진행하지 않았고, 차후 Service/Controller 이관 및 생성하면서 테스트 전부 진행하겠습니다.

주문/상품 테스트까지 수정하느라 PR 지연되고 범위가 커졌습니다. 양해를 부탁드립니다 ..


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->