### PR TITLE
[FEAT] 주문-결제 재고 차감 동시성 제어

### DIFF
--- a/src/main/java/com/kt/domain/entity/OrderProductEntity.java
+++ b/src/main/java/com/kt/domain/entity/OrderProductEntity.java
@@ -40,6 +40,15 @@ public class OrderProductEntity extends BaseEntity {
 	public static OrderProductEntity create(
 		Long quantity,
 		Long unitPrice,
+		OrderEntity order,
+		ProductEntity product
+	) {
+		return new OrderProductEntity(quantity, unitPrice, CREATED, order, product);
+	}
+
+	public static OrderProductEntity create(
+		Long quantity,
+		Long unitPrice,
 		OrderProductStatus status,
 		OrderEntity order,
 		ProductEntity product

--- a/src/main/java/com/kt/domain/entity/ProductEntity.java
+++ b/src/main/java/com/kt/domain/entity/ProductEntity.java
@@ -2,8 +2,6 @@ package com.kt.domain.entity;
 
 import static lombok.AccessLevel.*;
 
-import java.util.UUID;
-
 import com.kt.constant.ProductStatus;
 import com.kt.domain.entity.common.BaseEntity;
 
@@ -11,9 +9,9 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToOne;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -35,11 +33,11 @@ public class ProductEntity extends BaseEntity {
 	@Enumerated(EnumType.STRING)
 	private ProductStatus status;
 
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "category_id", nullable = false)
 	private CategoryEntity category;
 
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "seller_id", nullable = false)
 	private SellerEntity seller;
 

--- a/src/main/java/com/kt/repository/product/ProductRepository.java
+++ b/src/main/java/com/kt/repository/product/ProductRepository.java
@@ -1,22 +1,35 @@
 package com.kt.repository.product;
 
+import java.util.Optional;
 import java.util.UUID;
 
-import com.kt.exception.CustomException;
-
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.kt.constant.message.ErrorCode;
 import com.kt.domain.entity.ProductEntity;
+import com.kt.exception.CustomException;
 
-import com.kt.repository.product.ProductRepositoryCustom;
+import jakarta.persistence.LockModeType;
 
 @Repository
 public interface ProductRepository extends JpaRepository<ProductEntity, UUID>, ProductRepositoryCustom {
 
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("SELECT p FROM product p WHERE p.id = :productId")
+	Optional<ProductEntity> findByIdWithLock(@Param("productId") UUID productId);
+
 	default ProductEntity findByIdOrThrow(UUID productId) {
 		return findById(productId).orElseThrow(
+			() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND)
+		);
+	}
+
+	default ProductEntity findByIdWithLockOrThrow(UUID productId) {
+		return findByIdWithLock(productId).orElseThrow(
 			() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND)
 		);
 	}

--- a/src/main/java/com/kt/service/OrderPaymentService.java
+++ b/src/main/java/com/kt/service/OrderPaymentService.java
@@ -1,0 +1,23 @@
+package com.kt.service;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+
+import com.kt.domain.dto.request.OrderRequest;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class OrderPaymentService {
+
+	private final OrderService orderService;
+	// TODO: PayService 주입
+
+	public void orderPay(UUID userId, OrderRequest request) {
+		orderService.reduceStock(request.items());
+		orderService.createOrder(userId, request);
+		// TODO: PayService 결제 메서드 호출
+	}
+}

--- a/src/main/java/com/kt/service/OrderService.java
+++ b/src/main/java/com/kt/service/OrderService.java
@@ -22,6 +22,8 @@ public interface OrderService {
 
 	void reduceStock(UUID orderId);
 
+	void reduceStock(List<OrderRequest.Item> items);
+
 	void cancelOrderProduct(UUID userId, UUID orderProductId);
 
 	void changeOrderAddress(UUID userId, UUID orderId, OrderRequest.Update orderRequest);

--- a/src/main/java/com/kt/service/OrderServiceImpl.java
+++ b/src/main/java/com/kt/service/OrderServiceImpl.java
@@ -29,6 +29,7 @@ import com.kt.repository.AddressRepository;
 import com.kt.repository.PayRepository;
 import com.kt.repository.PaymentRepository;
 import com.kt.repository.ShippingDetailRepository;
+import com.kt.repository.order.OrderRepository;
 import com.kt.repository.orderproduct.OrderProductRepository;
 import com.kt.repository.product.ProductRepository;
 import com.kt.repository.user.UserRepository;
@@ -72,8 +73,7 @@ public class OrderServiceImpl implements OrderService {
 	public OrderEntity createOrder(
 		UUID userId,
 		OrderRequest request
-	)
-	{
+	) {
 		List<OrderRequest.Item> items = request.items();
 		UUID addressId = request.addressId();
 

--- a/src/test/java/com/kt/LockTest.java
+++ b/src/test/java/com/kt/LockTest.java
@@ -141,7 +141,11 @@ public class LockTest {
 			executorService.submit(() -> {
 				try {
 					System.out.println(String.format("===== 사용자 %d 주문 시도 =====", finalI));
-					orderService.createOrder(users.get(finalI).getEmail(), List.of(item), addresses.get(finalI).getId());
+					OrderRequest request = new OrderRequest(
+						List.of(item),
+						addresses.get(finalI).getId()
+					);
+					orderService.createOrder(users.get(finalI).getId(), request);
 					successCount.incrementAndGet();
 				} catch (RuntimeException e) {
 					e.printStackTrace();

--- a/src/test/java/com/kt/LockTest.java
+++ b/src/test/java/com/kt/LockTest.java
@@ -1,0 +1,143 @@
+package com.kt;
+
+import static com.kt.common.AddressCreator.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.kt.constant.AccountRole;
+import com.kt.constant.Gender;
+import com.kt.domain.dto.request.OrderRequest;
+import com.kt.domain.entity.AddressEntity;
+import com.kt.domain.entity.CategoryEntity;
+import com.kt.domain.entity.ProductEntity;
+import com.kt.domain.entity.SellerEntity;
+import com.kt.domain.entity.UserEntity;
+import com.kt.repository.AddressRepository;
+import com.kt.repository.CategoryRepository;
+import com.kt.repository.account.AccountRepository;
+import com.kt.repository.product.ProductRepository;
+import com.kt.service.OrderService;
+
+import lombok.extern.slf4j.Slf4j;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@Slf4j
+public class LockTest {
+
+	private final long productStock1 = 10L;
+	private final long productStock2 = 10L;
+	@Autowired
+	private OrderService orderService;
+	@Autowired
+	private ProductRepository productRepository;
+	@Autowired
+	private CategoryRepository categoryRepository;
+	@Autowired
+	private AccountRepository accountRepository;
+	@Autowired
+	private AddressRepository addressRepository;
+	private ProductEntity product1;
+	private ProductEntity product2;
+
+	private static UserEntity createUser(int i) {
+		return UserEntity.create(
+			"사용자" + i,
+			"user" + i + "@email.com",
+			"password",
+			AccountRole.MEMBER,
+			Gender.MALE,
+			LocalDate.now(),
+			"010-1234-1234"
+		);
+	}
+
+	@BeforeEach
+	void setup() {
+		CategoryEntity category = CategoryEntity.create("카테고리", null);
+		categoryRepository.save(category);
+		SellerEntity seller = SellerEntity.create(
+			"판매자",
+			"seller@email.com",
+			"password",
+			"가게명",
+			"010-1234-1234",
+			"seller@email.com",
+			Gender.MALE
+		);
+		accountRepository.save(seller);
+		product1 = ProductEntity.create(
+			"상품1", 100_000L, productStock1, category, seller
+		);
+		product2 = ProductEntity.create(
+			"상품2", 100_000L, productStock2, category, seller
+		);
+		productRepository.saveAll(List.of(product1, product2));
+	}
+
+	@Test
+	void 사용자_100명이_동시에_product1_상품에_대해서_주문_시도() throws InterruptedException {
+		int repeatCount = 100;
+		List<UserEntity> users = new ArrayList<>();
+		List<AddressEntity> addresses = new ArrayList<>();
+		for (int i = 0; i < repeatCount; i++) {
+			UserEntity user = createUser(i);
+			AddressEntity address = createAddress(user);
+			users.add(user);
+			addresses.add(address);
+		}
+		accountRepository.saveAll(users);
+		addressRepository.saveAll(addresses);
+		System.out.println("============== setup ==============");
+		OrderRequest.Item item = new OrderRequest.Item(
+			product1.getId(),
+			1L,
+			UUID.randomUUID()
+		);
+
+		// 동시에 주문해야하니까 쓰레드를 100개
+		ExecutorService executorService = Executors.newFixedThreadPool(repeatCount);
+		CountDownLatch countDownLatch = new CountDownLatch(repeatCount);
+		AtomicInteger successCount = new AtomicInteger(0);
+		AtomicInteger failureCount = new AtomicInteger(0);
+
+		for (int i = 0; i < repeatCount; i++) {
+			int finalI = i;
+			executorService.submit(() -> {
+				try {
+					System.out.println(String.format("===== 사용자 %d 주문 시도 =====", finalI));
+					orderService.createOrder(users.get(finalI).getEmail(), List.of(item), addresses.get(finalI).getId());
+					successCount.incrementAndGet();
+				} catch (RuntimeException e) {
+					e.printStackTrace();
+					failureCount.incrementAndGet();
+				} finally {
+					countDownLatch.countDown();
+				}
+			});
+		}
+
+		countDownLatch.await();
+		executorService.shutdown();
+
+		ProductEntity foundProduct = productRepository.findById(product1.getId()).orElse(null);
+
+		assertThat(successCount.get()).isEqualTo((int)productStock1);
+		assertThat(failureCount.get()).isEqualTo(repeatCount - (int)productStock1);
+		assertThat(foundProduct.getStock()).isEqualTo(0);
+	}
+}

--- a/src/test/java/com/kt/LockTest.java
+++ b/src/test/java/com/kt/LockTest.java
@@ -34,6 +34,7 @@ import com.kt.repository.account.AccountRepository;
 import com.kt.repository.order.OrderRepository;
 import com.kt.repository.orderproduct.OrderProductRepository;
 import com.kt.repository.product.ProductRepository;
+import com.kt.service.OrderPaymentService;
 import com.kt.service.OrderService;
 
 import lombok.extern.slf4j.Slf4j;
@@ -45,6 +46,8 @@ public class LockTest {
 
 	private final long productStock1 = 10L;
 	private final long productStock2 = 10L;
+	@Autowired
+	private OrderPaymentService orderPaymentService;
 	@Autowired
 	private OrderService orderService;
 	@Autowired
@@ -145,7 +148,7 @@ public class LockTest {
 						List.of(item),
 						addresses.get(finalI).getId()
 					);
-					orderService.createOrder(users.get(finalI).getId(), request);
+					orderPaymentService.orderPay(users.get(finalI).getId(), request);
 					successCount.incrementAndGet();
 				} catch (RuntimeException e) {
 					e.printStackTrace();

--- a/src/test/java/com/kt/service/OrderServiceTest.java
+++ b/src/test/java/com/kt/service/OrderServiceTest.java
@@ -5,10 +5,6 @@ import static org.assertj.core.api.Assertions.*;
 import java.util.List;
 import java.util.UUID;
 
-import com.kt.common.SellerEntityCreator;
-import com.kt.domain.entity.PaymentEntity;
-import com.kt.domain.entity.SellerEntity;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -22,6 +18,7 @@ import com.kt.common.CategoryEntityCreator;
 import com.kt.common.CourierEntityCreator;
 import com.kt.common.ProductEntityCreator;
 import com.kt.common.ReceiverCreator;
+import com.kt.common.SellerEntityCreator;
 import com.kt.common.UserEntityCreator;
 import com.kt.constant.OrderProductStatus;
 import com.kt.constant.message.ErrorCode;
@@ -33,6 +30,7 @@ import com.kt.domain.entity.CourierEntity;
 import com.kt.domain.entity.OrderEntity;
 import com.kt.domain.entity.OrderProductEntity;
 import com.kt.domain.entity.ProductEntity;
+import com.kt.domain.entity.SellerEntity;
 import com.kt.domain.entity.ShippingDetailEntity;
 import com.kt.domain.entity.UserEntity;
 import com.kt.exception.CustomException;
@@ -155,11 +153,14 @@ class OrderServiceTest {
 		OrderRequest orderRequest = new OrderRequest(items, address.getId());
 
 		// when, then
-		assertThatThrownBy(() ->
-			orderService.createOrder(
-				testUser.getId(),
-				orderRequest
-			)
+		assertThatThrownBy(() -> {
+				orderService.checkStock(orderRequest.items());
+				orderService.createOrder(
+					testUser.getId(),
+					orderRequest
+				);
+				orderService.reduceStock(orderRequest.items());
+			}
 		)
 			.isInstanceOf(CustomException.class)
 			.hasMessageContaining("PRODUCT_NOT_FOUND");
@@ -179,11 +180,14 @@ class OrderServiceTest {
 		OrderRequest orderRequest = new OrderRequest(items, address.getId());
 
 		// when, then
-		assertThatThrownBy(() ->
-			orderService.createOrder(
+		assertThatThrownBy(() -> {
+				orderService.checkStock(orderRequest.items());
+				orderService.createOrder(
 					testUser.getId(),
 					orderRequest
-				)
+				);
+				orderService.reduceStock(orderRequest.items());
+			}
 		)
 			.isInstanceOf(CustomException.class)
 			.hasMessageContaining("STOCK_NOT_ENOUGH");


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- resolves: #이슈번호, #이슈번호 -->
resolves:

## 📝작업 내용

여러 사용자가 동시에 주문-결제를 요청했을때 재고 차감 과정에서 발생할 수 있는 동시성 문제를 해결하고자 합니다.

재고 차감 로직(reduceStock)이 현재 주문 생성에서 분리되어 있어 임의로 포함시켰습니다.

유스케이스 개발 과정에서 다시 분리할 예정입니다.

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

동시성 문제 해결 전략으로 3가지가 있는데, (비관적 락, 낙관적 락, 분산 락)

필균 강사님께서 공유해주셨던 레퍼런스를 참고한 내용 중에

외부 결제 모듈을 사용하지 않으면서, 내부 서비스 로직에서 빠르게 처리가 가능한 경우 

**비관적락을 사용하는게 더 유리하다**는 글이 있었습니다.

<img width="717" height="202" alt="image" src="https://github.com/user-attachments/assets/ca92e7e3-e219-42dd-b353-6806322f875a" />

https://www.inflearn.com/community/questions/1693067/%EC%95%88%EB%85%95%ED%95%98%EC%84%B8%EC%9A%94-%EC%A3%BC%EB%AC%B8%EC%B2%98%EB%A6%AC%EC%97%90-%EA%B4%80%ED%95%98%EC%97%AC-%EC%A7%88%EB%AC%B8%EC%9E%88%EC%8A%B5%EB%8B%88%EB%8B%A4-%E3%85%A0-%E3%85%81-%E3%85%9C?srsltid=AfmBOooCXkk73tLhp6z411fckgtrxepS-McKjCM2HzbQnZsbalEsV4Q_

현재 저희 서비스는 외부 결제 모듈을 사용하는 상황이 아니고 내부 페이 서비스로 결제를 진행해서 

서버 내부 api 호출만으로 모든 로직이 실행되기 때문에 이에 맞춰서 비관적 락으로 해결하였는데, 

**프로젝트성 혹은 추후 멀티모듈을 고려해 redis를 위한 분산락으로 풀어가야할지 아니면 이대로 좋을지** 팀원들의 의견이 필요합니다.


<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->