### PR TITLE
[FEAT] 판매자 주문/리뷰 서비스 및 컨트롤러 구현 #210

### DIFF
--- a/src/main/java/com/kt/constant/OrderProductStatus.java
+++ b/src/main/java/com/kt/constant/OrderProductStatus.java
@@ -5,15 +5,17 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum OrderProductStatus {
 	CREATED("주문생성"),
-	PURCHASE_CONFIRMED("구매확정"),
-	CANCELED("주문취소"),
+	PAID("결제완료"),
 	SHIPPING_READY("배송대기"),
 	SHIPPING("배송중"),
 	SHIPPING_COMPLETED("배송완료"),
+	PURCHASE_CONFIRMED("구매확정"),
+	CANCELED("주문취소"),
 	RETURN_WAITING("반품대기"),
 	RETURN_SHIPPING("반품배송중"),
 	RETURN_ARRIVAL("반품도착"),
-	RETURN_CONFIRMED("반품확정");
+	RETURN_CONFIRMED("반품확정"),
+	;
 
 	private final String description;
 }

--- a/src/main/java/com/kt/constant/OrderProductStatus.java
+++ b/src/main/java/com/kt/constant/OrderProductStatus.java
@@ -5,7 +5,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum OrderProductStatus {
 	CREATED("주문생성"),
-	PAID("결제완료"),
+	PENDING_APPROVE("승인대기"),
 	SHIPPING_READY("배송대기"),
 	SHIPPING("배송중"),
 	SHIPPING_COMPLETED("배송완료"),

--- a/src/main/java/com/kt/constant/message/ErrorCode.java
+++ b/src/main/java/com/kt/constant/message/ErrorCode.java
@@ -60,6 +60,7 @@ public enum ErrorCode {
 	INVALID_FORCE_STATUS_TRANSITION(HttpStatus.BAD_REQUEST, "강제 변경이 허용되지 않은 상태 전이입니다."),
 	INVALID_ORDER_PRODUCT_STATUS(HttpStatus.BAD_REQUEST, "현재 주문 상태에서는 판매자 확정이 불가합니다."),
 	ORDER_PRODUCT_NOT_OWNER(HttpStatus.FORBIDDEN, "판매자의 주문 상품이 아닙니다."),
+	PRODUCT_NOT_OWNER(HttpStatus.FORBIDDEN, "판매자의 상품이 아닙니다."),
 	;
 
 	private final HttpStatus status;

--- a/src/main/java/com/kt/constant/message/ErrorCode.java
+++ b/src/main/java/com/kt/constant/message/ErrorCode.java
@@ -60,7 +60,6 @@ public enum ErrorCode {
 	INVALID_FORCE_STATUS_TRANSITION(HttpStatus.BAD_REQUEST, "강제 변경이 허용되지 않은 상태 전이입니다."),
 	INVALID_ORDER_PRODUCT_STATUS(HttpStatus.BAD_REQUEST, "현재 주문 상태에서는 판매자 확정이 불가합니다."),
 	ORDER_PRODUCT_NOT_OWNER(HttpStatus.FORBIDDEN, "판매자의 주문 상품이 아닙니다."),
-	PRODUCT_NOT_OWNER(HttpStatus.FORBIDDEN, "판매자의 상품이 아닙니다."),
 	;
 
 	private final HttpStatus status;

--- a/src/main/java/com/kt/constant/message/ErrorCode.java
+++ b/src/main/java/com/kt/constant/message/ErrorCode.java
@@ -57,8 +57,11 @@ public enum ErrorCode {
 	PRODUCT_NOT_OWNER(HttpStatus.FORBIDDEN, "본인의 상품이 아닙니다."),
 	ADMIN_PERMISSION_REQUIRED(HttpStatus.FORBIDDEN, "관리자 계정이 아닙니다."),
 	SAME_STATUS_CHANGE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "현재 상태와 동일한 상태로는 변경할 수 없습니다."),
-	INVALID_FORCE_STATUS_TRANSITION(HttpStatus.BAD_REQUEST,"강제 변경이 허용되지 않은 상태 전이입니다."),
-;
+	INVALID_FORCE_STATUS_TRANSITION(HttpStatus.BAD_REQUEST, "강제 변경이 허용되지 않은 상태 전이입니다."),
+	INVALID_ORDER_PRODUCT_STATUS(HttpStatus.BAD_REQUEST, "현재 주문 상태에서는 판매자 확정이 불가합니다."),
+	ORDER_PRODUCT_NOT_OWNER(HttpStatus.FORBIDDEN, "판매자의 주문 상품이 아닙니다."),
+	;
+
 	private final HttpStatus status;
 	private final String message;
 

--- a/src/main/java/com/kt/controller/seller/SellerOrderController.java
+++ b/src/main/java/com/kt/controller/seller/SellerOrderController.java
@@ -1,0 +1,68 @@
+package com.kt.controller.seller;
+
+import static com.kt.common.api.ApiResult.*;
+
+import com.kt.common.Paging;
+import com.kt.common.api.ApiResult;
+import com.kt.common.api.PageResponse;
+import com.kt.constant.OrderProductStatus;
+import com.kt.domain.dto.response.SellerOrderResponse;
+import com.kt.security.DefaultCurrentUser;
+import com.kt.service.seller.SellerOrderService;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/seller/orders")
+@RequiredArgsConstructor
+public class SellerOrderController {
+
+	private final SellerOrderService sellerOrderService;
+
+	@GetMapping
+	public ResponseEntity<ApiResult<PageResponse<SellerOrderResponse.Search>>> searchOrderProducts(
+		@AuthenticationPrincipal @Parameter(hidden = true) DefaultCurrentUser defaultCurrentUser,
+		@RequestParam(required = false) UUID orderProductId,
+		@RequestParam(required = false) OrderProductStatus status,
+		Paging paging
+	) {
+		return page(
+			sellerOrderService.searchOrderProducts(
+				paging.toPageable(),
+				status,
+				orderProductId,
+				defaultCurrentUser.getId()
+			)
+		);
+	}
+
+	@PatchMapping("/{orderProductId}/cancel")
+	public ResponseEntity<ApiResult<Void>> cancelOrderProduct(
+		@AuthenticationPrincipal @Parameter(hidden = true) DefaultCurrentUser defaultCurrentUser,
+		@PathVariable UUID orderProductId
+	) {
+		sellerOrderService.cancelOrderProduct(orderProductId, defaultCurrentUser.getId());
+		return empty();
+	}
+
+	@PatchMapping("/{orderProductId}/confirm")
+	public ResponseEntity<ApiResult<Void>> confirmPaidOrderProduct(
+		@AuthenticationPrincipal @Parameter(hidden = true) DefaultCurrentUser defaultCurrentUser,
+		@PathVariable UUID orderProductId
+	) {
+		sellerOrderService.confirmPaidOrderProduct(orderProductId, defaultCurrentUser.getId());
+		return empty();
+	}
+}

--- a/src/main/java/com/kt/controller/seller/SellerOrderController.java
+++ b/src/main/java/com/kt/controller/seller/SellerOrderController.java
@@ -11,8 +11,10 @@ import com.kt.security.DefaultCurrentUser;
 import com.kt.service.seller.SellerOrderService;
 
 import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -36,7 +38,7 @@ public class SellerOrderController {
 		@AuthenticationPrincipal @Parameter(hidden = true) DefaultCurrentUser defaultCurrentUser,
 		@RequestParam(required = false) UUID orderProductId,
 		@RequestParam(required = false) OrderProductStatus status,
-		Paging paging
+		@Valid @ParameterObject Paging paging
 	) {
 		return page(
 			sellerOrderService.searchOrderProducts(

--- a/src/main/java/com/kt/controller/seller/SellerReviewController.java
+++ b/src/main/java/com/kt/controller/seller/SellerReviewController.java
@@ -1,0 +1,59 @@
+package com.kt.controller.seller;
+
+import static com.kt.common.api.ApiResult.*;
+
+import java.util.UUID;
+
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.kt.common.Paging;
+import com.kt.common.api.ApiResult;
+import com.kt.common.api.PageResponse;
+import com.kt.domain.dto.response.SellerReviewResponse;
+import com.kt.security.DefaultCurrentUser;
+import com.kt.service.seller.SellerReviewService;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/seller/reviews")
+public class SellerReviewController {
+	private final SellerReviewService sellerReviewService;
+
+	@GetMapping
+	public ResponseEntity<ApiResult<PageResponse<SellerReviewResponse.search>>> getAllReviews(
+		@AuthenticationPrincipal @Parameter(hidden = true) DefaultCurrentUser defaultCurrentUser,
+		@Valid @ParameterObject Paging paging
+	) {
+		return page(
+			sellerReviewService.getAllReviews(
+				paging.toPageable(), defaultCurrentUser.getId()
+			)
+		);
+	}
+
+	@GetMapping("/{productId}")
+	public ResponseEntity<ApiResult<PageResponse<SellerReviewResponse.search>>> getReviewsByProduct(
+		@AuthenticationPrincipal @Parameter(hidden = true) DefaultCurrentUser defaultCurrentUser,
+		@Valid @ParameterObject Paging paging,
+		@PathVariable UUID productId
+	) {
+		return page(
+			sellerReviewService.getReviewsByProduct(
+				paging.toPageable(),
+				defaultCurrentUser.getId(),
+				productId
+			)
+		);
+	}
+
+}

--- a/src/main/java/com/kt/controller/seller/SellerReviewController.java
+++ b/src/main/java/com/kt/controller/seller/SellerReviewController.java
@@ -30,7 +30,7 @@ public class SellerReviewController {
 	private final SellerReviewService sellerReviewService;
 
 	@GetMapping
-	public ResponseEntity<ApiResult<PageResponse<SellerReviewResponse.search>>> getAllReviews(
+	public ResponseEntity<ApiResult<PageResponse<SellerReviewResponse.Search>>> getAllReviews(
 		@AuthenticationPrincipal @Parameter(hidden = true) DefaultCurrentUser defaultCurrentUser,
 		@Valid @ParameterObject Paging paging
 	) {
@@ -42,7 +42,7 @@ public class SellerReviewController {
 	}
 
 	@GetMapping("/{productId}")
-	public ResponseEntity<ApiResult<PageResponse<SellerReviewResponse.search>>> getReviewsByProduct(
+	public ResponseEntity<ApiResult<PageResponse<SellerReviewResponse.Search>>> getReviewsByProduct(
 		@AuthenticationPrincipal @Parameter(hidden = true) DefaultCurrentUser defaultCurrentUser,
 		@Valid @ParameterObject Paging paging,
 		@PathVariable UUID productId

--- a/src/main/java/com/kt/domain/dto/response/OrderProductResponse.java
+++ b/src/main/java/com/kt/domain/dto/response/OrderProductResponse.java
@@ -5,7 +5,13 @@ import java.util.UUID;
 import com.kt.constant.OrderProductStatus;
 import com.querydsl.core.annotations.QueryProjection;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class OrderProductResponse {
+	@Schema(name = "SellerOrderProductResponse")
 	public record SearchReviewable(
 		UUID orderProductId,
 		Long quantity,

--- a/src/main/java/com/kt/domain/dto/response/OrderResponse.java
+++ b/src/main/java/com/kt/domain/dto/response/OrderResponse.java
@@ -17,14 +17,14 @@ public class OrderResponse {
 		UUID orderId,
 		List<OrderProductItem> orderProducts
 	) {
-		public static OrderProducts of(
+		public static OrderProducts from(
 			UUID orderId,
 			List<OrderProductEntity> orderProductEntities
 		) {
 			return new OrderProducts(
 				orderId,
 				orderProductEntities.stream()
-					.map(OrderProductItem::of)
+					.map(OrderProductItem::from)
 					.toList()
 			);
 		}
@@ -37,7 +37,7 @@ public class OrderResponse {
 		Long quantity,
 		Long unitPrice
 	) {
-		public static OrderProductItem of(OrderProductEntity orderProductEntity) {
+		public static OrderProductItem from(OrderProductEntity orderProductEntity) {
 			return new OrderProductItem(
 				orderProductEntity.getId(),
 				orderProductEntity.getProduct().getId(),
@@ -81,7 +81,7 @@ public class OrderResponse {
 				order.getCreatedAt(),
 				order.getReceiverVO(),
 				orderProducts.stream()
-					.map(OrderProductItem::of)
+					.map(OrderProductItem::from)
 					.toList()
 			);
 		}

--- a/src/main/java/com/kt/domain/dto/response/SellerOrderResponse.java
+++ b/src/main/java/com/kt/domain/dto/response/SellerOrderResponse.java
@@ -9,6 +9,9 @@ import com.querydsl.core.annotations.QueryProjection;
 
 public class SellerOrderResponse {
 	public record Search(
+		UUID orderId,
+		UUID ordererId,
+		String ordererName,
 		UUID orderProductId,
 		UUID productId,
 		String productName,

--- a/src/main/java/com/kt/domain/dto/response/SellerOrderResponse.java
+++ b/src/main/java/com/kt/domain/dto/response/SellerOrderResponse.java
@@ -1,0 +1,24 @@
+package com.kt.domain.dto.response;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import com.kt.constant.OrderProductStatus;
+import com.kt.domain.entity.ReceiverVO;
+import com.querydsl.core.annotations.QueryProjection;
+
+public class SellerOrderResponse {
+	public record Search(
+		UUID orderProductId,
+		UUID productId,
+		String productName,
+		Long quantity,
+		ReceiverVO receiverVO,
+		OrderProductStatus status,
+		Instant createdAt
+	) {
+		@QueryProjection
+		public Search {
+		}
+	}
+}

--- a/src/main/java/com/kt/domain/dto/response/SellerReviewResponse.java
+++ b/src/main/java/com/kt/domain/dto/response/SellerReviewResponse.java
@@ -1,0 +1,21 @@
+package com.kt.domain.dto.response;
+
+import java.util.UUID;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+public class SellerReviewResponse {
+	public record search(
+		UUID productId,
+		String productName,
+		UUID userId,
+		String userName,
+		UUID reviewId,
+		String content
+	) {
+		@QueryProjection
+		public search {
+
+		}
+	}
+}

--- a/src/main/java/com/kt/domain/dto/response/SellerReviewResponse.java
+++ b/src/main/java/com/kt/domain/dto/response/SellerReviewResponse.java
@@ -5,7 +5,7 @@ import java.util.UUID;
 import com.querydsl.core.annotations.QueryProjection;
 
 public class SellerReviewResponse {
-	public record search(
+	public record Search(
 		UUID productId,
 		String productName,
 		UUID userId,
@@ -14,7 +14,7 @@ public class SellerReviewResponse {
 		String content
 	) {
 		@QueryProjection
-		public search {
+		public Search {
 
 		}
 	}

--- a/src/main/java/com/kt/domain/entity/OrderProductEntity.java
+++ b/src/main/java/com/kt/domain/entity/OrderProductEntity.java
@@ -60,4 +60,8 @@ public class OrderProductEntity extends BaseEntity {
 		this.status = status;
 	}
 
+	public void confirmPaidOrderProduct() {
+		this.status = SHIPPING_READY;
+	}
+
 }

--- a/src/main/java/com/kt/repository/orderproduct/OrderProductRepositoryCustom.java
+++ b/src/main/java/com/kt/repository/orderproduct/OrderProductRepositoryCustom.java
@@ -1,16 +1,21 @@
 package com.kt.repository.orderproduct;
 
-import java.util.List;
-import java.util.UUID;
+import com.kt.constant.OrderProductStatus;
+import com.kt.domain.dto.response.OrderProductResponse;
+import com.kt.domain.dto.response.SellerOrderResponse;
+import com.kt.domain.entity.OrderProductEntity;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
-import com.kt.domain.dto.response.OrderProductResponse;
-import com.kt.domain.entity.OrderProductEntity;
+import java.util.List;
+import java.util.UUID;
 
 public interface OrderProductRepositoryCustom {
 	Page<OrderProductResponse.SearchReviewable> getReviewableOrderProductsByUserId(Pageable pageable, UUID userId);
+
 	List<OrderProductEntity> findWithProductByOrderId(UUID orderId);
 
+	Page<SellerOrderResponse.Search> search(Pageable pageable, UUID orderProductId, OrderProductStatus status,
+		UUID sellerId);
 }

--- a/src/main/java/com/kt/repository/orderproduct/OrderProductRepositoryImpl.java
+++ b/src/main/java/com/kt/repository/orderproduct/OrderProductRepositoryImpl.java
@@ -11,6 +11,8 @@ import org.springframework.stereotype.Repository;
 import com.kt.constant.OrderProductStatus;
 import com.kt.domain.dto.response.OrderProductResponse;
 import com.kt.domain.dto.response.QOrderProductResponse_SearchReviewable;
+import com.kt.domain.dto.response.QSellerOrderResponse_Search;
+import com.kt.domain.dto.response.SellerOrderResponse;
 import com.kt.domain.entity.OrderProductEntity;
 import com.kt.domain.entity.QOrderEntity;
 import com.kt.domain.entity.QOrderProductEntity;
@@ -35,7 +37,8 @@ public class OrderProductRepositoryImpl implements OrderProductRepositoryCustom 
 	private final QReviewEntity review = QReviewEntity.reviewEntity;
 
 	@Override
-	public Page<OrderProductResponse.SearchReviewable> getReviewableOrderProductsByUserId(Pageable pageable, UUID userId) {
+	public Page<OrderProductResponse.SearchReviewable> getReviewableOrderProductsByUserId(Pageable pageable,
+		UUID userId) {
 		BooleanExpression condition = review.orderProduct.isNull()
 			.and(orderProduct.status.eq(OrderProductStatus.PURCHASE_CONFIRMED));
 
@@ -81,6 +84,60 @@ public class OrderProductRepositoryImpl implements OrderProductRepositoryCustom 
 			.join(orderProduct.product, product).fetchJoin()
 			.where(orderProduct.order.id.eq(orderId))
 			.fetch();
+	}
+
+	@Override
+	public Page<SellerOrderResponse.Search> search(
+		Pageable pageable,
+		UUID orderProductId,
+		OrderProductStatus status,
+		UUID sellerId
+	) {
+		List<SellerOrderResponse.Search> content = jpaQueryFactory
+			.select(new QSellerOrderResponse_Search(
+				orderProduct.id,
+				product.id,
+				product.name,
+				orderProduct.quantity,
+				order.receiverVO,
+				orderProduct.status,
+				orderProduct.createdAt
+			))
+			.from(orderProduct)
+			.join(orderProduct.order, order)
+			.join(orderProduct.product, product)
+			.where(
+				eqOrderProductId(orderProductId),
+				eqStatus(status),
+				eqSellerId(sellerId)
+			)
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+
+		int total = jpaQueryFactory
+			.select(orderProduct.count())
+			.from(orderProduct)
+			.where(
+				eqOrderProductId(orderProductId),
+				eqStatus(status),
+				eqSellerId(sellerId)
+			)
+			.fetch().size();
+
+		return new PageImpl<>(content, pageable, total);
+	}
+
+	private BooleanExpression eqOrderProductId(UUID orderProductId) {
+		return orderProductId != null ? orderProduct.id.eq(orderProductId) : null;
+	}
+
+	private BooleanExpression eqStatus(OrderProductStatus status) {
+		return status != null ? orderProduct.status.eq(status) : null;
+	}
+
+	private BooleanExpression eqSellerId(UUID sellerId) {
+		return sellerId != null ? orderProduct.product.seller.id.eq(sellerId) : null;
 	}
 
 }

--- a/src/main/java/com/kt/repository/orderproduct/OrderProductRepositoryImpl.java
+++ b/src/main/java/com/kt/repository/orderproduct/OrderProductRepositoryImpl.java
@@ -95,6 +95,9 @@ public class OrderProductRepositoryImpl implements OrderProductRepositoryCustom 
 	) {
 		List<SellerOrderResponse.Search> content = jpaQueryFactory
 			.select(new QSellerOrderResponse_Search(
+				orderProduct.order.id,
+				orderProduct.order.orderBy.id,
+				orderProduct.order.orderBy.name,
 				orderProduct.id,
 				product.id,
 				product.name,

--- a/src/main/java/com/kt/repository/review/ReviewRepositoryCustom.java
+++ b/src/main/java/com/kt/repository/review/ReviewRepositoryCustom.java
@@ -16,5 +16,4 @@ public interface ReviewRepositoryCustom {
 
 	Page<ReviewResponse.Search> searchReviewsByProductId(Pageable pageable, UUID productId);
 
-	Page<SellerReviewResponse.search> searchReviewsForSeller(Pageable pageable, UUID sellerId, UUID productId);
-}
+	        Page<SellerReviewResponse.Search> searchReviewsForSeller(Pageable pageable, UUID sellerId, UUID productId);}

--- a/src/main/java/com/kt/repository/review/ReviewRepositoryCustom.java
+++ b/src/main/java/com/kt/repository/review/ReviewRepositoryCustom.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Pageable;
 
 import com.kt.constant.searchtype.ProductSearchType;
 import com.kt.domain.dto.response.ReviewResponse;
+import com.kt.domain.dto.response.SellerReviewResponse;
 
 public interface ReviewRepositoryCustom {
 	Page<ReviewResponse.Search> searchReviews(Pageable pageable, String keyword, ProductSearchType type);
@@ -14,4 +15,6 @@ public interface ReviewRepositoryCustom {
 	Page<ReviewResponse.Search> searchReviewsByUserId(Pageable pageable, UUID userId);
 
 	Page<ReviewResponse.Search> searchReviewsByProductId(Pageable pageable, UUID productId);
+
+	Page<SellerReviewResponse.search> searchReviewsForSeller(Pageable pageable, UUID sellerId, UUID productId);
 }

--- a/src/main/java/com/kt/repository/review/ReviewRepositoryImpl.java
+++ b/src/main/java/com/kt/repository/review/ReviewRepositoryImpl.java
@@ -147,8 +147,8 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
 			booleanBuilder.and(product.id.eq(productId));
 		}
 
-		List<SellerReviewResponse.search> contents = jpaQueryFactory
-			.select(new QSellerReviewResponse_search(
+		List<SellerReviewResponse.Search> contents = jpaQueryFactory
+			.select(new QSellerReviewResponse_Search(
 				product.id,
 				product.name,
 				user.id,

--- a/src/main/java/com/kt/repository/review/ReviewRepositoryImpl.java
+++ b/src/main/java/com/kt/repository/review/ReviewRepositoryImpl.java
@@ -10,7 +10,7 @@ import org.springframework.data.domain.Pageable;
 
 import com.kt.constant.searchtype.ProductSearchType;
 import com.kt.domain.dto.response.QReviewResponse_Search;
-import com.kt.domain.dto.response.QSellerReviewResponse_search;
+import com.kt.domain.dto.response.QSellerReviewResponse_Search;
 import com.kt.domain.dto.response.ReviewResponse;
 import com.kt.domain.dto.response.SellerReviewResponse;
 import com.kt.domain.entity.QCategoryEntity;
@@ -135,8 +135,7 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
 	}
 
 	@Override
-	public Page<SellerReviewResponse.search> searchReviewsForSeller(
-		Pageable pageable,
+	public Page<SellerReviewResponse.Search> searchReviewsForSeller(Pageable pageable,
 		UUID sellerId,
 		UUID productId
 	) {

--- a/src/main/java/com/kt/service/OrderServiceImpl.java
+++ b/src/main/java/com/kt/service/OrderServiceImpl.java
@@ -27,7 +27,6 @@ import com.kt.repository.order.OrderRepository;
 import com.kt.repository.ShippingDetailRepository;
 import com.kt.repository.orderproduct.OrderProductRepository;
 import com.kt.repository.product.ProductRepository;
-import com.kt.repository.seller.SellerRepository;
 import com.kt.repository.user.UserRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -43,12 +42,11 @@ public class OrderServiceImpl implements OrderService {
 	private final OrderProductRepository orderProductRepository;
 	private final ShippingDetailRepository shippingDetailRepository;
 	private final AddressRepository addressRepository;
-	private final SellerRepository sellerRepository;
 
 	@Override
 	public OrderResponse.OrderProducts getOrderProducts(UUID orderId) {
 		List<OrderProductEntity> orderProducts = orderProductRepository.findWithProductByOrderId(orderId);
-		return OrderResponse.OrderProducts.of(orderId, orderProducts);
+		return OrderResponse.OrderProducts.from(orderId, orderProducts);
 	}
 
 	// TODO: @Lock 붙이기
@@ -89,7 +87,6 @@ public class OrderServiceImpl implements OrderService {
 
 			UUID productId = item.productId();
 			Long quantity = item.quantity();
-			UUID sellerId = item.sellerId();
 
 			ProductEntity product = productRepository.findByIdOrThrow(productId);
 

--- a/src/main/java/com/kt/service/seller/SellerOrderService.java
+++ b/src/main/java/com/kt/service/seller/SellerOrderService.java
@@ -10,7 +10,6 @@ import com.kt.domain.dto.response.SellerOrderResponse;
 
 public interface SellerOrderService {
 
-	// TODO: OrderProductStatus.PAID 추가되면 취소 조건 변경
 	void cancelOrderProduct(UUID orderProductId, UUID sellerId);
 
 	void confirmPaidOrderProduct(UUID orderProductId, UUID sellerId);

--- a/src/main/java/com/kt/service/seller/SellerOrderService.java
+++ b/src/main/java/com/kt/service/seller/SellerOrderService.java
@@ -2,10 +2,20 @@ package com.kt.service.seller;
 
 import java.util.UUID;
 
-import com.kt.domain.dto.response.OrderResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
-// TODO: 다음 작업 단위에서 구현
+import com.kt.constant.OrderProductStatus;
+import com.kt.domain.dto.response.SellerOrderResponse;
+
 public interface SellerOrderService {
-	// OrderResponse.OrderProducts getOrderProducts(UUID productId, UUID sellerId);
+
+	// TODO: OrderProductStatus.PAID 추가되면 취소 조건 변경
+	void cancelOrderProduct(UUID orderProductId, UUID sellerId);
+
+	void confirmPaidOrderProduct(UUID orderProductId, UUID sellerId);
+
+	Page<SellerOrderResponse.Search> searchOrderProducts(Pageable pageable, OrderProductStatus status,
+		UUID orderProductId, UUID sellerID);
 
 }

--- a/src/main/java/com/kt/service/seller/SellerOrderServiceImpl.java
+++ b/src/main/java/com/kt/service/seller/SellerOrderServiceImpl.java
@@ -34,7 +34,7 @@ public class SellerOrderServiceImpl implements SellerOrderService {
 
 		OrderProductStatus status = orderProduct.getStatus();
 
-		if (status != OrderProductStatus.SHIPPING_READY && status != OrderProductStatus.PAID) {
+		if (status != OrderProductStatus.PENDING_APPROVE) {
 			throw new CustomException(ErrorCode.ORDER_ALREADY_SHIPPED);
 		}
 
@@ -54,7 +54,7 @@ public class SellerOrderServiceImpl implements SellerOrderService {
 		OrderProductEntity orderProduct = getOrderProductWithOwnerCheck(orderProductId, sellerId);
 		OrderProductStatus status = orderProduct.getStatus();
 
-		if (status != OrderProductStatus.PAID) {
+		if (status != OrderProductStatus.PENDING_APPROVE) {
 			throw new CustomException(ErrorCode.INVALID_ORDER_PRODUCT_STATUS);
 		}
 		orderProduct.confirmPaidOrderProduct();

--- a/src/main/java/com/kt/service/seller/SellerOrderServiceImpl.java
+++ b/src/main/java/com/kt/service/seller/SellerOrderServiceImpl.java
@@ -1,6 +1,71 @@
 package com.kt.service.seller;
 
-// TODO: 다음 작업 단위에서 구현
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import com.kt.constant.OrderProductStatus;
+import com.kt.constant.message.ErrorCode;
+import com.kt.domain.dto.response.SellerOrderResponse;
+import com.kt.domain.entity.OrderProductEntity;
+import com.kt.domain.entity.ProductEntity;
+import com.kt.domain.entity.SellerEntity;
+import com.kt.exception.CustomException;
+import com.kt.repository.orderproduct.OrderProductRepository;
+import com.kt.repository.seller.SellerRepository;
+import com.kt.util.Preconditions;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
 public class SellerOrderServiceImpl implements SellerOrderService {
+
+	private final SellerRepository sellerRepository;
+	private final OrderProductRepository orderProductRepository;
+
+	@Override
+	public void cancelOrderProduct(UUID orderProductId, UUID sellerId) {
+		OrderProductEntity orderProduct = getOrderProductWithOwnerCheck(orderProductId, sellerId);
+
+		OrderProductStatus status = orderProduct.getStatus();
+
+		if (status != OrderProductStatus.SHIPPING_READY && status != OrderProductStatus.PAID) {
+			throw new CustomException(ErrorCode.ORDER_ALREADY_SHIPPED);
+		}
+
+		ProductEntity product = orderProduct.getProduct();
+		product.addStock(orderProduct.getQuantity());
+		orderProduct.cancel();
+	}
+
+	@Override
+	public Page<SellerOrderResponse.Search> searchOrderProducts(Pageable pageable, OrderProductStatus status,
+		UUID orderProductId, UUID sellerId) {
+		return orderProductRepository.search(pageable, orderProductId, status, sellerId);
+	}
+
+	@Override
+	public void confirmPaidOrderProduct(UUID orderProductId, UUID sellerId) {
+		OrderProductEntity orderProduct = getOrderProductWithOwnerCheck(orderProductId, sellerId);
+		OrderProductStatus status = orderProduct.getStatus();
+
+		if (status != OrderProductStatus.PAID) {
+			throw new CustomException(ErrorCode.INVALID_ORDER_PRODUCT_STATUS);
+		}
+		orderProduct.confirmPaidOrderProduct();
+	}
+
+	private OrderProductEntity getOrderProductWithOwnerCheck(UUID orderProductId, UUID sellerId) {
+		OrderProductEntity orderProduct = orderProductRepository.findByIdOrThrow(orderProductId);
+		SellerEntity seller = sellerRepository.findByIdOrThrow(sellerId);
+		Preconditions.validate(orderProduct.getProduct().getSeller().getId().equals(seller.getId()),
+			ErrorCode.ORDER_PRODUCT_NOT_OWNER);
+		return orderProduct;
+	}
 
 }

--- a/src/main/java/com/kt/service/seller/SellerReviewService.java
+++ b/src/main/java/com/kt/service/seller/SellerReviewService.java
@@ -9,7 +9,7 @@ import com.kt.constant.searchtype.ProductSearchType;
 import com.kt.domain.dto.response.SellerReviewResponse;
 
 public interface SellerReviewService {
-	Page<SellerReviewResponse.search> getAllReviews(Pageable pageable, UUID sellerId);
+	Page<SellerReviewResponse.Search> getAllReviews(Pageable pageable, UUID sellerId);
 
-	Page<SellerReviewResponse.search> getReviewsByProduct(Pageable pageable, UUID sellerId, UUID productId);
+	Page<SellerReviewResponse.Search> getReviewsByProduct(Pageable pageable, UUID sellerId, UUID productId);
 }

--- a/src/main/java/com/kt/service/seller/SellerReviewService.java
+++ b/src/main/java/com/kt/service/seller/SellerReviewService.java
@@ -1,0 +1,5 @@
+package com.kt.service.seller;
+
+public interface SellerReviewService {
+
+}

--- a/src/main/java/com/kt/service/seller/SellerReviewService.java
+++ b/src/main/java/com/kt/service/seller/SellerReviewService.java
@@ -1,5 +1,15 @@
 package com.kt.service.seller;
 
-public interface SellerReviewService {
+import java.util.UUID;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import com.kt.constant.searchtype.ProductSearchType;
+import com.kt.domain.dto.response.SellerReviewResponse;
+
+public interface SellerReviewService {
+	Page<SellerReviewResponse.search> getAllReviews(Pageable pageable, UUID sellerId);
+
+	Page<SellerReviewResponse.search> getReviewsByProduct(Pageable pageable, UUID sellerId, UUID productId);
 }

--- a/src/main/java/com/kt/service/seller/SellerReviewServiceImpl.java
+++ b/src/main/java/com/kt/service/seller/SellerReviewServiceImpl.java
@@ -25,12 +25,12 @@ public class SellerReviewServiceImpl implements SellerReviewService {
 	private final ProductRepository productRepository;
 
 	@Override
-	public Page<SellerReviewResponse.search> getAllReviews(Pageable pageable, UUID sellerId) {
+	public Page<SellerReviewResponse.Search> getAllReviews(Pageable pageable, UUID sellerId) {
 		return reviewRepository.searchReviewsForSeller(pageable, sellerId, null);
 	}
 
 	@Override
-	public Page<SellerReviewResponse.search> getReviewsByProduct(Pageable pageable, UUID sellerId, UUID productId) {
+	public Page<SellerReviewResponse.Search> getReviewsByProduct(Pageable pageable, UUID sellerId, UUID productId) {
 		checkSellerId(sellerId, productId);
 		return reviewRepository.searchReviewsForSeller(pageable, sellerId, productId);
 	}

--- a/src/main/java/com/kt/service/seller/SellerReviewServiceImpl.java
+++ b/src/main/java/com/kt/service/seller/SellerReviewServiceImpl.java
@@ -1,0 +1,43 @@
+package com.kt.service.seller;
+
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import com.kt.constant.message.ErrorCode;
+import com.kt.domain.dto.response.SellerReviewResponse;
+import com.kt.repository.orderproduct.OrderProductRepository;
+import com.kt.repository.product.ProductRepository;
+import com.kt.repository.review.ReviewRepository;
+import com.kt.util.Preconditions;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class SellerReviewServiceImpl implements SellerReviewService {
+
+	private final ReviewRepository reviewRepository;
+	private final ProductRepository productRepository;
+
+	@Override
+	public Page<SellerReviewResponse.search> getAllReviews(Pageable pageable, UUID sellerId) {
+		return reviewRepository.searchReviewsForSeller(pageable, sellerId, null);
+	}
+
+	@Override
+	public Page<SellerReviewResponse.search> getReviewsByProduct(Pageable pageable, UUID sellerId, UUID productId) {
+		checkSellerId(sellerId, productId);
+		return reviewRepository.searchReviewsForSeller(pageable, sellerId, productId);
+	}
+
+	private void checkSellerId(UUID sellerId, UUID productId) {
+		Preconditions.validate(productRepository.findByIdOrThrow(productId).getSeller().getId().equals(sellerId),
+			ErrorCode.PRODUCT_NOT_OWNER);
+	}
+}
+

--- a/src/test/java/com/kt/api/seller/order/OrderCancelTest.java
+++ b/src/test/java/com/kt/api/seller/order/OrderCancelTest.java
@@ -1,0 +1,103 @@
+package com.kt.api.seller.order;
+
+import com.kt.common.CurrentUserCreator;
+import com.kt.common.MockMvcTest;
+import com.kt.common.SellerEntityCreator;
+import com.kt.common.UserEntityCreator;
+import com.kt.constant.OrderProductStatus;
+import com.kt.domain.entity.CategoryEntity;
+import com.kt.domain.entity.OrderEntity;
+import com.kt.domain.entity.OrderProductEntity;
+import com.kt.domain.entity.ProductEntity;
+import com.kt.domain.entity.ReceiverVO;
+import com.kt.domain.entity.SellerEntity;
+import com.kt.domain.entity.UserEntity;
+import com.kt.repository.CategoryRepository;
+import com.kt.repository.order.OrderRepository;
+import com.kt.repository.orderproduct.OrderProductRepository;
+import com.kt.repository.product.ProductRepository;
+import com.kt.repository.seller.SellerRepository;
+import com.kt.repository.user.UserRepository;
+import com.kt.security.DefaultCurrentUser;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static com.kt.common.CategoryEntityCreator.createCategory;
+import static com.kt.common.ProductEntityCreator.createProduct;
+import static com.kt.common.SellerEntityCreator.createSeller;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("판매자 주문 상품 취소 - PATCH /api/seller/orders/{orderProductId}/cancel")
+public class OrderCancelTest extends MockMvcTest {
+
+	@Autowired
+	private OrderProductRepository orderProductRepository;
+	@Autowired
+	private ProductRepository productRepository;
+	@Autowired
+	private CategoryRepository categoryRepository;
+	@Autowired
+	private SellerRepository sellerRepository;
+	@Autowired
+	private UserRepository userRepository;
+	@Autowired
+	private OrderRepository orderRepository;
+
+	private SellerEntity testSeller;
+	private UserEntity testUser;
+	private CategoryEntity testCategory;
+	private OrderEntity testOrder;
+	private OrderProductEntity testOrderProduct;
+	private DefaultCurrentUser sellerDetails;
+
+	@BeforeEach
+	void setUp() {
+		testUser = UserEntityCreator.createMember();
+		userRepository.save(testUser);
+
+		testSeller = SellerEntityCreator.createSeller();
+		sellerRepository.save(testSeller);
+
+		testCategory = createCategory();
+		categoryRepository.save(testCategory);
+
+		sellerDetails = CurrentUserCreator.getSellerUserDetails(testSeller.getId());
+
+		ReceiverVO receiverVO = ReceiverVO.create("test", "010-1234-5678", "city", "district", "road", "detail");
+		testOrder = orderRepository.save(OrderEntity.create(receiverVO, testUser));
+
+		ProductEntity product = createProduct(testCategory, testSeller);
+		productRepository.save(product);
+		testOrderProduct = orderProductRepository.save(
+			OrderProductEntity.create(1L, product.getPrice(), OrderProductStatus.CREATED, testOrder, product));
+	}
+
+	@Test
+	void 판매자_주문_상품_취소_성공__200_OK() throws Exception {
+		// given
+		testOrderProduct.updateStatus(OrderProductStatus.SHIPPING_READY);
+		orderProductRepository.save(testOrderProduct);
+
+		// when
+		ResultActions actions = mockMvc.perform(
+				patch("/api/seller/orders/{orderProductId}/cancel", testOrderProduct.getId())
+					.with(user(sellerDetails)))
+			.andDo(print());
+
+		// then
+		actions.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value("ok"));
+
+		OrderProductEntity cancelledOrderProduct = orderProductRepository.findById(testOrderProduct.getId()).orElseThrow();
+		assertThat(cancelledOrderProduct.getStatus()).isEqualTo(OrderProductStatus.CANCELED);
+	}
+}

--- a/src/test/java/com/kt/api/seller/order/OrderCancelTest.java
+++ b/src/test/java/com/kt/api/seller/order/OrderCancelTest.java
@@ -84,7 +84,7 @@ public class OrderCancelTest extends MockMvcTest {
 	@Test
 	void 판매자_주문_상품_취소_성공__200_OK() throws Exception {
 		// given
-		testOrderProduct.updateStatus(OrderProductStatus.SHIPPING_READY);
+		testOrderProduct.updateStatus(OrderProductStatus.PENDING_APPROVE);
 		orderProductRepository.save(testOrderProduct);
 
 		// when

--- a/src/test/java/com/kt/api/seller/order/OrderConfirmTest.java
+++ b/src/test/java/com/kt/api/seller/order/OrderConfirmTest.java
@@ -76,7 +76,7 @@ public class OrderConfirmTest extends MockMvcTest {
 		ProductEntity product = createProduct(testCategory, testSeller);
 		productRepository.save(product);
 		testOrderProduct = orderProductRepository.save(
-			OrderProductEntity.create(1L, product.getPrice(), OrderProductStatus.PAID, testOrder, product));
+			OrderProductEntity.create(1L, product.getPrice(), OrderProductStatus.PENDING_APPROVE, testOrder, product));
 	}
 
 	@Test

--- a/src/test/java/com/kt/api/seller/order/OrderConfirmTest.java
+++ b/src/test/java/com/kt/api/seller/order/OrderConfirmTest.java
@@ -1,0 +1,98 @@
+package com.kt.api.seller.order;
+
+import com.kt.common.CurrentUserCreator;
+import com.kt.common.MockMvcTest;
+import com.kt.common.SellerEntityCreator;
+import com.kt.common.UserEntityCreator;
+import com.kt.constant.OrderProductStatus;
+import com.kt.domain.entity.CategoryEntity;
+import com.kt.domain.entity.OrderEntity;
+import com.kt.domain.entity.OrderProductEntity;
+import com.kt.domain.entity.ProductEntity;
+import com.kt.domain.entity.ReceiverVO;
+import com.kt.domain.entity.SellerEntity;
+import com.kt.domain.entity.UserEntity;
+import com.kt.repository.CategoryRepository;
+import com.kt.repository.order.OrderRepository;
+import com.kt.repository.orderproduct.OrderProductRepository;
+import com.kt.repository.product.ProductRepository;
+import com.kt.repository.seller.SellerRepository;
+import com.kt.repository.user.UserRepository;
+import com.kt.security.DefaultCurrentUser;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static com.kt.common.CategoryEntityCreator.createCategory;
+import static com.kt.common.ProductEntityCreator.createProduct;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("판매자 주문 상품 취소 - PATCH /api/seller/orders/{orderProductId}/confirm")
+public class OrderConfirmTest extends MockMvcTest {
+	@Autowired
+	private OrderProductRepository orderProductRepository;
+	@Autowired
+	private ProductRepository productRepository;
+	@Autowired
+	private CategoryRepository categoryRepository;
+	@Autowired
+	private SellerRepository sellerRepository;
+	@Autowired
+	private UserRepository userRepository;
+	@Autowired
+	private OrderRepository orderRepository;
+
+	private SellerEntity testSeller;
+	private UserEntity testUser;
+	private CategoryEntity testCategory;
+	private OrderEntity testOrder;
+	private OrderProductEntity testOrderProduct;
+	private DefaultCurrentUser sellerDetails;
+
+	@BeforeEach
+	void setUp() {
+		testUser = UserEntityCreator.createMember();
+		userRepository.save(testUser);
+
+		testSeller = SellerEntityCreator.createSeller();
+		sellerRepository.save(testSeller);
+
+		testCategory = createCategory();
+		categoryRepository.save(testCategory);
+
+		sellerDetails = CurrentUserCreator.getSellerUserDetails(testSeller.getId());
+
+		ReceiverVO receiverVO = ReceiverVO.create("test", "010-1234-5678", "city", "district", "road", "detail");
+		testOrder = orderRepository.save(OrderEntity.create(receiverVO, testUser));
+
+		ProductEntity product = createProduct(testCategory, testSeller);
+		productRepository.save(product);
+		testOrderProduct = orderProductRepository.save(
+			OrderProductEntity.create(1L, product.getPrice(), OrderProductStatus.PAID, testOrder, product));
+	}
+
+	@Test
+	void 판매자_주문_상품_배송_대기중으로_변경__200_OK() throws Exception {
+		// when
+		ResultActions actions = mockMvc.perform(
+				patch("/api/seller/orders/{orderProductId}/confirm", testOrderProduct.getId())
+					.with(user(sellerDetails)))
+			.andDo(print());
+
+		// then
+		actions.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value("ok"));
+
+		OrderProductEntity confirmedOrderProduct = orderProductRepository.findByIdOrThrow(testOrderProduct.getId());
+		assertThat(confirmedOrderProduct.getStatus()).isEqualTo(OrderProductStatus.SHIPPING_READY);
+
+	}
+}

--- a/src/test/java/com/kt/api/seller/order/OrderSearchTest.java
+++ b/src/test/java/com/kt/api/seller/order/OrderSearchTest.java
@@ -1,0 +1,203 @@
+package com.kt.api.seller.order;
+
+import com.kt.common.CurrentUserCreator;
+import com.kt.common.MockMvcTest;
+import com.kt.common.SellerEntityCreator;
+import com.kt.common.UserEntityCreator;
+import com.kt.constant.OrderProductStatus;
+import com.kt.domain.entity.CategoryEntity;
+import com.kt.domain.entity.OrderEntity;
+import com.kt.domain.entity.OrderProductEntity;
+import com.kt.domain.entity.ProductEntity;
+import com.kt.domain.entity.ReceiverVO;
+import com.kt.domain.entity.SellerEntity;
+import com.kt.domain.entity.UserEntity;
+import com.kt.repository.CategoryRepository;
+import com.kt.repository.order.OrderRepository;
+import com.kt.repository.orderproduct.OrderProductRepository;
+import com.kt.repository.product.ProductRepository;
+import com.kt.repository.seller.SellerRepository;
+import com.kt.repository.user.UserRepository;
+import com.kt.security.DefaultCurrentUser;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static com.kt.common.CategoryEntityCreator.createCategory;
+import static com.kt.common.ProductEntityCreator.createProduct;
+import static com.kt.common.SellerEntityCreator.createSeller;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("판매자 주문 상품 목록 조회 - GET /api/seller/orders")
+public class OrderSearchTest extends MockMvcTest {
+
+	@Autowired
+	private OrderProductRepository orderProductRepository;
+	@Autowired
+	private ProductRepository productRepository;
+	@Autowired
+	private CategoryRepository categoryRepository;
+	@Autowired
+	private SellerRepository sellerRepository;
+	@Autowired
+	private UserRepository userRepository;
+	@Autowired
+	private OrderRepository orderRepository;
+
+	private SellerEntity testSeller;
+	private UserEntity testUser;
+	private CategoryEntity testCategory;
+	private OrderEntity testOrder;
+	private OrderProductEntity testOrderProduct1;
+	private OrderProductEntity testOrderProduct2;
+	private DefaultCurrentUser sellerDetails;
+
+	@BeforeEach
+	void setUp() {
+		testUser = UserEntityCreator.createMember();
+		userRepository.save(testUser);
+
+		testSeller = SellerEntityCreator.createSeller();
+		sellerRepository.save(testSeller);
+
+		sellerDetails = CurrentUserCreator.getSellerUserDetails(testSeller.getId());
+
+		testCategory = createCategory();
+		categoryRepository.save(testCategory);
+
+		ReceiverVO receiverVO = ReceiverVO.create(
+			"test", "010-1234-5678", "city", "district", "road", "detail"
+		);
+		testOrder = orderRepository.save(OrderEntity.create(receiverVO, testUser));
+
+		ProductEntity product1 = createProduct(testCategory, testSeller);
+		productRepository.save(product1);
+		testOrderProduct1 = orderProductRepository.save(
+			OrderProductEntity.create(
+				1L,
+				product1.getPrice(),
+				OrderProductStatus.CREATED,
+				testOrder,
+				product1
+			)
+		);
+
+		ProductEntity product2 = createProduct(testCategory, testSeller);
+		productRepository.save(product2);
+		testOrderProduct2 = orderProductRepository.save(
+			OrderProductEntity.create(
+				2L,
+				product2.getPrice(),
+				OrderProductStatus.SHIPPING,
+				testOrder,
+				product2
+			)
+		);
+	}
+
+	@Test
+	void 판매자_주문_상품_목록_조회_성공__200_OK() throws Exception {
+
+		// given
+		ResultActions actions = mockMvc.perform(
+				get("/api/seller/orders")
+					.with(user(sellerDetails))
+					.param("page", "1")
+					.param("size", "10")
+			)
+			.andDo(print());
+
+		// then
+		actions.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value("ok"))
+			.andExpect(jsonPath("$.data.list.length()").value(2));
+	}
+
+	@Test
+	void 판매자_주문_상품_목록_조회_필터링__orderProductId_성공() throws Exception {
+
+		// given
+		ResultActions actions = mockMvc.perform(
+				get("/api/seller/orders")
+					.with(user(sellerDetails))
+					.param("page", "1")
+					.param("size", "10")
+					.param("orderProductId", testOrderProduct1.getId().toString())
+			)
+			.andDo(print());
+
+		// then
+		actions.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value("ok"))
+			.andExpect(jsonPath("$.data.list.length()").value(1))
+			.andExpect(jsonPath("$.data.list[0].orderProductId")
+				.value(testOrderProduct1.getId().toString()));
+	}
+
+	@Test
+	void 판매자_주문_상품_목록_조회_필터링__status_성공() throws Exception {
+
+		// given
+
+		ResultActions actions = mockMvc.perform(
+				get("/api/seller/orders")
+					.with(user(sellerDetails))
+					.param("page", "1")
+					.param("size", "10")
+					.param("status", OrderProductStatus.SHIPPING.name())
+			)
+			.andDo(print());
+
+		actions.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value("ok"))
+			.andExpect(jsonPath("$.data.list.length()").value(1))
+			.andExpect(jsonPath("$.data.list[0].orderProductId")
+				.value(testOrderProduct2.getId().toString()))
+			.andExpect(jsonPath("$.data.list[0].status")
+				.value(OrderProductStatus.SHIPPING.name()));
+	}
+
+	@Test
+	void 판매자_주문_상품_목록_조회_실패__다른_판매자_상품() throws Exception {
+
+		// given
+
+		SellerEntity otherSeller = createSeller();
+		sellerRepository.save(otherSeller);
+
+		ProductEntity otherProduct = createProduct(testCategory, otherSeller);
+		productRepository.save(otherProduct);
+
+		OrderProductEntity otherOrderProduct = orderProductRepository.save(
+			OrderProductEntity.create(
+				1L,
+				otherProduct.getPrice(),
+				OrderProductStatus.CREATED,
+				testOrder,
+				otherProduct
+			)
+		);
+
+		// then
+
+		ResultActions actions = mockMvc.perform(
+				get("/api/seller/orders")
+					.with(user(sellerDetails))
+					.param("page", "1")
+					.param("size", "10")
+					.param("orderProductId", otherOrderProduct.getId().toString())
+			)
+			.andDo(print());
+
+		actions.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value("ok"))
+			.andExpect(jsonPath("$.data.list.length()").value(0));
+	}
+}

--- a/src/test/java/com/kt/api/seller/review/ReviewSearchAllTest.java
+++ b/src/test/java/com/kt/api/seller/review/ReviewSearchAllTest.java
@@ -1,0 +1,109 @@
+package com.kt.api.seller.review;
+
+import com.kt.common.CurrentUserCreator;
+import com.kt.common.MockMvcTest;
+import com.kt.common.SellerEntityCreator;
+import com.kt.common.UserEntityCreator;
+import com.kt.constant.OrderProductStatus;
+import com.kt.domain.entity.CategoryEntity;
+import com.kt.domain.entity.OrderEntity;
+import com.kt.domain.entity.OrderProductEntity;
+import com.kt.domain.entity.ProductEntity;
+import com.kt.domain.entity.ReceiverVO;
+import com.kt.domain.entity.ReviewEntity;
+import com.kt.domain.entity.SellerEntity;
+import com.kt.domain.entity.UserEntity;
+import com.kt.repository.CategoryRepository;
+import com.kt.repository.order.OrderRepository;
+import com.kt.repository.orderproduct.OrderProductRepository;
+import com.kt.repository.product.ProductRepository;
+import com.kt.repository.review.ReviewRepository;
+import com.kt.repository.seller.SellerRepository;
+import com.kt.repository.user.UserRepository;
+import com.kt.security.DefaultCurrentUser;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static com.kt.common.CategoryEntityCreator.createCategory;
+import static com.kt.common.ProductEntityCreator.createProduct;
+import static com.kt.common.SellerEntityCreator.createSeller;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("판매자 전체 리뷰 조회 - GET /api/seller/reviews")
+public class ReviewSearchAllTest extends MockMvcTest {
+
+	@Autowired
+	private ReviewRepository reviewRepository;
+	@Autowired
+	private OrderProductRepository orderProductRepository;
+	@Autowired
+	private ProductRepository productRepository;
+	@Autowired
+	private UserRepository userRepository;
+	@Autowired
+	private OrderRepository orderRepository;
+	@Autowired
+	private CategoryRepository categoryRepository;
+	@Autowired
+	private SellerRepository sellerRepository;
+
+	private SellerEntity testSeller;
+	private UserEntity testUser;
+	private CategoryEntity testCategory;
+	private OrderEntity testOrder;
+	private OrderProductEntity testOrderProduct;
+	private ReviewEntity testReview;
+	private DefaultCurrentUser sellerDetails;
+
+	@BeforeEach
+	void setUp() {
+		testUser = UserEntityCreator.createMember();
+		userRepository.save(testUser);
+
+		testSeller = createSeller();
+		sellerRepository.save(testSeller);
+
+		testCategory = createCategory();
+		categoryRepository.save(testCategory);
+
+		sellerDetails = CurrentUserCreator.getSellerUserDetails(testSeller.getId());
+
+		ReceiverVO receiverVO = ReceiverVO.create("test", "010-1234-5678", "city", "district", "road", "detail");
+		testOrder = orderRepository.save(OrderEntity.create(receiverVO, testUser));
+
+		ProductEntity product = createProduct(testCategory, testSeller);
+		productRepository.save(product);
+
+		testOrderProduct = orderProductRepository.save(
+			OrderProductEntity.create(1L, product.getPrice(), OrderProductStatus.PURCHASE_CONFIRMED, testOrder, product));
+
+		testReview = ReviewEntity.create("판매자 리뷰 내용");
+		testReview.mapToOrderProduct(testOrderProduct);
+		reviewRepository.save(testReview);
+	}
+
+	@Test
+	void 판매자_전체_리뷰_조회_성공__200_OK() throws Exception {
+		// when
+		ResultActions actions = mockMvc.perform(get("/api/seller/reviews")
+				.with(user(sellerDetails))
+				.param("page", "1")
+				.param("size", "10"))
+			.andDo(print());
+
+		// then
+		actions.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value("ok"))
+			.andExpect(jsonPath("$.data.list.length()").value(1))
+			.andExpect(jsonPath("$.data.list[0].reviewId").value(testReview.getId().toString()))
+			.andExpect(jsonPath("$.data.list[0].content").value(testReview.getContent()));
+	}
+}

--- a/src/test/java/com/kt/api/seller/review/ReviewSearchByProductTest.java
+++ b/src/test/java/com/kt/api/seller/review/ReviewSearchByProductTest.java
@@ -1,0 +1,110 @@
+package com.kt.api.seller.review;
+
+import com.kt.common.CurrentUserCreator;
+import com.kt.common.MockMvcTest;
+import com.kt.common.UserEntityCreator;
+import com.kt.constant.OrderProductStatus;
+import com.kt.domain.entity.CategoryEntity;
+import com.kt.domain.entity.OrderEntity;
+import com.kt.domain.entity.OrderProductEntity;
+import com.kt.domain.entity.ProductEntity;
+import com.kt.domain.entity.ReceiverVO;
+import com.kt.domain.entity.ReviewEntity;
+import com.kt.domain.entity.SellerEntity;
+import com.kt.domain.entity.UserEntity;
+import com.kt.repository.CategoryRepository;
+import com.kt.repository.order.OrderRepository;
+import com.kt.repository.orderproduct.OrderProductRepository;
+import com.kt.repository.product.ProductRepository;
+import com.kt.repository.review.ReviewRepository;
+import com.kt.repository.seller.SellerRepository;
+import com.kt.repository.user.UserRepository;
+import com.kt.security.DefaultCurrentUser;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static com.kt.common.CategoryEntityCreator.createCategory;
+import static com.kt.common.ProductEntityCreator.createProduct;
+import static com.kt.common.SellerEntityCreator.createSeller;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("판매자 상품별 리뷰 조회 - GET /api/seller/reviews/{productId}")
+public class ReviewSearchByProductTest extends MockMvcTest {
+
+	@Autowired
+	private ReviewRepository reviewRepository;
+	@Autowired
+	private OrderProductRepository orderProductRepository;
+	@Autowired
+	private ProductRepository productRepository;
+	@Autowired
+	private UserRepository userRepository;
+	@Autowired
+	private OrderRepository orderRepository;
+	@Autowired
+	private CategoryRepository categoryRepository;
+	@Autowired
+	private SellerRepository sellerRepository;
+
+	private SellerEntity testSeller;
+	private UserEntity testUser;
+	private CategoryEntity testCategory;
+	private OrderEntity testOrder;
+	private ProductEntity testProduct;
+	private OrderProductEntity testOrderProduct;
+	private ReviewEntity testReview;
+	private DefaultCurrentUser sellerDetails;
+
+	@BeforeEach
+	void setUp() {
+		testUser = UserEntityCreator.createMember();
+		userRepository.save(testUser);
+
+		testSeller = createSeller();
+		sellerRepository.save(testSeller);
+
+		testCategory = createCategory();
+		categoryRepository.save(testCategory);
+
+		sellerDetails = CurrentUserCreator.getSellerUserDetails(testSeller.getId());
+
+		ReceiverVO receiverVO = ReceiverVO.create("test", "010-1234-5678", "city", "district", "road", "detail");
+		testOrder = orderRepository.save(OrderEntity.create(receiverVO, testUser));
+
+		testProduct = createProduct(testCategory, testSeller);
+		productRepository.save(testProduct);
+
+		testOrderProduct = orderProductRepository.save(
+			OrderProductEntity.create(1L, testProduct.getPrice(), OrderProductStatus.PURCHASE_CONFIRMED, testOrder,
+				testProduct));
+
+		testReview = ReviewEntity.create("판매자 상품별 리뷰 내용");
+		testReview.mapToOrderProduct(testOrderProduct);
+		reviewRepository.save(testReview);
+	}
+
+	@Test
+	void 판매자_상품별_리뷰_조회_성공__200_OK() throws Exception {
+		// when
+		ResultActions actions = mockMvc.perform(get("/api/seller/reviews/{productId}", testProduct.getId())
+				.with(user(sellerDetails))
+				.param("page", "1")
+				.param("size", "10"))
+			.andDo(print());
+
+		// then
+		actions.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value("ok"))
+			.andExpect(jsonPath("$.data.list.length()").value(1))
+			.andExpect(jsonPath("$.data.list[0].reviewId").value(testReview.getId().toString()))
+			.andExpect(jsonPath("$.data.list[0].content").value(testReview.getContent()));
+	}
+}

--- a/src/test/java/com/kt/common/CurrentUserCreator.java
+++ b/src/test/java/com/kt/common/CurrentUserCreator.java
@@ -87,4 +87,5 @@ public class CurrentUserCreator {
 		);
 	}
 
+
 }

--- a/src/test/java/com/kt/service/seller/SellerOrderServiceTest.java
+++ b/src/test/java/com/kt/service/seller/SellerOrderServiceTest.java
@@ -1,0 +1,157 @@
+package com.kt.service.seller;
+
+import com.kt.common.CategoryEntityCreator;
+import com.kt.common.ProductEntityCreator;
+import com.kt.common.SellerEntityCreator;
+import com.kt.common.UserEntityCreator;
+import com.kt.constant.OrderProductStatus;
+import com.kt.domain.entity.CategoryEntity;
+import com.kt.domain.entity.OrderEntity;
+import com.kt.domain.entity.OrderProductEntity;
+import com.kt.domain.entity.ProductEntity;
+import com.kt.domain.entity.ReceiverVO;
+import com.kt.domain.entity.SellerEntity;
+import com.kt.domain.entity.UserEntity;
+import com.kt.repository.CategoryRepository;
+import com.kt.repository.order.OrderRepository;
+import com.kt.repository.orderproduct.OrderProductRepository;
+import com.kt.repository.product.ProductRepository;
+import com.kt.repository.seller.SellerRepository;
+import com.kt.repository.user.UserRepository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Transactional
+@ActiveProfiles("test")
+@SpringBootTest
+@DisplayName("판매자 주문 서비스 테스트")
+class SellerOrderServiceTest {
+
+	@Autowired
+	private SellerOrderService sellerOrderService;
+	@Autowired
+	private OrderProductRepository orderProductRepository;
+	@Autowired
+	private ProductRepository productRepository;
+	@Autowired
+	private CategoryRepository categoryRepository;
+	@Autowired
+	private SellerRepository sellerRepository;
+	@Autowired
+	private UserRepository userRepository;
+	@Autowired
+	private OrderRepository orderRepository;
+
+	private SellerEntity testSeller;
+	private CategoryEntity testCategory;
+	private UserEntity testUser;
+
+	@BeforeEach
+	void setUp() {
+		testUser = UserEntityCreator.createMember();
+		userRepository.save(testUser);
+
+		testSeller = SellerEntityCreator.createSeller();
+		sellerRepository.save(testSeller);
+
+		testCategory = CategoryEntityCreator.createCategory();
+		categoryRepository.save(testCategory);
+	}
+
+	private OrderEntity createOrder() {
+		ReceiverVO receiverVO = ReceiverVO.create("test", "010-1234-5678", "city", "district", "road", "detail");
+		return orderRepository.save(OrderEntity.create(receiverVO, testUser));
+	}
+
+	private OrderProductEntity createOrderProduct(OrderEntity order, OrderProductStatus status) {
+		ProductEntity product = ProductEntityCreator.createProduct(testCategory, testSeller);
+		productRepository.save(product);
+		return orderProductRepository.save(OrderProductEntity.create(1L, product.getPrice(), status, order, product));
+	}
+
+	@Test
+	void 판매자_주문_상품_검색_성공() {
+		// given
+		OrderEntity order = createOrder();
+		createOrderProduct(order, OrderProductStatus.CREATED);
+		createOrderProduct(order, OrderProductStatus.SHIPPING);
+		createOrderProduct(order, OrderProductStatus.SHIPPING_COMPLETED);
+
+		Pageable pageable = PageRequest.of(0, 10);
+
+		// when
+		Page<com.kt.domain.dto.response.SellerOrderResponse.Search> result = sellerOrderService.searchOrderProducts(
+			pageable, null, null, testSeller.getId());
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.getTotalElements()).isEqualTo(3);
+		assertThat(result.getContent()).hasSize(3);
+	}
+
+	@Test
+	void 판매자_주문_상품_검색_필터링__orderProductId_성공() {
+		// given
+		OrderEntity order = createOrder();
+		OrderProductEntity op1 = createOrderProduct(order, OrderProductStatus.CREATED);
+		createOrderProduct(order, OrderProductStatus.SHIPPING);
+
+		Pageable pageable = PageRequest.of(0, 10);
+
+		// when
+		Page<com.kt.domain.dto.response.SellerOrderResponse.Search> result = sellerOrderService.searchOrderProducts(
+			pageable, null, op1.getId(), testSeller.getId());
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.getTotalElements()).isEqualTo(1);
+		assertThat(result.getContent()).hasSize(1);
+		assertThat(result.getContent().get(0).orderProductId()).isEqualTo(op1.getId());
+	}
+
+	@Test
+	void 판매자_주문_상품_검색_필터링__status_성공() {
+		// given
+		OrderEntity order = createOrder();
+		createOrderProduct(order, OrderProductStatus.CREATED);
+		createOrderProduct(order, OrderProductStatus.SHIPPING);
+		createOrderProduct(order, OrderProductStatus.SHIPPING);
+
+		Pageable pageable = PageRequest.of(0, 10);
+
+		// when
+		Page<com.kt.domain.dto.response.SellerOrderResponse.Search> result = sellerOrderService.searchOrderProducts(
+			pageable, OrderProductStatus.SHIPPING, null, testSeller.getId());
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.getTotalElements()).isEqualTo(2);
+		assertThat(result.getContent()).hasSize(2);
+		assertThat(result.getContent().get(0).status()).isEqualTo(OrderProductStatus.SHIPPING);
+	}
+
+	@Test
+	void 판매자_결제_상품_컨펌_성공() {
+		// given
+		OrderEntity order = createOrder();
+		OrderProductEntity op1 = createOrderProduct(order, OrderProductStatus.PAID);
+
+		// when
+		sellerOrderService.confirmPaidOrderProduct(op1.getId(), testSeller.getId());
+
+		// then
+		assertThat(op1.getStatus()).isEqualTo(OrderProductStatus.SHIPPING_READY);
+
+	}
+}

--- a/src/test/java/com/kt/service/seller/SellerOrderServiceTest.java
+++ b/src/test/java/com/kt/service/seller/SellerOrderServiceTest.java
@@ -145,7 +145,7 @@ class SellerOrderServiceTest {
 	void 판매자_결제_상품_컨펌_성공() {
 		// given
 		OrderEntity order = createOrder();
-		OrderProductEntity op1 = createOrderProduct(order, OrderProductStatus.PAID);
+		OrderProductEntity op1 = createOrderProduct(order, OrderProductStatus.PENDING_APPROVE);
 
 		// when
 		sellerOrderService.confirmPaidOrderProduct(op1.getId(), testSeller.getId());

--- a/src/test/java/com/kt/service/seller/SellerReviewServiceTest.java
+++ b/src/test/java/com/kt/service/seller/SellerReviewServiceTest.java
@@ -1,0 +1,136 @@
+package com.kt.service.seller;
+
+import com.kt.common.CategoryEntityCreator;
+import com.kt.common.OrderEntityCreator;
+import com.kt.common.OrderProductCreator;
+import com.kt.common.ProductCreator;
+import com.kt.common.SellerEntityCreator;
+import com.kt.common.UserEntityCreator;
+import com.kt.constant.OrderProductStatus;
+import com.kt.constant.ReviewStatus;
+import com.kt.domain.dto.response.SellerReviewResponse;
+import com.kt.domain.entity.CategoryEntity;
+import com.kt.domain.entity.OrderEntity;
+import com.kt.domain.entity.OrderProductEntity;
+import com.kt.domain.entity.ProductEntity;
+import com.kt.domain.entity.ReceiverVO;
+import com.kt.domain.entity.ReviewEntity;
+import com.kt.domain.entity.SellerEntity;
+import com.kt.domain.entity.UserEntity;
+import com.kt.repository.CategoryRepository;
+import com.kt.repository.order.OrderRepository;
+import com.kt.repository.orderproduct.OrderProductRepository;
+import com.kt.repository.product.ProductRepository;
+import com.kt.repository.review.ReviewRepository;
+import com.kt.repository.seller.SellerRepository;
+import com.kt.repository.user.UserRepository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Transactional
+@SpringBootTest
+@ActiveProfiles("test")
+@DisplayName("판매자 리뷰 서비스 테스트")
+class SellerReviewServiceTest {
+
+	@Autowired
+	private SellerReviewService sellerReviewService;
+	@Autowired
+	private ReviewRepository reviewRepository;
+	@Autowired
+	private OrderProductRepository orderProductRepository;
+	@Autowired
+	private ProductRepository productRepository;
+	@Autowired
+	private UserRepository userRepository;
+	@Autowired
+	private OrderRepository orderRepository;
+	@Autowired
+	private CategoryRepository categoryRepository;
+	@Autowired
+	private SellerRepository sellerRepository;
+
+	private OrderProductEntity testOrderProduct;
+	private UserEntity testUser;
+	private CategoryEntity testCategory;
+	private SellerEntity testSeller;
+	private ProductEntity testProduct;
+
+	@BeforeEach
+	void setUp() {
+		testUser = UserEntityCreator.createMember();
+		userRepository.save(testUser);
+
+		testSeller = SellerEntityCreator.createSeller();
+		sellerRepository.save(testSeller);
+
+		testCategory = CategoryEntityCreator.createCategory();
+		categoryRepository.save(testCategory);
+
+		OrderEntity order = createOrderEntity(testUser);
+		orderRepository.save(order);
+
+		testProduct = ProductCreator.createProduct(testCategory, testSeller);
+		productRepository.save(testProduct);
+
+		testOrderProduct = OrderProductCreator.createOrderProduct(order, testProduct, testSeller);
+		orderProductRepository.save(testOrderProduct);
+
+		order.getOrderProducts().add(testOrderProduct);
+	}
+
+	private OrderEntity createOrderEntity(UserEntity user) {
+		ReceiverVO receiverVO = ReceiverVO.create("test", "010-1234-5678", "city", "district", "road", "detail");
+		return OrderEntity.create(receiverVO, user);
+	}
+
+	@Test
+	void 판매자_모든_리뷰_조회_성공() {
+		// given
+		ReviewEntity review = ReviewEntity.create("테스트리뷰내용");
+		review.mapToOrderProduct(testOrderProduct);
+		reviewRepository.save(review);
+
+		Pageable pageable = PageRequest.of(0, 10);
+
+		// when
+		Page<SellerReviewResponse.Search> result = sellerReviewService.getAllReviews(pageable, testSeller.getId());
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.getTotalElements()).isEqualTo(1);
+		assertThat(result.getContent()).hasSize(1);
+		assertThat(result.getContent().get(0).reviewId()).isEqualTo(review.getId());
+	}
+
+	@Test
+	void 판매자_상품별_리뷰_조회_성공() {
+		// given
+		ReviewEntity review = ReviewEntity.create("테스트리뷰내용");
+		review.mapToOrderProduct(testOrderProduct);
+		reviewRepository.save(review);
+
+		Pageable pageable = PageRequest.of(0, 10);
+
+		// when
+		Page<SellerReviewResponse.Search> result = sellerReviewService.getReviewsByProduct(pageable, testSeller.getId(),
+			testProduct.getId());
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.getTotalElements()).isEqualTo(1);
+		assertThat(result.getContent()).hasSize(1);
+		assertThat(result.getContent().get(0).reviewId()).isEqualTo(review.getId());
+	}
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- resolves: #이슈번호, #이슈번호 -->
resolves: #210 

## 📝작업 내용

판매자 주문, 리뷰 서비스/컨트롤러 및 테스트 작성했습니다.

**주문**
- cancelOrderProduct
  - 판매자의 주문 취소 로직
- searchOrdeProducts
  - 판매자의 판매 물품 조회 
- confirmPaidOrderProduct
  - OrderProduct PAID -> SHIPPING_READY 상태 전환

판매자 주문 취소 로직에서 PAID, SHIPPING_READY 일 때 가능하도록 했습니다.
판매자 취소는 PAID일 때만 가능하게 변경하면 좋을까요?

**리뷰**
- getAllReviews
  - 리뷰 전체 조회
- getReviewsByProduct
  - 상품 별 리뷰 조회
리뷰는 두 로직 하나의 QueryDsl 메서드 사용합니다.

급하다보니 자꾸 PR크기가 커지네요 다음부터 주의하겠습니다.
스웨거 관련은 다른 PR에서 작업하도록 하겠습니다.


<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->