### PR TITLE
[REFACTOR] PAID 상태 복귀 #216

### DIFF
--- a/src/main/java/com/kt/constant/OrderProductStatus.java
+++ b/src/main/java/com/kt/constant/OrderProductStatus.java
@@ -7,7 +7,7 @@ public enum OrderProductStatus {
 	CREATED("주문생성"),
 	PURCHASE_CONFIRMED("구매확정"),
 	CANCELED("주문취소"),
-	PAID("결제완료"),
+	PENDING_APPROVE("승인대기"),
 	SHIPPING_READY("배송대기"),
 	SHIPPING("배송중"),
 	SHIPPING_COMPLETED("배송완료"),

--- a/src/main/java/com/kt/constant/OrderProductStatus.java
+++ b/src/main/java/com/kt/constant/OrderProductStatus.java
@@ -7,6 +7,7 @@ public enum OrderProductStatus {
 	CREATED("주문생성"),
 	PURCHASE_CONFIRMED("구매확정"),
 	CANCELED("주문취소"),
+	PAID("결제완료"),
 	SHIPPING_READY("배송대기"),
 	SHIPPING("배송중"),
 	SHIPPING_COMPLETED("배송완료"),

--- a/src/main/java/com/kt/constant/OrderProductStatusPolicy.java
+++ b/src/main/java/com/kt/constant/OrderProductStatusPolicy.java
@@ -15,12 +15,12 @@ public final class OrderProductStatusPolicy {
 			EnumSet.of(
 				OrderProductStatus.SHIPPING,
 				OrderProductStatus.CANCELED,
-				OrderProductStatus.PAID
+				OrderProductStatus.PENDING_APPROVE
 			)
 		);
 
 		FORCE_CHANGE_ALLOWED_MAP.put(
-			OrderProductStatus.PAID,
+			OrderProductStatus.PENDING_APPROVE,
 			EnumSet.of(
 				OrderProductStatus.SHIPPING_READY,
 				OrderProductStatus.CANCELED

--- a/src/main/java/com/kt/constant/OrderProductStatusPolicy.java
+++ b/src/main/java/com/kt/constant/OrderProductStatusPolicy.java
@@ -14,6 +14,15 @@ public final class OrderProductStatusPolicy {
 			OrderProductStatus.SHIPPING_READY,
 			EnumSet.of(
 				OrderProductStatus.SHIPPING,
+				OrderProductStatus.CANCELED,
+				OrderProductStatus.PAID
+			)
+		);
+
+		FORCE_CHANGE_ALLOWED_MAP.put(
+			OrderProductStatus.PAID,
+			EnumSet.of(
+				OrderProductStatus.SHIPPING_READY,
 				OrderProductStatus.CANCELED
 			)
 		);

--- a/src/main/java/com/kt/domain/entity/OrderEntity.java
+++ b/src/main/java/com/kt/domain/entity/OrderEntity.java
@@ -92,7 +92,7 @@ public class OrderEntity extends BaseEntity {
 		}
 
 		boolean anyPaid = orderProducts.stream()
-			.anyMatch(orderProduct -> orderProduct.getStatus() == OrderProductStatus.PAID);
+			.anyMatch(orderProduct -> orderProduct.getStatus() == OrderProductStatus.PENDING_APPROVE);
 
 		if (anyPaid) {
 			return OrderDerivedStatus.PAID;

--- a/src/main/java/com/kt/domain/entity/OrderEntity.java
+++ b/src/main/java/com/kt/domain/entity/OrderEntity.java
@@ -92,7 +92,7 @@ public class OrderEntity extends BaseEntity {
 		}
 
 		boolean anyPaid = orderProducts.stream()
-			.anyMatch(orderProduct -> orderProduct.getStatus() == OrderProductStatus.SHIPPING_READY);
+			.anyMatch(orderProduct -> orderProduct.getStatus() == OrderProductStatus.PAID);
 
 		if (anyPaid) {
 			return OrderDerivedStatus.PAID;

--- a/src/main/java/com/kt/service/OrderServiceImpl.java
+++ b/src/main/java/com/kt/service/OrderServiceImpl.java
@@ -117,7 +117,7 @@ public class OrderServiceImpl implements OrderService {
 			Long quantity = orderProduct.getQuantity();
 
 			product.decreaseStock(quantity);
-			orderProduct.updateStatus(OrderProductStatus.SHIPPING_READY);
+			orderProduct.updateStatus(OrderProductStatus.PAID);
 		}
 	}
 

--- a/src/main/java/com/kt/service/OrderServiceImpl.java
+++ b/src/main/java/com/kt/service/OrderServiceImpl.java
@@ -117,7 +117,7 @@ public class OrderServiceImpl implements OrderService {
 			Long quantity = orderProduct.getQuantity();
 
 			product.decreaseStock(quantity);
-			orderProduct.updateStatus(OrderProductStatus.PAID);
+			orderProduct.updateStatus(OrderProductStatus.PENDING_APPROVE);
 		}
 	}
 

--- a/src/test/java/com/kt/api/order/OrderCancelTest.java
+++ b/src/test/java/com/kt/api/order/OrderCancelTest.java
@@ -18,9 +18,7 @@ import org.junit.jupiter.api.Test;
 import com.kt.common.SellerEntityCreator;
 import com.kt.domain.entity.SellerEntity;
 import com.kt.repository.seller.SellerRepository;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.web.servlet.ResultActions;
 
@@ -97,7 +95,7 @@ public class OrderCancelTest extends MockMvcTest {
 		OrderEntity saved = orderRepository.findAll().stream().findFirst().orElseThrow();
 
 		OrderProductEntity orderProduct = saved.getOrderProducts().get(0);
-		orderProduct.updateStatus(OrderProductStatus.PAID);
+		orderProduct.updateStatus(OrderProductStatus.PENDING_APPROVE);
 
 		// when
 		ResultActions actions = mockMvc.perform(
@@ -121,7 +119,7 @@ public class OrderCancelTest extends MockMvcTest {
 		OrderEntity saved = orderRepository.findAll().stream().findFirst().orElseThrow();
 
 		saved.getOrderProducts().get(0)
-		.updateStatus(OrderProductStatus.PAID);
+		.updateStatus(OrderProductStatus.PENDING_APPROVE);
 
 		if(saved.getOrderProducts().size() > 1) {
 			saved.getOrderProducts().subList(1, saved.getOrderProducts().size())

--- a/src/test/java/com/kt/api/order/OrderCancelTest.java
+++ b/src/test/java/com/kt/api/order/OrderCancelTest.java
@@ -97,7 +97,7 @@ public class OrderCancelTest extends MockMvcTest {
 		OrderEntity saved = orderRepository.findAll().stream().findFirst().orElseThrow();
 
 		OrderProductEntity orderProduct = saved.getOrderProducts().get(0);
-		orderProduct.updateStatus(OrderProductStatus.SHIPPING_READY);
+		orderProduct.updateStatus(OrderProductStatus.PAID);
 
 		// when
 		ResultActions actions = mockMvc.perform(
@@ -121,7 +121,7 @@ public class OrderCancelTest extends MockMvcTest {
 		OrderEntity saved = orderRepository.findAll().stream().findFirst().orElseThrow();
 
 		saved.getOrderProducts().get(0)
-		.updateStatus(OrderProductStatus.SHIPPING_READY);
+		.updateStatus(OrderProductStatus.PAID);
 
 		if(saved.getOrderProducts().size() > 1) {
 			saved.getOrderProducts().subList(1, saved.getOrderProducts().size())

--- a/src/test/java/com/kt/service/OrderServiceTest.java
+++ b/src/test/java/com/kt/service/OrderServiceTest.java
@@ -7,14 +7,11 @@ import java.util.UUID;
 
 import com.kt.common.SellerEntityCreator;
 import com.kt.domain.entity.SellerEntity;
-import com.kt.repository.account.AccountRepository;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,10 +22,8 @@ import com.kt.common.ProductEntityCreator;
 import com.kt.common.ReceiverCreator;
 import com.kt.common.UserEntityCreator;
 import com.kt.constant.OrderProductStatus;
-import com.kt.constant.ShippingType;
 import com.kt.constant.message.ErrorCode;
 import com.kt.domain.dto.request.OrderRequest;
-import com.kt.domain.dto.response.AdminOrderResponse;
 import com.kt.domain.dto.response.OrderResponse;
 import com.kt.domain.entity.AddressEntity;
 import com.kt.domain.entity.CategoryEntity;
@@ -183,7 +178,7 @@ class OrderServiceTest {
 		);
 
 		OrderProductEntity orderProduct = createOrderWithProducts(order, 3L);
-		orderProduct.updateStatus(OrderProductStatus.PAID);
+		orderProduct.updateStatus(OrderProductStatus.PENDING_APPROVE);
 
 		// when
 		OrderResponse.OrderProducts foundOrderProduct = orderService.getOrderProducts(order.getId());
@@ -206,8 +201,8 @@ class OrderServiceTest {
 		OrderProductEntity orderProduct1 = createOrderWithProducts(order, 3L);
 		OrderProductEntity orderProduct2 = createOrderWithProducts(order, 2L);
 
-		orderProduct1.updateStatus(OrderProductStatus.PAID);
-		orderProduct2.updateStatus(OrderProductStatus.PAID);
+		orderProduct1.updateStatus(OrderProductStatus.PENDING_APPROVE);
+		orderProduct2.updateStatus(OrderProductStatus.PENDING_APPROVE);
 
 		long beforeStock1 = orderProduct1.getProduct().getStock();
 		long beforeStock2 = orderProduct2.getProduct().getStock();

--- a/src/test/java/com/kt/service/OrderServiceTest.java
+++ b/src/test/java/com/kt/service/OrderServiceTest.java
@@ -183,7 +183,7 @@ class OrderServiceTest {
 		);
 
 		OrderProductEntity orderProduct = createOrderWithProducts(order, 3L);
-		orderProduct.updateStatus(OrderProductStatus.SHIPPING_READY);
+		orderProduct.updateStatus(OrderProductStatus.PAID);
 
 		// when
 		OrderResponse.OrderProducts foundOrderProduct = orderService.getOrderProducts(order.getId());
@@ -206,8 +206,8 @@ class OrderServiceTest {
 		OrderProductEntity orderProduct1 = createOrderWithProducts(order, 3L);
 		OrderProductEntity orderProduct2 = createOrderWithProducts(order, 2L);
 
-		orderProduct1.updateStatus(OrderProductStatus.SHIPPING_READY);
-		orderProduct2.updateStatus(OrderProductStatus.SHIPPING_READY);
+		orderProduct1.updateStatus(OrderProductStatus.PAID);
+		orderProduct2.updateStatus(OrderProductStatus.PAID);
 
 		long beforeStock1 = orderProduct1.getProduct().getStock();
 		long beforeStock2 = orderProduct2.getProduct().getStock();

--- a/src/test/java/com/kt/service/admin/AdminOrderServiceTest.java
+++ b/src/test/java/com/kt/service/admin/AdminOrderServiceTest.java
@@ -129,7 +129,7 @@ class AdminOrderServiceTest {
 		);
 
 		OrderProductEntity orderProduct = createOrderWithProducts(order, 3L);
-		orderProduct.updateStatus(OrderProductStatus.PAID);
+		orderProduct.updateStatus(OrderProductStatus.PENDING_APPROVE);
 
 		// when
 		AdminOrderResponse.Detail detail = adminOrderService.getOrderDetail(order.getId());
@@ -151,7 +151,7 @@ class AdminOrderServiceTest {
 		OrderEntity order = createOrder(adminEntity);
 
 		OrderProductEntity orderProduct = createOrderWithProducts(order, 2L);
-		orderProduct.updateStatus(OrderProductStatus.PAID);
+		orderProduct.updateStatus(OrderProductStatus.PENDING_APPROVE);
 
 		// when
 		adminOrderService.forceChangeStatus(
@@ -175,7 +175,7 @@ class AdminOrderServiceTest {
 		OrderEntity order = createOrder(adminEntity);
 
 		OrderProductEntity orderProduct = createOrderWithProducts(order, 1L);
-		orderProduct.updateStatus(OrderProductStatus.PAID);
+		orderProduct.updateStatus(OrderProductStatus.PENDING_APPROVE);
 
 		// when & then
 		assertThatThrownBy(() ->

--- a/src/test/java/com/kt/service/admin/AdminOrderServiceTest.java
+++ b/src/test/java/com/kt/service/admin/AdminOrderServiceTest.java
@@ -129,7 +129,7 @@ class AdminOrderServiceTest {
 		);
 
 		OrderProductEntity orderProduct = createOrderWithProducts(order, 3L);
-		orderProduct.updateStatus(OrderProductStatus.SHIPPING_READY);
+		orderProduct.updateStatus(OrderProductStatus.PAID);
 
 		// when
 		AdminOrderResponse.Detail detail = adminOrderService.getOrderDetail(order.getId());
@@ -151,19 +151,19 @@ class AdminOrderServiceTest {
 		OrderEntity order = createOrder(adminEntity);
 
 		OrderProductEntity orderProduct = createOrderWithProducts(order, 2L);
-		orderProduct.updateStatus(OrderProductStatus.SHIPPING_READY);
+		orderProduct.updateStatus(OrderProductStatus.PAID);
 
 		// when
 		adminOrderService.forceChangeStatus(
 			orderProduct.getId(),
-			OrderProductStatus.SHIPPING
+			OrderProductStatus.SHIPPING_READY
 		);
 
 		// then
 		OrderProductEntity updated =
 			orderProductRepository.findById(orderProduct.getId()).orElseThrow();
 
-		assertThat(updated.getStatus()).isEqualTo(OrderProductStatus.SHIPPING);
+		assertThat(updated.getStatus()).isEqualTo(OrderProductStatus.SHIPPING_READY);
 	}
 
 	@Test
@@ -175,7 +175,7 @@ class AdminOrderServiceTest {
 		OrderEntity order = createOrder(adminEntity);
 
 		OrderProductEntity orderProduct = createOrderWithProducts(order, 1L);
-		orderProduct.updateStatus(OrderProductStatus.SHIPPING_READY);
+		orderProduct.updateStatus(OrderProductStatus.PAID);
 
 		// when & then
 		assertThatThrownBy(() ->


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- resolves: #이슈번호, #이슈번호 -->
resolves: #216 

## 📝작업 내용
PAID -> PENDING_APPROVE(승인대기) 상태로 변경
OrderProductStatusPolicy: PENDING_APPROVE 상태 전이 정책 추가

허용되는 상태 전이:
1. SHIPPING_READY → PENDING_APPROVE (되돌리기)
배송 준비를 잘못 처리했을 때
2. PENDING_APPROVE → SHIPPING_READY
결제만 된 주문을 배송 대기로 넘길 때
3. PENDING_APPROVE → CANCELED
결제는 됐지만 관리자가 강제 취소하는 경우
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->