### PR TITLE
[FEAT] FAQ, VectorStore 기반 AI 응답 시스템 초기 구축

### DIFF
--- a/src/main/java/com/kt/ai/DefaultVectorApi.java
+++ b/src/main/java/com/kt/ai/DefaultVectorApi.java
@@ -6,7 +6,7 @@ import org.springframework.core.io.ByteArrayResource;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 
-import com.kt.ai.dto.OpenAIRequest;
+import com.kt.ai.dto.request.OpenAIRequest;
 
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/kt/ai/OpenAIClient.java
+++ b/src/main/java/com/kt/ai/OpenAIClient.java
@@ -9,8 +9,8 @@ import org.springframework.web.service.annotation.DeleteExchange;
 import org.springframework.web.service.annotation.HttpExchange;
 import org.springframework.web.service.annotation.PostExchange;
 
-import com.kt.ai.dto.OpenAIRequest;
-import com.kt.ai.dto.OpenAIResponse;
+import com.kt.ai.dto.request.OpenAIRequest;
+import com.kt.ai.dto.response.OpenAIResponse;
 
 @HttpExchange(url = "https://api.openai.com/v1", contentType = MediaType.APPLICATION_JSON_VALUE)
 public interface OpenAIClient {

--- a/src/main/java/com/kt/ai/controller/FAQAdminController.java
+++ b/src/main/java/com/kt/ai/controller/FAQAdminController.java
@@ -1,0 +1,44 @@
+package com.kt.ai.controller;
+
+import static com.kt.common.api.ApiResult.*;
+
+import java.util.UUID;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.kt.ai.dto.request.FAQRequest;
+import com.kt.ai.service.FAQService;
+import com.kt.common.api.ApiResult;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/admin/faq")
+@RequiredArgsConstructor
+public class FAQAdminController {
+
+	private final FAQService faqService;
+
+	@PostMapping
+	public ResponseEntity<ApiResult<Void>> createFAQ(
+		@RequestBody @Valid FAQRequest.Create request
+	) throws Exception {
+		faqService.create(request.title(), request.content(), request.category());
+
+		return empty();
+	}
+
+	@DeleteMapping("/{faqId}")
+	public ResponseEntity<ApiResult<Void>> deleteFAQ(@PathVariable UUID faqId) {
+		faqService.delete(faqId);
+		return empty();
+	}
+
+}

--- a/src/main/java/com/kt/ai/dto/request/FAQRequest.java
+++ b/src/main/java/com/kt/ai/dto/request/FAQRequest.java
@@ -1,0 +1,17 @@
+package com.kt.ai.dto.request;
+
+import com.kt.constant.FAQCategory;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public class FAQRequest {
+
+	@Schema(name = "FAQCreateRequest")
+	public record Create(
+		String title,
+		String content,
+		FAQCategory category
+	) {
+
+	}
+}

--- a/src/main/java/com/kt/ai/dto/request/OpenAIRequest.java
+++ b/src/main/java/com/kt/ai/dto/request/OpenAIRequest.java
@@ -1,4 +1,4 @@
-package com.kt.ai.dto;
+package com.kt.ai.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 

--- a/src/main/java/com/kt/ai/dto/response/OpenAIResponse.java
+++ b/src/main/java/com/kt/ai/dto/response/OpenAIResponse.java
@@ -1,4 +1,4 @@
-package com.kt.ai.dto;
+package com.kt.ai.dto.response;
 
 import java.util.List;
 

--- a/src/main/java/com/kt/ai/service/FAQService.java
+++ b/src/main/java/com/kt/ai/service/FAQService.java
@@ -1,0 +1,12 @@
+package com.kt.ai.service;
+
+import java.util.UUID;
+
+import com.kt.constant.FAQCategory;
+
+public interface FAQService {
+
+	void create(String title, String Content, FAQCategory category) throws Exception;
+
+	void delete(UUID id);
+}

--- a/src/main/java/com/kt/ai/service/FAQServiceImpl.java
+++ b/src/main/java/com/kt/ai/service/FAQServiceImpl.java
@@ -1,0 +1,66 @@
+package com.kt.ai.service;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kt.ai.VectorApi;
+import com.kt.constant.FAQCategory;
+import com.kt.constant.VectorType;
+import com.kt.constant.message.ErrorCode;
+import com.kt.domain.entity.FAQEntity;
+import com.kt.exception.CustomException;
+import com.kt.repository.faq.FAQRepository;
+import com.kt.repository.vector.VectorStoreRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class FAQServiceImpl implements FAQService {
+	private final FAQRepository faqRepository;
+	private final VectorApi vectorApi;
+	private final VectorStoreRepository vectorStoreRepository;
+	private final ObjectMapper objectMapper;
+
+	@Override
+	public void create(
+		String title,
+		String content,
+		FAQCategory category
+	) throws Exception {
+		var faq = faqRepository.save(
+			FAQEntity.create(
+				title,
+				content,
+				category
+			)
+		);
+
+		var vector = vectorStoreRepository.findByType(VectorType.FAQ)
+			.orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_VECTOR_STORE));
+
+		var fileId = vectorApi.uploadFile(
+			vector.getStoreId(),
+			objectMapper.writeValueAsBytes(faq)
+		);
+
+		faq.updateFileId(fileId);
+	}
+
+	@Override
+	public void delete(UUID id) {
+		var faq = faqRepository.findById(id)
+			.orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_FAQ));
+
+		var vector = vectorStoreRepository.findByType(VectorType.FAQ)
+			.orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_VECTOR_STORE));
+
+		vectorApi.delete(vector.getStoreId(), faq.getFileId());
+
+		faqRepository.delete(faq);
+	}
+}

--- a/src/main/java/com/kt/ai/service/VectorService.java
+++ b/src/main/java/com/kt/ai/service/VectorService.java
@@ -1,0 +1,11 @@
+package com.kt.ai.service;
+
+import com.kt.constant.VectorType;
+
+public interface VectorService {
+
+	// TODO: 배포 환경시에만 생성되도록 변경
+	// void init()
+
+	void create(String storeId, String name, String description, VectorType type);
+}

--- a/src/main/java/com/kt/ai/service/VectorServiceImpl.java
+++ b/src/main/java/com/kt/ai/service/VectorServiceImpl.java
@@ -1,0 +1,51 @@
+package com.kt.ai.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kt.ai.VectorApi;
+import com.kt.constant.VectorType;
+import com.kt.domain.entity.VectorStoreEntity;
+import com.kt.repository.vector.VectorStoreRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class VectorServiceImpl implements VectorService {
+
+	private final VectorStoreRepository vectorStoreRepository;
+	private final VectorApi vectorApi;
+
+	// TODO: 배포 환경시에만 생성되도록 변경
+	// @Override
+	// @PostConstruct
+	// void init() {
+	// 	if (!vectorStoreRepository.existsByType(VectorType.FAQ)) {
+	// 		var name = "FAQ 벡터 스토어";
+	// 		var description = "자주 묻는 질문(FAQ) 데이터를 위한 벡터 스토어입니다.";
+	//
+	// 		var vectorStoreId = vectorApi.create(name, description);
+	//
+	// 		create(
+	// 			vectorStoreId,
+	// 			name,
+	// 			description,
+	// 			VectorType.FAQ
+	// 		);
+	// 	}
+	// }
+
+	@Override
+	public void create(String storeId, String name, String description, VectorType type) {
+		vectorStoreRepository.save(
+			VectorStoreEntity.create(
+				type,
+				storeId,
+				description,
+				name
+			)
+		);
+	}
+}

--- a/src/main/java/com/kt/constant/FAQCategory.java
+++ b/src/main/java/com/kt/constant/FAQCategory.java
@@ -1,6 +1,5 @@
 package com.kt.constant;
 
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor

--- a/src/main/java/com/kt/constant/FAQCategory.java
+++ b/src/main/java/com/kt/constant/FAQCategory.java
@@ -1,0 +1,18 @@
+package com.kt.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum FAQCategory {
+	ACCOUNT("계정"),
+	ORDER("주문"),
+	DELIVERY("배송"),
+	RETURN("반품"),
+	PAYMENT("결제"),
+	PRODUCT("상품"),
+	OTHER("기타"),
+	;
+
+	private final String description;
+}

--- a/src/main/java/com/kt/constant/VectorType.java
+++ b/src/main/java/com/kt/constant/VectorType.java
@@ -1,0 +1,12 @@
+package com.kt.constant;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum VectorType {
+	FAQ("FAQ"),
+	;
+
+	private final String description;
+
+}

--- a/src/main/java/com/kt/constant/message/ErrorCode.java
+++ b/src/main/java/com/kt/constant/message/ErrorCode.java
@@ -68,12 +68,14 @@ public enum ErrorCode {
 	PAY_NOT_FOUND(HttpStatus.NOT_FOUND, "Pay가 존재하지 않습니다."),
 	INVALID_REFUND_AMOUNT(HttpStatus.BAD_REQUEST, "잘못된 환불 금액입니다."),
 	INVALID_REFUND_REASON(HttpStatus.BAD_REQUEST, "이유는 반드시 작성해야 합니다."),
+	NOT_FOUND_VECTOR_STORE(HttpStatus.NOT_FOUND, "벡터스토어가 존재하지 않습니다."),
+	NOT_FOUND_FAQ(HttpStatus.NOT_FOUND, "FAQ가 존재하지 않습니다."),
 	CART_NOT_FOUND(HttpStatus.NOT_FOUND, "장바구니가 존재하지 않습니다."),
 	CART_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "장바구니 상품을 찾을 수 없습니다."),
 	INVALID_CART_ITEM_QUANTITY(HttpStatus.BAD_REQUEST, "장바구니 상품 수량은 1 이상이어야 합니다."),
-	MAX_CART_ITEM_QUANTITY(HttpStatus.FORBIDDEN, "장바구니에 담을 수 있는 최대 수량은 100개입니다.")
+	MAX_CART_ITEM_QUANTITY(HttpStatus.FORBIDDEN, "장바구니에 담을 수 있는 최대 수량은 100개입니다."),
 
-;
+	;
 	private final HttpStatus status;
 	private final String message;
 

--- a/src/main/java/com/kt/constant/message/ErrorCode.java
+++ b/src/main/java/com/kt/constant/message/ErrorCode.java
@@ -76,6 +76,7 @@ public enum ErrorCode {
 	MAX_CART_ITEM_QUANTITY(HttpStatus.FORBIDDEN, "장바구니에 담을 수 있는 최대 수량은 100개입니다."),
 
 	;
+
 	private final HttpStatus status;
 	private final String message;
 

--- a/src/main/java/com/kt/domain/entity/FAQEntity.java
+++ b/src/main/java/com/kt/domain/entity/FAQEntity.java
@@ -24,17 +24,18 @@ public class FAQEntity extends BaseEntity {
 
 	@Enumerated(EnumType.STRING)
 	private FAQCategory category;
+
+	@Column
 	private String fileId;
 
-	private FAQEntity(String title, String content, FAQCategory category, String fileId) {
+	private FAQEntity(String title, String content, FAQCategory category) {
 		this.title = title;
 		this.content = content;
 		this.category = category;
-		this.fileId = fileId;
 	}
 
-	public static FAQEntity create(String title, String content, FAQCategory category, String fileId) {
-		return new FAQEntity(title, content, category, null);
+	public static FAQEntity create(String title, String content, FAQCategory category) {
+		return new FAQEntity(title, content, category);
 	}
 
 	public void updateFileId(String fileId) {

--- a/src/main/java/com/kt/domain/entity/FAQEntity.java
+++ b/src/main/java/com/kt/domain/entity/FAQEntity.java
@@ -1,0 +1,44 @@
+package com.kt.domain.entity;
+
+import com.kt.constant.FAQCategory;
+import com.kt.domain.entity.common.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "faq")
+public class FAQEntity extends BaseEntity {
+
+	@Column(nullable = false)
+	private String title;
+
+	@Column(nullable = false)
+	private String content;
+
+	@Enumerated(EnumType.STRING)
+	private FAQCategory category;
+	private String fileId;
+
+	private FAQEntity(String title, String content, FAQCategory category, String fileId) {
+		this.title = title;
+		this.content = content;
+		this.category = category;
+		this.fileId = fileId;
+	}
+
+	public static FAQEntity create(String title, String content, FAQCategory category, String fileId) {
+		return new FAQEntity(title, content, category, null);
+	}
+
+	public void updateFileId(String fileId) {
+		this.fileId = fileId;
+	}
+
+}

--- a/src/main/java/com/kt/domain/entity/VectorStoreEntity.java
+++ b/src/main/java/com/kt/domain/entity/VectorStoreEntity.java
@@ -17,7 +17,7 @@ import lombok.NoArgsConstructor;
 public class VectorStoreEntity extends BaseEntity {
 
 	@Enumerated(EnumType.STRING)
-	private VectorType vectorType;
+	private VectorType type;
 
 	@Column(nullable = false)
 	private String storeId;
@@ -26,16 +26,16 @@ public class VectorStoreEntity extends BaseEntity {
 	@Column(nullable = false)
 	private String name;
 
-	private VectorStoreEntity(VectorType vectorType, String storeId, String name, String description) {
-		this.vectorType = vectorType;
+	private VectorStoreEntity(VectorType type, String storeId, String name, String description) {
+		this.type = type;
 		this.storeId = storeId;
 		this.name = name;
 		this.description = description;
 	}
 
-	public static VectorStoreEntity create(VectorType vectorType, String storeId, String name, String description) {
+	public static VectorStoreEntity create(VectorType type, String storeId, String name, String description) {
 		return new VectorStoreEntity(
-			vectorType, storeId, name, description
+			type, storeId, name, description
 		);
 	}
 }

--- a/src/main/java/com/kt/domain/entity/VectorStoreEntity.java
+++ b/src/main/java/com/kt/domain/entity/VectorStoreEntity.java
@@ -1,0 +1,41 @@
+package com.kt.domain.entity;
+
+import com.kt.constant.VectorType;
+import com.kt.domain.entity.common.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity(name = "vector")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class VectorStoreEntity extends BaseEntity {
+
+	@Enumerated(EnumType.STRING)
+	private VectorType vectorType;
+
+	@Column(nullable = false)
+	private String storeId;
+	@Column(nullable = false)
+	private String description;
+	@Column(nullable = false)
+	private String name;
+
+	private VectorStoreEntity(VectorType vectorType, String storeId, String name, String description) {
+		this.vectorType = vectorType;
+		this.storeId = storeId;
+		this.name = name;
+		this.description = description;
+	}
+
+	public static VectorStoreEntity create(VectorType vectorType, String storeId, String name, String description) {
+		return new VectorStoreEntity(
+			vectorType, storeId, name, description
+		);
+	}
+}

--- a/src/main/java/com/kt/repository/faq/FAQRepository.java
+++ b/src/main/java/com/kt/repository/faq/FAQRepository.java
@@ -1,0 +1,11 @@
+package com.kt.repository.faq;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.kt.domain.entity.FAQEntity;
+
+public interface FAQRepository extends JpaRepository<FAQEntity, UUID> {
+
+}

--- a/src/main/java/com/kt/repository/vector/VectorStoreRepository.java
+++ b/src/main/java/com/kt/repository/vector/VectorStoreRepository.java
@@ -1,0 +1,18 @@
+package com.kt.repository.vector;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.kt.constant.VectorType;
+import com.kt.domain.entity.VectorStoreEntity;
+
+@Repository
+public interface VectorStoreRepository extends JpaRepository<VectorStoreEntity, UUID> {
+
+	boolean existsByType(VectorType type);
+
+	Optional<VectorStoreEntity> findByType(VectorType type);
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- resolves: #이슈번호, #이슈번호 -->
resolves: #226 

## 📝작업 내용

https://vivid-thyme-ac6.notion.site/2d69e3e335cc8079a2e9cc6090812d5f?source=copy_link

간단히 현재 작업에 대한 생각 흐름 작성해보았습니다.
읽어보시고 피알 보시면 보기 편하실 것 같아요!

현재 PR 내 FAQ로 명명이 되어있지만(강사님도 하셔서..)
모든 고객 문의는 FAQ로 다뤄짐을 기대합니다.

1. 관리자가 예상 FAQ 질문/답변을 벡터스토어에 업로드
2. 유저가 챗봇 질문
2-1. 직접적 상품 관련 질문 시 학습 및 정규식을 통해 검증 이후 판매자에게 직접 문의 유도(프론트)
4. 3회까지 미해결 혹은 그 이전 낮은 정확도 확인
5. 관리자 1대1 채팅 전환

현재 우선 AI 관련 코드들은 /ai 내 서비스, 컨트롤러 다 넣고 있는데
저희 프로젝트 컨셉 상 기존 디렉토리 서비스, 컨트롤러로 옮기는 것이 좋을까요?

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->