### PR TITLE
[FEAT] 계좌거래내역(BankAccountTransaction) 생성 및 계좌 도메인 소지자 분리 (User, Seller - BankAccountHolderEntity)

### DIFF
--- a/src/main/java/com/kt/constant/bankaccount/BankAccountTransactionPurpose.java
+++ b/src/main/java/com/kt/constant/bankaccount/BankAccountTransactionPurpose.java
@@ -1,0 +1,14 @@
+package com.kt.constant.bankaccount;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum BankAccountTransactionPurpose {
+	SALARY("급여입금"),
+	PAY_CHARGE("페이충전"),
+	PAY_WITHDRAW("페이잔액 계좌입금"),
+	ORDER_SETTLEMENT("판매정산입금"),
+	ORDER_REFUND("환불출금");
+
+	private final String description;
+}

--- a/src/main/java/com/kt/constant/bankaccount/BankAccountTransactionType.java
+++ b/src/main/java/com/kt/constant/bankaccount/BankAccountTransactionType.java
@@ -1,0 +1,11 @@
+package com.kt.constant.bankaccount;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum BankAccountTransactionType {
+	DEPOSIT("입금"),
+	WITHDRAW("출금");
+
+	private final String description;
+}

--- a/src/main/java/com/kt/domain/entity/BankAccountEntity.java
+++ b/src/main/java/com/kt/domain/entity/BankAccountEntity.java
@@ -11,6 +11,8 @@ import jakarta.persistence.Version;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
+
 import static lombok.AccessLevel.PROTECTED;
 
 @Getter
@@ -18,27 +20,27 @@ import static lombok.AccessLevel.PROTECTED;
 @NoArgsConstructor(access = PROTECTED)
 public class BankAccountEntity extends BaseEntity {
 
-	@Column(nullable = false)
-	private Long balance;
+	@Column(precision = 19, scale = 0, nullable = false)
+	private BigDecimal balance;
 
 	@Version
 	private Long version;
 
 	@OneToOne(fetch = FetchType.LAZY)
 	@JoinColumn(
-		name = "account_id",
+		name = "user_id",
 		nullable = false,
 		unique = true
 	)
-	private AbstractAccountEntity account;
+	private UserEntity user;
 
-	protected BankAccountEntity(AbstractAccountEntity account) {
-		this.balance = 0L;
-		this.account = account;
+	private BankAccountEntity(UserEntity user) {
+		this.balance = BigDecimal.ZERO;
+		this.user = user;
 	}
 
-	public static BankAccountEntity create(final AbstractAccountEntity account) {
-		return new BankAccountEntity(account);
+	public static BankAccountEntity create(final UserEntity user) {
+		return new BankAccountEntity(user);
 	}
 
 }

--- a/src/main/java/com/kt/domain/entity/BankAccountEntity.java
+++ b/src/main/java/com/kt/domain/entity/BankAccountEntity.java
@@ -28,19 +28,19 @@ public class BankAccountEntity extends BaseEntity {
 
 	@OneToOne(fetch = FetchType.LAZY)
 	@JoinColumn(
-		name = "user_id",
+		name = "holder_id",
 		nullable = false,
 		unique = true
 	)
-	private UserEntity user;
+	private BankAccountHolderEntity holder;
 
-	private BankAccountEntity(UserEntity user) {
+	private BankAccountEntity(BankAccountHolderEntity holder) {
 		this.balance = BigDecimal.ZERO;
-		this.user = user;
+		this.holder = holder;
 	}
 
-	public static BankAccountEntity create(final UserEntity user) {
-		return new BankAccountEntity(user);
+	public static BankAccountEntity create(final BankAccountHolderEntity holder) {
+		return new BankAccountEntity(holder);
 	}
 
 }

--- a/src/main/java/com/kt/domain/entity/BankAccountHolderEntity.java
+++ b/src/main/java/com/kt/domain/entity/BankAccountHolderEntity.java
@@ -1,0 +1,24 @@
+package com.kt.domain.entity;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.OneToOne;
+import lombok.Getter;
+
+@Getter
+@Entity
+public class BankAccountHolderEntity extends AbstractAccountEntity {
+
+	@OneToOne(
+		mappedBy = "holder",
+		cascade = {
+			CascadeType.PERSIST,
+			CascadeType.REMOVE
+		},
+		orphanRemoval = true,
+		fetch = FetchType.LAZY
+	)
+	protected BankAccountEntity bankAccount;
+
+}

--- a/src/main/java/com/kt/domain/entity/BankAccountTransactionEntity.java
+++ b/src/main/java/com/kt/domain/entity/BankAccountTransactionEntity.java
@@ -1,0 +1,26 @@
+package com.kt.domain.entity;
+
+import com.kt.constant.bankaccount.BankAccountTransactionPurpose;
+import com.kt.constant.bankaccount.BankAccountTransactionType;
+import com.kt.domain.entity.common.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@Entity
+@Table(name = "bank_account_transactions")
+@NoArgsConstructor(access = PROTECTED)
+public class BankAccountTransactionEntity extends BaseEntity {
+
+	@Column(nullable = false)
+	private BankAccountTransactionType transactionType;
+
+	@Column(nullable = false)
+	private BankAccountTransactionPurpose transactionPurpose;
+}

--- a/src/main/java/com/kt/domain/entity/BankAccountTransactionEntity.java
+++ b/src/main/java/com/kt/domain/entity/BankAccountTransactionEntity.java
@@ -6,21 +6,39 @@ import com.kt.domain.entity.common.BaseEntity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.Table;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
 
 import static lombok.AccessLevel.PROTECTED;
 
 @Getter
-@Entity
-@Table(name = "bank_account_transactions")
+@Entity(name = "bank_account_transactions")
 @NoArgsConstructor(access = PROTECTED)
 public class BankAccountTransactionEntity extends BaseEntity {
 
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "bank_account_id", nullable = false)
+	private BankAccountEntity bankAccount;
+
 	@Column(nullable = false)
+	@Enumerated(EnumType.STRING)
 	private BankAccountTransactionType transactionType;
 
 	@Column(nullable = false)
+	@Enumerated(EnumType.STRING)
 	private BankAccountTransactionPurpose transactionPurpose;
+
+	@Column(precision = 19, scale = 0, nullable = false)
+	private BigDecimal amount;
+
+	@Column(precision = 19, scale = 0, nullable = false)
+	private BigDecimal balanceSnapshot;
 }

--- a/src/main/java/com/kt/domain/entity/BankAccountTransactionEntity.java
+++ b/src/main/java/com/kt/domain/entity/BankAccountTransactionEntity.java
@@ -16,6 +16,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
+import java.util.UUID;
 
 import static lombok.AccessLevel.PROTECTED;
 
@@ -41,4 +42,7 @@ public class BankAccountTransactionEntity extends BaseEntity {
 
 	@Column(precision = 19, scale = 0, nullable = false)
 	private BigDecimal balanceSnapshot;
+
+	@Column(nullable = false)
+	private UUID targetId;
 }

--- a/src/main/java/com/kt/domain/entity/BankAccountTransactionEntity.java
+++ b/src/main/java/com/kt/domain/entity/BankAccountTransactionEntity.java
@@ -4,6 +4,8 @@ import com.kt.constant.bankaccount.BankAccountTransactionPurpose;
 import com.kt.constant.bankaccount.BankAccountTransactionType;
 import com.kt.domain.entity.common.BaseEntity;
 
+import com.kt.util.ValidationUtil;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -70,6 +72,10 @@ public class BankAccountTransactionEntity extends BaseEntity {
 		final BigDecimal balanceSnapshot,
 		final UUID targetId
 	) {
+		ValidationUtil.validateRequiredEnum(transactionType, "거래 타입");
+		ValidationUtil.validateRequiredEnum(transactionPurpose, "거래 목적");
+		ValidationUtil.validatePositive(amount.intValue(), "거래 금액");
+		ValidationUtil.validateNonNegative(balanceSnapshot.intValue(), "거래 잔액");
 		return new BankAccountTransactionEntity(
 			bankAccount,
 			transactionType,

--- a/src/main/java/com/kt/domain/entity/BankAccountTransactionEntity.java
+++ b/src/main/java/com/kt/domain/entity/BankAccountTransactionEntity.java
@@ -45,4 +45,38 @@ public class BankAccountTransactionEntity extends BaseEntity {
 
 	@Column(nullable = false)
 	private UUID targetId;
+
+	private BankAccountTransactionEntity(
+		BankAccountEntity bankAccount,
+		BankAccountTransactionType transactionType,
+		BankAccountTransactionPurpose transactionPurpose,
+		BigDecimal amount,
+		BigDecimal balanceSnapshot,
+		UUID targetId
+	) {
+		this.bankAccount = bankAccount;
+		this.transactionType = transactionType;
+		this.transactionPurpose = transactionPurpose;
+		this.amount = amount;
+		this.balanceSnapshot = balanceSnapshot;
+		this.targetId = targetId;
+	}
+
+	public static BankAccountTransactionEntity create(
+		final BankAccountEntity bankAccount,
+		final BankAccountTransactionType transactionType,
+		final BankAccountTransactionPurpose transactionPurpose,
+		final BigDecimal amount,
+		final BigDecimal balanceSnapshot,
+		final UUID targetId
+	) {
+		return new BankAccountTransactionEntity(
+			bankAccount,
+			transactionType,
+			transactionPurpose,
+			amount,
+			balanceSnapshot,
+			targetId
+		);
+	}
 }

--- a/src/main/java/com/kt/domain/entity/PasswordRequestEntity.java
+++ b/src/main/java/com/kt/domain/entity/PasswordRequestEntity.java
@@ -72,7 +72,7 @@ public class PasswordRequestEntity extends BaseEntity {
 			ValidationUtil.validateNotNullAndBlank(requestedPassword, "변경요청 비밀번호");
 			encryptedPassword = EncryptUtil.encrypt(requestedPassword);
 		}
-		ValidationUtil.validationNotNullEnum(requestType, "비밀번호 복원 요청타입");
+		ValidationUtil.validateRequiredEnum(requestType, "비밀번호 복원 요청타입");
 		return new PasswordRequestEntity(
 			account,
 			encryptedPassword,

--- a/src/main/java/com/kt/domain/entity/PayEntity.java
+++ b/src/main/java/com/kt/domain/entity/PayEntity.java
@@ -11,6 +11,8 @@ import jakarta.persistence.Version;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
+
 import static lombok.AccessLevel.PROTECTED;
 
 @Getter
@@ -18,8 +20,8 @@ import static lombok.AccessLevel.PROTECTED;
 @NoArgsConstructor(access = PROTECTED)
 public class PayEntity extends BaseEntity {
 
-	@Column(nullable = false)
-	private Long balance;
+	@Column(precision = 19, scale = 0, nullable = false)
+	private BigDecimal balance;
 
 	@Version
 	private Long version;
@@ -32,8 +34,8 @@ public class PayEntity extends BaseEntity {
 	)
 	private UserEntity user;
 
-	protected PayEntity(UserEntity user) {
-		this.balance = 0L;
+	private PayEntity(UserEntity user) {
+		this.balance = BigDecimal.ZERO;
 		this.user = user;
 	}
 

--- a/src/main/java/com/kt/domain/entity/SellerEntity.java
+++ b/src/main/java/com/kt/domain/entity/SellerEntity.java
@@ -1,10 +1,10 @@
 package com.kt.domain.entity;
 
-import jakarta.persistence.CascadeType;
+import com.kt.util.ValidationUtil;
+
 import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.OneToOne;
 import jakarta.validation.constraints.Email;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -14,10 +14,11 @@ import com.kt.constant.Gender;
 import com.kt.constant.AccountRole;
 import com.kt.constant.UserStatus;
 
-@Entity
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class SellerEntity extends AbstractAccountEntity {
+@Entity(name = "seller")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@DiscriminatorValue("SELLER")
+public class SellerEntity extends BankAccountHolderEntity {
 
 	@Column(nullable = false)
 	private String storeName;
@@ -25,39 +26,34 @@ public class SellerEntity extends AbstractAccountEntity {
 	@Column(nullable = false)
 	private String contactMobile;
 
-	@Column(nullable = false)
-	@Email
-	private String contactEmail;
-
-	@OneToOne(
-		mappedBy = "account",
-		cascade = {
-			CascadeType.PERSIST,
-			CascadeType.REMOVE
-		},
-		orphanRemoval = true,
-		fetch = FetchType.LAZY
-	)
-	private BankAccountEntity bankAccount;
-
 	// TODO: 사업자등록번호, 결제용 판매자 계좌번호, 예금주 등
 
-	protected SellerEntity(String name, String email, String password, String storeName, String contactMobile,
-		String contactEmail, Gender gender) {
+	private SellerEntity(String name, String email, String password,
+		String storeName, String contactMobile, Gender gender) {
 		this.name = name;
 		this.email = email;
 		this.password = password;
 		this.storeName = storeName;
 		this.contactMobile = contactMobile;
-		this.contactEmail = contactEmail;
 		this.role = AccountRole.SELLER;
 		this.status = UserStatus.ENABLED;
 		this.gender = gender;
 		this.bankAccount = BankAccountEntity.create(this);
 	}
 
-	public static SellerEntity create(String name, String email, String password, String storeName, String contactMobile,
-		String contactEmail, Gender gender) {
-		return new SellerEntity(name, email, password, storeName, contactMobile, contactEmail, gender);
+	public static SellerEntity create(
+		final String name,
+		final String email,
+		final String password,
+		final String storeName,
+		final String contactMobile,
+		final Gender gender) {
+		ValidationUtil.validateNotNullAndBlank(name, "판매자이름");
+		ValidationUtil.validateNotNullAndBlank(email, "이메일");
+		ValidationUtil.validateAccountPassword(password, "비밀번호");
+		ValidationUtil.validateNotNullAndBlank(storeName, "판매 스토어명");
+		ValidationUtil.validateNotNullAndBlank(contactMobile, "판매자 연락처");
+		ValidationUtil.validateRequiredEnum(gender, "판매자성별");
+		return new SellerEntity(name, email, password, storeName, contactMobile, gender);
 	}
 }

--- a/src/main/java/com/kt/domain/entity/SellerEntity.java
+++ b/src/main/java/com/kt/domain/entity/SellerEntity.java
@@ -5,7 +5,6 @@ import com.kt.util.ValidationUtil;
 import jakarta.persistence.Column;
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
-import jakarta.validation.constraints.Email;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/kt/domain/entity/UserEntity.java
+++ b/src/main/java/com/kt/domain/entity/UserEntity.java
@@ -25,7 +25,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "\"user\"")
 @NoArgsConstructor(access = PROTECTED)
 @DiscriminatorValue("USER")
-public class UserEntity extends AbstractAccountEntity {
+public class UserEntity extends BankAccountHolderEntity {
 
 	@OneToMany(
 		mappedBy = "createdBy",
@@ -44,17 +44,6 @@ public class UserEntity extends AbstractAccountEntity {
 		fetch = FetchType.LAZY
 	)
 	private PayEntity pay;
-
-	@OneToOne(
-		mappedBy = "account",
-		cascade = {
-			CascadeType.PERSIST,
-			CascadeType.REMOVE
-		},
-		orphanRemoval = true,
-		fetch = FetchType.LAZY
-	)
-	private BankAccountEntity bankAccount;
 
 	@Column(nullable = false)
 	private LocalDate birth;

--- a/src/main/java/com/kt/exception/FieldValidationException.java
+++ b/src/main/java/com/kt/exception/FieldValidationException.java
@@ -15,7 +15,7 @@ public class FieldValidationException extends BaseException {
 
 	public FieldValidationException(ErrorCode error, String errorMessage) {
 		super(error);
-		this.errorMessage = errorMessage;
+		this.errorMessage = error.format(errorMessage);
 	}
 
 }

--- a/src/main/java/com/kt/exception/handler/SystemExceptionHandler.java
+++ b/src/main/java/com/kt/exception/handler/SystemExceptionHandler.java
@@ -17,8 +17,7 @@ public class SystemExceptionHandler extends BaseExceptionHandler {
 
 	@ExceptionHandler(FieldValidationException.class)
 	public ResponseEntity<ApiErrorResponse> handleFieldValid(FieldValidationException ex) {
-		ErrorCode error = ErrorCode.INVALID_DOMAIN_FIELD;
-		String errorMessage = error.format(ex.getErrorMessage());
+		String errorMessage = ex.getErrorMessage();
 		log.warn("[FieldValidationException] message = {}", errorMessage);
 		return toResponse(ex.error().getStatus(), errorMessage);
 	}

--- a/src/main/java/com/kt/util/ValidationUtil.java
+++ b/src/main/java/com/kt/util/ValidationUtil.java
@@ -16,6 +16,7 @@ public class ValidationUtil {
 	static final String PASSWORD_MIN_LENGTH_MESSAGE = "은(는) 60자 이상이여야 합니다";
 	static final String INVALID_ENUM_VALUE_MESSAGE = "{0} 값이 유효하지 않습니다. 허용값 {1}";
 	static final String PASSWORD_KEYWORD = "비밀번호";
+
 	public static void validateNotNullAndBlank(String value, String fieldName) {
 		if (!StringUtils.hasText(value)) {
 			String errorMessage = getFormatterMessage(NOT_BLANK_MESSAGE, fieldName);
@@ -23,7 +24,7 @@ public class ValidationUtil {
 		}
 	}
 
-	public static void validateCollectPassword(String value, String fieldName) {
+	public static void validateAccountPassword(String value, String fieldName) {
 		validateNotNullAndBlank(value, fieldName);
 		if (fieldName.equals(PASSWORD_KEYWORD)) {
 			if (value.length() < 60) {

--- a/src/main/java/com/kt/util/ValidationUtil.java
+++ b/src/main/java/com/kt/util/ValidationUtil.java
@@ -35,7 +35,7 @@ public class ValidationUtil {
 
 	public static <E extends Enum<E>> void validateRequiredEnum(E value, String fieldName) {
 		if (value == null) {
-			String errorMessage = getFormatterMessage(fieldName, REQUIRED_FIELD_MESSAGE);
+			String errorMessage = getFormatterMessage(REQUIRED_FIELD_MESSAGE, fieldName);
 			rejectInvalidField(errorMessage);
 		}
 	}

--- a/src/main/java/com/kt/util/ValidationUtil.java
+++ b/src/main/java/com/kt/util/ValidationUtil.java
@@ -10,46 +10,47 @@ import org.springframework.util.StringUtils;
 public class ValidationUtil {
 
 	static final String POSITIVE_MESSAGE = "{0}은(는) 0보다 커야합니다.";
+	static final String NOT_NEGATIVE_MESSAGE = "{0}은(는) 0보다 작을 수 없습니다.";
 	static final String NOT_BLANK_MESSAGE = "{0}은(는) 비어 있을 수 없습니다.";
-	static final String NOT_NULL_MESSAGE = "{0}은(는) null 일 수 없습니다.";
+	static final String REQUIRED_FIELD_MESSAGE = "{0}은(는) 필수 항목입니다.";
 	static final String PASSWORD_MIN_LENGTH_MESSAGE = "은(는) 60자 이상이여야 합니다";
 	static final String INVALID_ENUM_VALUE_MESSAGE = "{0} 값이 유효하지 않습니다. 허용값 {1}";
-
+	static final String PASSWORD_KEYWORD = "비밀번호";
 	public static void validateNotNullAndBlank(String value, String fieldName) {
 		if (!StringUtils.hasText(value)) {
 			String errorMessage = getFormatterMessage(NOT_BLANK_MESSAGE, fieldName);
-			throw new FieldValidationException(
-				ErrorCode.INVALID_DOMAIN_FIELD, errorMessage
-			);
+			rejectInvalidField(errorMessage);
 		}
 	}
 
 	public static void validateCollectPassword(String value, String fieldName) {
 		validateNotNullAndBlank(value, fieldName);
-
-		if (fieldName.equals("유저 비밀번호")) {
+		if (fieldName.equals(PASSWORD_KEYWORD)) {
 			if (value.length() < 60) {
 				String errorMessage = fieldName + PASSWORD_MIN_LENGTH_MESSAGE;
-				throw new FieldValidationException(
-					ErrorCode.INVALID_DOMAIN_FIELD, errorMessage
-				);
+				rejectInvalidField(errorMessage);
 			}
 		}
 	}
 
-	public static <E extends Enum<E>> void validationNotNullEnum(E value, String fieldName) {
+	public static <E extends Enum<E>> void validateRequiredEnum(E value, String fieldName) {
 		if (value == null) {
-			String errorMessage = getFormatterMessage(fieldName, NOT_NULL_MESSAGE);
-			throw new FieldValidationException(
-				ErrorCode.INVALID_DOMAIN_FIELD, errorMessage
-			);
+			String errorMessage = getFormatterMessage(fieldName, REQUIRED_FIELD_MESSAGE);
+			rejectInvalidField(errorMessage);
 		}
 	}
 
 	public static void validatePositive(int value, String fieldName) {
 		if (value <= 0) {
 			String errorMessage = getFormatterMessage(POSITIVE_MESSAGE, fieldName);
-			throw new FieldValidationException(ErrorCode.INVALID_DOMAIN_FIELD, errorMessage);
+			rejectInvalidField(errorMessage);
+		}
+	}
+
+	public static void validateNonNegative(int value, String fieldName) {
+		if (value < 0) {
+			String errorMessage = getFormatterMessage(NOT_NEGATIVE_MESSAGE, fieldName);
+			rejectInvalidField(errorMessage);
 		}
 	}
 
@@ -57,4 +58,7 @@ public class ValidationUtil {
 		return MessageFormat.format(message, fieldName);
 	}
 
+	private static void rejectInvalidField(String errorMessage) {
+		throw new FieldValidationException(ErrorCode.INVALID_DOMAIN_FIELD, errorMessage);
+	}
 }

--- a/src/test/java/com/kt/api/seller/product/ProductActivateTest.java
+++ b/src/test/java/com/kt/api/seller/product/ProductActivateTest.java
@@ -21,11 +21,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.web.servlet.ResultActions;
 
-import java.util.UUID;
-
 import static com.kt.common.CategoryEntityCreator.createCategory;
 import static com.kt.common.ProductEntityCreator.createProduct;
-import static com.kt.common.SellerEntityCreator.createSeller;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;

--- a/src/test/java/com/kt/common/SellerEntityCreator.java
+++ b/src/test/java/com/kt/common/SellerEntityCreator.java
@@ -5,17 +5,16 @@ import com.kt.domain.entity.SellerEntity;
 
 public class SellerEntityCreator {
 
-	public static SellerEntity createSeller(String email, String password) {
-		return SellerEntity.create(
-			"판매자1",
-			email,
-			password,
-			"상점1",
-			"010-1234-5678",
-			"seller@test.com",
-			Gender.MALE
-		);
-	}
+    public static SellerEntity createSeller(String email, String password) {
+        return SellerEntity.create(
+                "판매자1",
+                email,
+                password,
+                "상점1",
+                "010-1234-5678",
+                Gender.MALE
+        );
+    }
 
 	public static SellerEntity createSeller(String email) {
 		return SellerEntity.create(
@@ -24,7 +23,6 @@ public class SellerEntityCreator {
 			"passowrd",
 			"상점1",
 			"010-1234-5678",
-			"seller@test.com",
 			Gender.MALE
 		);
 	}
@@ -36,7 +34,6 @@ public class SellerEntityCreator {
 			"1234",
 			"상점1",
 			"010-1234-5678",
-			"seller@test.com",
 			Gender.MALE
 		);
 	}

--- a/src/test/java/com/kt/common/SellerEntityCreator.java
+++ b/src/test/java/com/kt/common/SellerEntityCreator.java
@@ -5,22 +5,11 @@ import com.kt.domain.entity.SellerEntity;
 
 public class SellerEntityCreator {
 
-    public static SellerEntity createSeller(String email, String password) {
-        return SellerEntity.create(
-                "판매자1",
-                email,
-                password,
-                "상점1",
-                "010-1234-5678",
-                Gender.MALE
-        );
-    }
-
 	public static SellerEntity createSeller(String email) {
 		return SellerEntity.create(
 			"판매자1",
 			email,
-			"passowrd",
+			"$2a$10$HOmkYePSaqAHzPT5DkwwiuEZt4uBGEbo24aefvDSc9yx74PzUkDPW",
 			"상점1",
 			"010-1234-5678",
 			Gender.MALE
@@ -31,7 +20,7 @@ public class SellerEntityCreator {
 		return SellerEntity.create(
 			"판매자1",
 			"seller@test.com",
-			"1234",
+			"$2a$10$HOmkYePSaqAHzPT5DkwwiuEZt4uBGEbo24aefvDSc9yx74PzUkDPW",
 			"상점1",
 			"010-1234-5678",
 			Gender.MALE

--- a/src/test/java/com/kt/domain/entity/BankAccountEntityTest.java
+++ b/src/test/java/com/kt/domain/entity/BankAccountEntityTest.java
@@ -5,6 +5,8 @@ import com.kt.common.UserEntityCreator;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ActiveProfiles;
 
+import java.math.BigDecimal;
+
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -17,7 +19,7 @@ public class BankAccountEntityTest {
 		BankAccountEntity bankAccount = testUser.getBankAccount();
 
 		assertNotNull(bankAccount);
-		assertEquals(0L, bankAccount.getBalance());
-		assertEquals(bankAccount.getAccount(), testUser);
+		assertEquals(BigDecimal.ZERO, bankAccount.getBalance());
+		assertEquals(bankAccount.getHolder(), testUser);
 	}
 }

--- a/src/test/java/com/kt/domain/entity/BankAccountEntityTest.java
+++ b/src/test/java/com/kt/domain/entity/BankAccountEntityTest.java
@@ -2,6 +2,8 @@ package com.kt.domain.entity;
 
 import com.kt.common.UserEntityCreator;
 
+import lombok.extern.slf4j.Slf4j;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ActiveProfiles;
 
@@ -10,6 +12,7 @@ import java.math.BigDecimal;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@Slf4j
 @ActiveProfiles("test")
 public class BankAccountEntityTest {
 
@@ -21,5 +24,7 @@ public class BankAccountEntityTest {
 		assertNotNull(bankAccount);
 		assertEquals(BigDecimal.ZERO, bankAccount.getBalance());
 		assertEquals(bankAccount.getHolder(), testUser);
+		log.info("getHolder email : {}",bankAccount.getHolder().getEmail());
+		log.info("testUser email : {}",testUser.getEmail());
 	}
 }

--- a/src/test/java/com/kt/domain/entity/BankAccountTransactionEntityTest.java
+++ b/src/test/java/com/kt/domain/entity/BankAccountTransactionEntityTest.java
@@ -1,0 +1,125 @@
+package com.kt.domain.entity;
+
+import com.kt.common.UserEntityCreator;
+
+import com.kt.constant.bankaccount.BankAccountTransactionPurpose;
+import com.kt.constant.bankaccount.BankAccountTransactionType;
+
+import com.kt.exception.FieldValidationException;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Slf4j
+@ActiveProfiles("test")
+public class BankAccountTransactionEntityTest {
+
+	UserEntity testUser;
+
+	@BeforeEach
+	void init() {
+		testUser = UserEntityCreator.createMember();
+	}
+
+	@Test
+	void 계좌거래내역_객체생성_성공() {
+		BankAccountTransactionEntity bankAccountTransaction =
+			BankAccountTransactionEntity.create(
+				testUser.getBankAccount(),
+				BankAccountTransactionType.DEPOSIT,
+				BankAccountTransactionPurpose.SALARY,
+				BigDecimal.valueOf(10_000),
+				BigDecimal.valueOf(10_000),
+				testUser.getBankAccount().getId()
+			);
+		assertNotNull(bankAccountTransaction);
+	}
+
+	@Test
+	void 객체생성_실패_거래타입_null() {
+
+		assertThatThrownBy(() ->
+			BankAccountTransactionEntity.create(
+				testUser.getBankAccount(),
+				null,
+				BankAccountTransactionPurpose.SALARY,
+				BigDecimal.valueOf(10_000),
+				BigDecimal.valueOf(10_000),
+				testUser.getBankAccount().getId()
+			)
+		)
+			.isInstanceOfSatisfying(FieldValidationException.class, ex -> {
+				log.info("getErrorMessage : {}", ex.getErrorMessage());
+				assertEquals("도메인 필드 오류 : 거래 타입은(는) 필수 항목입니다.", ex.getErrorMessage());
+			});
+	}
+
+	@Test
+	void 객체생성_실패_거래목적_null() {
+
+		assertThatThrownBy(() ->
+			BankAccountTransactionEntity.create(
+				testUser.getBankAccount(),
+				BankAccountTransactionType.DEPOSIT,
+				null,
+				BigDecimal.valueOf(10_000),
+				BigDecimal.valueOf(10_000),
+				testUser.getBankAccount().getId()
+			)
+		)
+			.isInstanceOfSatisfying(FieldValidationException.class, ex -> {
+				log.info("getErrorMessage : {}", ex.getErrorMessage());
+				assertEquals("도메인 필드 오류 : 거래 목적은(는) 필수 항목입니다.", ex.getErrorMessage());
+			});
+	}
+
+	@Test
+	void 객체생성_실패_거래금액_0_이하() {
+
+		assertThatThrownBy(() ->
+			BankAccountTransactionEntity.create(
+				testUser.getBankAccount(),
+				BankAccountTransactionType.DEPOSIT,
+				BankAccountTransactionPurpose.SALARY,
+				BigDecimal.valueOf(0),
+				BigDecimal.valueOf(10_000),
+				testUser.getBankAccount().getId()
+			)
+		)
+			.isInstanceOfSatisfying(FieldValidationException.class, ex -> {
+				log.info("getErrorMessage : {}", ex.getErrorMessage());
+				assertEquals("도메인 필드 오류 : 거래 금액은(는) 0보다 커야합니다.", ex.getErrorMessage());
+			});
+	}
+
+	@Test
+	void 객체생성_실패_거래잔액_0_미만() {
+
+		assertThatThrownBy(() ->
+			BankAccountTransactionEntity.create(
+				testUser.getBankAccount(),
+				BankAccountTransactionType.DEPOSIT,
+				BankAccountTransactionPurpose.SALARY,
+				BigDecimal.valueOf(10_000),
+				BigDecimal.valueOf(-1),
+				testUser.getBankAccount().getId()
+			)
+		)
+			.isInstanceOfSatisfying(FieldValidationException.class, ex -> {
+				log.info("getErrorMessage : {}", ex.getErrorMessage());
+				assertEquals("도메인 필드 오류 : 거래 잔액은(는) 0보다 작을 수 없습니다.", ex.getErrorMessage());
+			});
+	}
+
+}
+
+

--- a/src/test/java/com/kt/domain/entity/CartEntityTest.java
+++ b/src/test/java/com/kt/domain/entity/CartEntityTest.java
@@ -38,7 +38,6 @@ class CartEntityTest {
 			"1234",
 			"상점1",
 			"010-1234-5678",
-			"seller@test.com",
 			Gender.MALE
 		);
 		testProduct = ProductEntity.create(

--- a/src/test/java/com/kt/domain/entity/CartEntityTest.java
+++ b/src/test/java/com/kt/domain/entity/CartEntityTest.java
@@ -3,6 +3,7 @@ package com.kt.domain.entity;
 
 import java.time.LocalDate;
 
+import com.kt.common.SellerEntityCreator;
 import com.kt.constant.AccountRole;
 
 import org.junit.jupiter.api.Assertions;
@@ -32,14 +33,7 @@ class CartEntityTest {
 		);
 
 		testCategory = CategoryEntity.create("테스트 카테고리", null);
-		SellerEntity testSeller = SellerEntity.create(
-			"판매자1",
-			"seller@test.com",
-			"1234",
-			"상점1",
-			"010-1234-5678",
-			Gender.MALE
-		);
+		SellerEntity testSeller = SellerEntityCreator.createSeller();
 		testProduct = ProductEntity.create(
 			"테스트상품명",
 			1000L,

--- a/src/test/java/com/kt/domain/entity/PaymentEntityTest.java
+++ b/src/test/java/com/kt/domain/entity/PaymentEntityTest.java
@@ -54,7 +54,6 @@ class PaymentEntityTest {
 			"1234",
 			"상점1",
 			"010-1234-5678",
-			"seller@test.com",
 			Gender.MALE
 		);
 

--- a/src/test/java/com/kt/domain/entity/PaymentEntityTest.java
+++ b/src/test/java/com/kt/domain/entity/PaymentEntityTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.*;
 
 import java.time.LocalDate;
 
+import com.kt.common.SellerEntityCreator;
 import com.kt.constant.AccountRole;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -48,14 +49,7 @@ class PaymentEntityTest {
 			user
 		);
 
-		SellerEntity testSeller = SellerEntity.create(
-			"판매자1",
-			"seller@test.com",
-			"1234",
-			"상점1",
-			"010-1234-5678",
-			Gender.MALE
-		);
+		SellerEntity testSeller = SellerEntityCreator.createSeller();
 
 		ProductEntity product = ProductEntity.create(
 			"테스트상품명",

--- a/src/test/java/com/kt/domain/entity/ProductEntityTest.java
+++ b/src/test/java/com/kt/domain/entity/ProductEntityTest.java
@@ -24,7 +24,6 @@ class ProductEntityTest {
 			"1234",
 			"상점1",
 			"010-1234-5678",
-			"seller@test.com",
 			Gender.MALE
 		);
 

--- a/src/test/java/com/kt/domain/entity/ProductEntityTest.java
+++ b/src/test/java/com/kt/domain/entity/ProductEntityTest.java
@@ -2,6 +2,7 @@ package com.kt.domain.entity;
 
 import static org.assertj.core.api.Assertions.*;
 
+import com.kt.common.SellerEntityCreator;
 import com.kt.constant.Gender;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ActiveProfiles;
@@ -18,14 +19,7 @@ class ProductEntityTest {
 			null
 		);
 
-		SellerEntity testSeller = SellerEntity.create(
-			"판매자1",
-			"seller@test.com",
-			"1234",
-			"상점1",
-			"010-1234-5678",
-			Gender.MALE
-		);
+		SellerEntity testSeller = SellerEntityCreator.createSeller();
 
 		ProductEntity comparisonProduct = ProductEntity.create(
 			"테스트상품명",

--- a/src/test/java/com/kt/domain/entity/SellerEntityTest.java
+++ b/src/test/java/com/kt/domain/entity/SellerEntityTest.java
@@ -1,0 +1,36 @@
+package com.kt.domain.entity;
+
+import com.kt.constant.Gender;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+@ActiveProfiles("test")
+public class SellerEntityTest {
+
+	@Autowired
+	PasswordEncoder passwordEncoder;
+
+	@Test
+	void 판매자_객체생성_성공() {
+		SellerEntity seller = SellerEntity.create(
+			"테스트판매자",
+			"seller@test.com",
+			passwordEncoder.encode("1234"),
+			"테스트_스트어",
+			"010-1234-1234",
+			Gender.MALE
+		);
+
+		assertNotNull(seller);
+		assertEquals(60, seller.password.length());
+	}
+
+}

--- a/src/test/java/com/kt/domain/entity/ShippingDetailEntityTest.java
+++ b/src/test/java/com/kt/domain/entity/ShippingDetailEntityTest.java
@@ -54,7 +54,6 @@ class ShippingDetailEntityTest {
 			"1234",
 			"상점1",
 			"010-1234-5678",
-			"seller@test.com",
 			Gender.MALE
 		);
 

--- a/src/test/java/com/kt/domain/entity/ShippingDetailEntityTest.java
+++ b/src/test/java/com/kt/domain/entity/ShippingDetailEntityTest.java
@@ -2,6 +2,8 @@ package com.kt.domain.entity;
 
 import java.time.LocalDate;
 
+import com.kt.common.SellerEntityCreator;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -48,14 +50,7 @@ class ShippingDetailEntityTest {
 			null
 		);
 
-		SellerEntity testSeller = SellerEntity.create(
-			"판매자1",
-			"seller@test.com",
-			"1234",
-			"상점1",
-			"010-1234-5678",
-			Gender.MALE
-		);
+		SellerEntity testSeller = SellerEntityCreator.createSeller();
 
 		ProductEntity product = ProductEntity.create(
 			"테스트상품명",


### PR DESCRIPTION
## #️⃣연관된 이슈

resolves: #211 

## 📝작업 내용

계좌거래내역(BankAccountTransaction) 엔티티 도메인 생성,
계좌거래내역 도메인 생성 성공 및 실패 테스트 코드 추가
BankAccountHolderEntity(계좌소지자 엔티티) 생성 및 계좌 도메인 소지자 분리 (User, Seller - BankAccountHolderEntity)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->