### PR TITLE
[FEAT] spring AI 기본 세팅 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,8 @@ dependencies {
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.14'
     implementation 'org.redisson:redisson-spring-boot-starter:3.32.0'
+    implementation 'org.springframework.ai:spring-ai-starter-model-openai'
+    implementation platform("org.springframework.ai:spring-ai-bom:1.1.2")
 
     annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
     annotationProcessor 'jakarta.annotation:jakarta.annotation-api'

--- a/src/main/java/com/kt/ai/client/BaseChatClient.java
+++ b/src/main/java/com/kt/ai/client/BaseChatClient.java
@@ -1,6 +1,8 @@
 package com.kt.ai.client;
 
 import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor;
+import org.springframework.ai.chat.memory.ChatMemory;
 import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
@@ -10,10 +12,17 @@ import lombok.RequiredArgsConstructor;
 public class BaseChatClient {
 
 	private final ChatClient chatClient;
+	private final ChatMemory chatMemory;
 
-	public ChatClient.ChatClientRequestSpec prompt() {
-		// TODO: advisor와 같이 공통 로직 추가 예정
-		return chatClient.prompt();
+	public ChatClient.ChatClientRequestSpec prompt(String conversationId) {
+		// TODO: RAG 로직 추가
+		return chatClient.prompt()
+			.advisors(
+				MessageChatMemoryAdvisor
+					.builder(chatMemory)
+					.conversationId(conversationId)
+					.build()
+			);
 	}
 
 	public String ask(String userMessage) {

--- a/src/main/java/com/kt/ai/client/BaseChatClient.java
+++ b/src/main/java/com/kt/ai/client/BaseChatClient.java
@@ -11,6 +11,11 @@ public class BaseChatClient {
 
 	private final ChatClient chatClient;
 
+	public ChatClient.ChatClientRequestSpec prompt() {
+		// TODO: advisor와 같이 공통 로직 추가 예정
+		return chatClient.prompt();
+	}
+
 	public String ask(String userMessage) {
 		return chatClient.prompt()
 			.user(userMessage)

--- a/src/main/java/com/kt/ai/client/BaseChatClient.java
+++ b/src/main/java/com/kt/ai/client/BaseChatClient.java
@@ -1,0 +1,20 @@
+package com.kt.ai.client;
+
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class BaseChatClient {
+
+	private final ChatClient chatClient;
+
+	public String ask(String userMessage) {
+		return chatClient.prompt()
+			.user(userMessage)
+			.call()
+			.content();
+	}
+}

--- a/src/main/java/com/kt/ai/client/FAQChatClient.java
+++ b/src/main/java/com/kt/ai/client/FAQChatClient.java
@@ -1,23 +1,20 @@
 package com.kt.ai.client;
 
+import org.springframework.ai.chat.memory.ChatMemory;
 import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
-
 public class FAQChatClient {
 
-	// TODO: userMessage 탬플릿 구체화
+	private final BaseChatClient baseChatClient;
 
-	private BaseChatClient baseChatClient;
-
-	String ask(String userMessage) {
-		return baseChatClient.prompt()
+	public String ask(String userMessage, String conversationId) {
+		return baseChatClient.prompt(conversationId)
 			.user(userMessage)
 			.call()
 			.content();
 	}
-
 }

--- a/src/main/java/com/kt/ai/client/FAQChatClient.java
+++ b/src/main/java/com/kt/ai/client/FAQChatClient.java
@@ -1,0 +1,23 @@
+package com.kt.ai.client;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+
+public class FAQChatClient {
+
+	// TODO: userMessage 탬플릿 구체화
+
+	private BaseChatClient baseChatClient;
+
+	String ask(String userMessage) {
+		return baseChatClient.prompt()
+			.user(userMessage)
+			.call()
+			.content();
+	}
+
+}

--- a/src/main/java/com/kt/ai/config/ChatClientConfig.java
+++ b/src/main/java/com/kt/ai/config/ChatClientConfig.java
@@ -1,0 +1,22 @@
+package com.kt.ai.config;
+
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ChatClientConfig {
+
+	@Bean
+	ChatClient chatClient(ChatClient.Builder builder) {
+		return builder
+			.defaultSystem("""
+				You are an AI assistant operating within an e-commerce system.
+				You must respond politely, factually, and avoid speculation.
+				Always respond in Korean.
+				Use natural and professional Korean appropriate for customer service.
+				""")
+			.build();
+	}
+
+}

--- a/src/main/java/com/kt/ai/config/ChatMemoryConfig.java
+++ b/src/main/java/com/kt/ai/config/ChatMemoryConfig.java
@@ -1,0 +1,26 @@
+package com.kt.ai.config;
+
+import org.springframework.ai.chat.memory.ChatMemory;
+import org.springframework.ai.chat.memory.ChatMemoryRepository;
+import org.springframework.ai.chat.memory.InMemoryChatMemoryRepository;
+import org.springframework.ai.chat.memory.MessageWindowChatMemory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ChatMemoryConfig {
+
+	@Bean
+	public ChatMemory chatMemory(ChatMemoryRepository repository) {
+		return MessageWindowChatMemory.builder()
+			.chatMemoryRepository(repository)
+			.maxMessages(20)
+			.build();
+	}
+
+	@Bean
+	public ChatMemoryRepository chatMemoryRepository() {
+		// TODO: 인메모리 -> 레디스/DB 전환
+		return new InMemoryChatMemoryRepository();
+	}
+}

--- a/src/main/java/com/kt/ai/controller/FAQController.java
+++ b/src/main/java/com/kt/ai/controller/FAQController.java
@@ -1,0 +1,29 @@
+package com.kt.ai.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.kt.ai.client.FAQChatClient;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/ai")
+@RequiredArgsConstructor
+public class FAQController {
+
+	private final FAQChatClient faqChatClient;
+
+	@GetMapping("/faq")
+	public String ask(
+		@RequestParam String userId,
+		@RequestParam String message
+	) {
+		// TODO: 실제 채팅방 ID로 변경 필요
+		String conversationId = "faq:" + userId;
+
+		return faqChatClient.ask(message, conversationId);
+	}
+}

--- a/src/main/java/com/kt/security/SecurityPath.java
+++ b/src/main/java/com/kt/security/SecurityPath.java
@@ -11,6 +11,7 @@ public final class SecurityPath {
 		"/v3/api-docs/**"
 	};
 	public static final String[] AUTHENTICATED = {
+		"/api/ai/**",
 		"/api/matches/**"
 	};
 	public static final String[] MEMBER = {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,7 +41,13 @@ spring:
       cluster:
         nodes: ${REDIS_HOST}
         max-redirects: 3
-
+  ai:
+    openai:
+      api-key: ${OPENAI_API_KEY}
+      chat:
+        options:
+          model: gpt-5-nano
+          temperature: 0.2
 jwt:
   secret: ${JWT_SECRET_KEY}
   access-valid-time: ${JWT_ACCESS_TIME}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -47,7 +47,7 @@ spring:
       chat:
         options:
           model: gpt-5-nano
-          temperature: 0.2
+          temperature: 1
 jwt:
   secret: ${JWT_SECRET_KEY}
   access-valid-time: ${JWT_ACCESS_TIME}


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- resolves: #이슈번호, #이슈번호 -->
resolves: #226 

## 📝작업 내용

**Spring AI 챗봇 기반** 구성했습니다.
`BaseChatClient`를 중심으로 `ChatClient`로직 분리,
대화방 단위로 메시지 유지(AI가 기억)할 수 있도록 
`MessageChatMemoryAdvisor` 적용
현재 인메모리로 저장했고, 차후 Redis 기반 저장소로 분리 예정입니다.

강사님도 AI 디렉토리 아예 분리하셔서 우선 저도 분리해놓았습니다.

간이 테스트 위해 FAQController 생성하고 동작 확인 스웨거에서 진행했습니다.

차후 RAG + 벡터스토어 기반하여 검색 응답(철호 강사님 강의), 상담 단계 분기 이후 채팅방 전환 계속 진행하겠습니다.
AI관련 문서화도 이번주 내로 같이 진행해보도록 하겠습니다.

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
<img width="1569" height="997" alt="image" src="https://github.com/user-attachments/assets/65ecdf4b-6718-459f-bedb-ee6a0034c2ad" />

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->