### PR TITLE
[FEAT] OpenAI 벡터 스토어 연동

### DIFF
--- a/src/main/java/com/kt/ai/DefaultVectorApi.java
+++ b/src/main/java/com/kt/ai/DefaultVectorApi.java
@@ -1,0 +1,75 @@
+package com.kt.ai;
+
+import java.util.UUID;
+
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+
+import com.kt.ai.dto.OpenAIRequest;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class DefaultVectorApi implements VectorApi {
+	private final OpenAIClient openAIClient;
+	private final OpenAIProperties openAIProperties;
+
+	private String token() {
+		return "Bearer " + openAIProperties.apiKey();
+	}
+
+	@Override
+	public String create(String name, String description) {
+		var response = openAIClient.create(
+			token(),
+			new OpenAIRequest.VectorCreate(name, description)
+		);
+		return response.id();
+	}
+
+	@Override
+	public String uploadFile(String vectorStoreId, byte[] json) {
+		var map = new LinkedMultiValueMap<String, Object>();
+
+		var fileResource = new ByteArrayResource(
+			json
+		) {
+			@Override
+			public String getFilename() {
+				return String.format("%s.json", UUID.randomUUID());
+			}
+		};
+
+		map.add("purpose", "assistants");
+		map.add("file", fileResource);
+
+		var response = openAIClient.upload(
+			token(),
+			map
+		);
+
+		openAIClient.uploadVectorStore(
+			vectorStoreId,
+			token(),
+			new OpenAIRequest.UploadFile(response.id())
+		);
+
+		return response.id();
+	}
+
+	@Override
+	public void delete(String vectorStoreId, String fileId) {
+		openAIClient.delete(
+			vectorStoreId,
+			fileId,
+			token()
+		);
+
+		openAIClient.deleteFile(
+			fileId,
+			token()
+		);
+	}
+}

--- a/src/main/java/com/kt/ai/OpenAIClient.java
+++ b/src/main/java/com/kt/ai/OpenAIClient.java
@@ -1,0 +1,56 @@
+package com.kt.ai;
+
+import org.springframework.http.MediaType;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.service.annotation.DeleteExchange;
+import org.springframework.web.service.annotation.HttpExchange;
+import org.springframework.web.service.annotation.PostExchange;
+
+import com.kt.ai.dto.OpenAIRequest;
+import com.kt.ai.dto.OpenAIResponse;
+
+@HttpExchange(url = "https://api.openai.com/v1", contentType = MediaType.APPLICATION_JSON_VALUE)
+public interface OpenAIClient {
+	@PostExchange("/vector_stores")
+	OpenAIResponse.VectorCreate create(
+		@RequestHeader("Authorization") String authorization,
+		@RequestBody OpenAIRequest.VectorCreate request
+	);
+
+	@PostExchange(value = "/files", contentType = MediaType.MULTIPART_FORM_DATA_VALUE)
+	OpenAIResponse.Upload upload(
+		@RequestHeader("Authorization") String authorization,
+		@RequestBody MultiValueMap<String, Object> request
+	);
+
+	@PostExchange(value = "/vector_stores/{vector_store_id}/files")
+	void uploadVectorStore(
+		@PathVariable("vector_store_id") String vectorStoreId,
+		@RequestHeader("Authorization") String authorization,
+		@RequestBody OpenAIRequest.UploadFile request
+	);
+
+	@DeleteExchange("/vector_stores/{vector_store_id}/files/{file_id}")
+	void delete(
+		@PathVariable("vector_store_id") String vectorStoreId,
+		@PathVariable("file_id") String fileId,
+		@RequestHeader("Authorization") String authorization
+	);
+
+	@DeleteExchange("/files/{file_id}")
+	void deleteFile(
+		@PathVariable("file_id") String fileId,
+		@RequestHeader("Authorization") String authorization
+	);
+
+	@PostExchange("/vector_stores/{vector_store_id}/search")
+	OpenAIResponse.Search search(
+		@PathVariable("vector_store_id") String vectorStoreId,
+		@RequestHeader("Authorization") String authorization,
+		@RequestBody OpenAIRequest.Search request
+	);
+
+}

--- a/src/main/java/com/kt/ai/OpenAIProperties.java
+++ b/src/main/java/com/kt/ai/OpenAIProperties.java
@@ -1,0 +1,9 @@
+package com.kt.ai;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "spring.ai.openai")
+public record OpenAIProperties(
+	String apiKey
+) {
+}

--- a/src/main/java/com/kt/ai/VectorApi.java
+++ b/src/main/java/com/kt/ai/VectorApi.java
@@ -1,0 +1,15 @@
+package com.kt.ai;
+
+public interface VectorApi {
+	/**
+	 *
+	 * @param name        벡터 스토어 이름
+	 * @param description 벡터 스토어 설명
+	 * @return 생성된 벡터 스토어 ID
+	 */
+	String create(String name, String description);
+
+	String uploadFile(String vectorStoreId, byte[] json);
+
+	void delete(String vectorStoreId, String fileId);
+}

--- a/src/main/java/com/kt/ai/client/FAQChatClient.java
+++ b/src/main/java/com/kt/ai/client/FAQChatClient.java
@@ -1,6 +1,5 @@
 package com.kt.ai.client;
 
-import org.springframework.ai.chat.memory.ChatMemory;
 import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/kt/ai/dto/OpenAIRequest.java
+++ b/src/main/java/com/kt/ai/dto/OpenAIRequest.java
@@ -1,0 +1,22 @@
+package com.kt.ai.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class OpenAIRequest {
+	public record VectorCreate(
+		String name,
+		String description
+	) {
+	}
+
+	public record UploadFile(
+		@JsonProperty("file_id")
+		String id
+	) {
+	}
+
+	public record Search(
+		String query
+	) {
+	}
+}

--- a/src/main/java/com/kt/ai/dto/OpenAIResponse.java
+++ b/src/main/java/com/kt/ai/dto/OpenAIResponse.java
@@ -1,0 +1,78 @@
+package com.kt.ai.dto;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class OpenAIResponse {
+	public record VectorCreate(
+		String id,
+		String object,
+		@JsonProperty("created_at")
+		Long createdAt,
+		String name,
+		String description,
+		Long bytes,
+		@JsonProperty("file_counts")
+		FileCounts fileCounts
+	) {
+
+	}
+
+	public record FileCounts(
+		@JsonProperty("in_progress")
+		int inProgress,
+		int completed,
+		int failed,
+		int cancelled,
+		int total
+	) {
+	}
+
+	public record Upload(
+		String id,
+		String object,
+		Long bytes,
+		@JsonProperty("created_at")
+		Long createdAt,
+		@JsonProperty("expires_at")
+		Long expiresAt,
+		String filename,
+		String purpose
+	) {
+	}
+
+	public record Search(
+		String object,
+		@JsonProperty("search_query")
+		List<String> searchQuery,
+		List<SearchData> data,
+		@JsonProperty("has_more")
+		Boolean hasMore,
+		@JsonProperty("next_page")
+		Object nextPage
+	) {
+	}
+
+	public record SearchData(
+		@JsonProperty("file_id")
+		String fileId,
+		String filename,
+		Double score,
+		Attribute attributes,
+		List<Content> content
+	) {
+	}
+
+	public record Content(
+		String type,
+		String text
+	) {
+	}
+
+	public record Attribute(
+		String author,
+		String date
+	) {
+	}
+}

--- a/src/main/java/com/kt/common/interceptor/SimpleApiLoggingInterceptor.java
+++ b/src/main/java/com/kt/common/interceptor/SimpleApiLoggingInterceptor.java
@@ -1,0 +1,29 @@
+package com.kt.common.interceptor;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class SimpleApiLoggingInterceptor implements ClientHttpRequestInterceptor {
+	@Override
+	public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution) throws
+		IOException {
+
+		log.info("[External API Call] [{}] {} Headers: {} -d {} Body Length: {}",
+			request.getMethod(),
+			request.getURI(),
+			request.getHeaders(),
+			new String(body, StandardCharsets.UTF_8),
+			body.length
+		);
+
+		return execution.execute(request, body);
+	}
+}

--- a/src/main/java/com/kt/common/processor/HttpInterfaceBeanFactoryPostProcessor.java
+++ b/src/main/java/com/kt/common/processor/HttpInterfaceBeanFactoryPostProcessor.java
@@ -1,0 +1,95 @@
+package com.kt.common.processor;
+
+import java.util.Objects;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.annotation.AnnotatedBeanDefinition;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
+import org.springframework.core.env.Environment;
+import org.springframework.core.type.filter.AnnotationTypeFilter;
+import org.springframework.http.converter.StringHttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.stereotype.Component;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.support.RestClientAdapter;
+import org.springframework.web.service.annotation.HttpExchange;
+import org.springframework.web.service.invoker.HttpServiceProxyFactory;
+
+import com.kt.common.interceptor.SimpleApiLoggingInterceptor;
+
+@Component
+public class HttpInterfaceBeanFactoryPostProcessor implements BeanFactoryPostProcessor {
+	private static final String BASE_PACKAGE = "com.kt";
+	private static final String SUFFIX_CLIENT = "Client";
+
+	@Override
+	public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
+		var environment = beanFactory.getBean(Environment.class);
+		var componentProvider = new HttpClientCandidateComponentProvider(environment);
+
+		componentProvider.findCandidateComponents(BASE_PACKAGE).stream()
+			.filter(it -> StringUtils.hasText(it.getBeanClassName()))
+			.forEach(it -> {
+				var restClientBuilder = RestClient.builder()
+					.requestInterceptor(new SimpleApiLoggingInterceptor())
+					.messageConverters(converters -> {
+						var stringConverter = beanFactory.getBean(StringHttpMessageConverter.class);
+						converters.add(stringConverter);
+
+						var jacksonConverter = beanFactory.getBean(MappingJackson2HttpMessageConverter.class);
+						converters.add(jacksonConverter);
+					}).build();
+
+				beanFactory.registerSingleton(it.getBeanClassName(),
+					registerToProxyFactory(beanFactory, it, restClientBuilder));
+			});
+
+	}
+
+	private Object registerToProxyFactory(
+		BeanFactory beanFactory, BeanDefinition beanDefinition, RestClient restClient) {
+		Class<?> interfaceClass = findHttpInterfaceClass(beanDefinition);
+
+		return HttpServiceProxyFactory.builderFor(RestClientAdapter.create(restClient))
+			.build()
+			.createClient(interfaceClass);
+	}
+
+	private Class<?> findHttpInterfaceClass(BeanDefinition beanDefinition) {
+		try {
+			return ClassUtils.forName(Objects.requireNonNull(beanDefinition.getBeanClassName()),
+				this.getClass().getClassLoader());
+		} catch (ClassNotFoundException e) {
+			throw new IllegalStateException(e);
+		}
+	}
+
+	private String resolveBaseUrl(Class<?> interfaceClass, Environment environment) {
+		var targetBeanName = interfaceClass.getSimpleName();
+		var propertyPrefix = targetBeanName.endsWith(SUFFIX_CLIENT) ?
+			targetBeanName.substring(0, targetBeanName.length() - SUFFIX_CLIENT.length()) : targetBeanName;
+		var propertyName = "https://api.openai.com";
+
+		return environment.getProperty(propertyName);
+	}
+
+	private static class HttpClientCandidateComponentProvider extends ClassPathScanningCandidateComponentProvider {
+		public HttpClientCandidateComponentProvider(Environment environment) {
+			super(false, environment);
+			addIncludeFilter(new AnnotationTypeFilter(HttpExchange.class));
+		}
+
+		@Override
+		protected boolean isCandidateComponent(AnnotatedBeanDefinition beanDefinition) {
+			var metadata = beanDefinition.getMetadata();
+
+			return metadata.isInterface() && metadata.hasAnnotation(HttpExchange.class.getName());
+		}
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -43,6 +43,7 @@ spring:
         max-redirects: 3
   ai:
     openai:
+      base-url: https://api.openai.com/v1
       api-key: ${OPENAI_API_KEY}
       chat:
         options:


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- resolves: #이슈번호, #이슈번호 -->
resolves: #227 

## 📝작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

강사님 강의 기반으로 코드 작성했습니다.

- OpenAI 벡터스토어 기반 API 연동
VectorApi 및 DefaultVectorApi 구현체 작성
벡터스토어 생성, 파일 업로드, 검색, 삭제 기능 추가
공식 홈페이지 검토 후 강사님 코드 가져왔습니다.
https://platform.openai.com/docs/api-reference/vector-stores/search

- HTTP 인터페이스 빈 자동 등록
HttpInterfaceBeanFactoryPostProcessor -> 강사님 코드 사용
@HttpExchange 어노테이션 스캔 이후 자동 빈 생성합니다.


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->