### PR TITLE
[FEAT] 유저 및 판매자 계좌 도메인(엔티티) 생성 및 연관관계 구조 정의

### DIFF
--- a/src/main/java/com/kt/domain/entity/BankAccountEntity.java
+++ b/src/main/java/com/kt/domain/entity/BankAccountEntity.java
@@ -1,0 +1,44 @@
+package com.kt.domain.entity;
+
+import com.kt.domain.entity.common.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Version;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@Entity(name = "bank_account")
+@NoArgsConstructor(access = PROTECTED)
+public class BankAccountEntity extends BaseEntity {
+
+	@Column(nullable = false)
+	private Long balance;
+
+	@Version
+	private Long version;
+
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(
+		name = "user_id",
+		nullable = false,
+		unique = true
+	)
+	private UserEntity user;
+
+	protected BankAccountEntity(UserEntity user) {
+		this.balance = 0L;
+		this.user = user;
+	}
+
+	public static BankAccountEntity create(final UserEntity user) {
+		return new BankAccountEntity(user);
+	}
+
+}

--- a/src/main/java/com/kt/domain/entity/UserEntity.java
+++ b/src/main/java/com/kt/domain/entity/UserEntity.java
@@ -45,6 +45,18 @@ public class UserEntity extends AbstractAccountEntity {
 	)
 	private PayEntity pay;
 
+
+	@OneToOne(
+		mappedBy = "user",
+		cascade = {
+			CascadeType.PERSIST,
+			CascadeType.REMOVE
+		},
+		orphanRemoval = true,
+		fetch = FetchType.LAZY
+	)
+	private BankAccountEntity bankAccount;
+
 	@Column(nullable = false)
 	private LocalDate birth;
 
@@ -69,6 +81,7 @@ public class UserEntity extends AbstractAccountEntity {
 		this.mobile = mobile;
 		this.status = UserStatus.ENABLED;
 		this.pay = PayEntity.create(this);
+		this.bankAccount = BankAccountEntity.create(this);
 	}
 
 	public static UserEntity create(

--- a/src/test/java/com/kt/domain/entity/BankAccountEntityTest.java
+++ b/src/test/java/com/kt/domain/entity/BankAccountEntityTest.java
@@ -1,0 +1,23 @@
+package com.kt.domain.entity;
+
+import com.kt.common.UserEntityCreator;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ActiveProfiles("test")
+public class BankAccountEntityTest {
+
+	@Test
+	void 계좌_객체생성_성공() {
+		UserEntity testUser = UserEntityCreator.createMember();
+		BankAccountEntity bankAccount = testUser.getBankAccount();
+
+		assertNotNull(bankAccount);
+		assertEquals(0L, bankAccount.getBalance());
+		assertEquals(bankAccount.getUser(), testUser);
+	}
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

resolves: #197 

## 📝작업 내용

계좌(BankAccountEntity) 엔티티도메인 생성 및 유저 <--> 계좌 연관관계 생성
계좌 도메인 생성 테스트 코드 추가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->