### PR TITLE
 [FEAT] 주문, 리뷰 서비스 일부 메서드 시그니처 수정

### DIFF
--- a/src/main/java/com/kt/controller/address/AddressController.java
+++ b/src/main/java/com/kt/controller/address/AddressController.java
@@ -28,7 +28,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequestMapping("/api/addresses")
 @RequiredArgsConstructor
-public class AddressController implements AddressSwaggerSupporter{
+public class AddressController implements AddressSwaggerSupporter {
 
 	private final AddressService addressService;
 
@@ -38,7 +38,7 @@ public class AddressController implements AddressSwaggerSupporter{
 		@AuthenticationPrincipal DefaultCurrentUser currentUser,
 		@RequestBody @Valid AddressRequest request
 	) {
-		return wrap(addressService.create(currentUser.getUsername(), request));
+		return wrap(addressService.create(currentUser.getId(), request));
 	}
 
 	@Override
@@ -46,7 +46,7 @@ public class AddressController implements AddressSwaggerSupporter{
 	public ResponseEntity<ApiResult<List<AddressResponse>>> getMyAddresses(
 		@AuthenticationPrincipal DefaultCurrentUser currentUser
 	) {
-		return wrap(addressService.getMyAddresses(currentUser.getUsername()));
+		return wrap(addressService.getMyAddresses(currentUser.getId()));
 	}
 
 	@Override
@@ -55,7 +55,7 @@ public class AddressController implements AddressSwaggerSupporter{
 		@AuthenticationPrincipal DefaultCurrentUser currentUser,
 		@PathVariable UUID addressId
 	) {
-		return wrap(addressService.getOne(currentUser.getUsername(), addressId));
+		return wrap(addressService.getOne(currentUser.getId(), addressId));
 	}
 
 	@Override
@@ -65,7 +65,7 @@ public class AddressController implements AddressSwaggerSupporter{
 		@PathVariable UUID addressId,
 		@RequestBody @Valid AddressRequest request
 	) {
-		addressService.update(currentUser.getUsername(), addressId, request);
+		addressService.update(currentUser.getId(), addressId, request);
 		return empty();
 	}
 
@@ -75,7 +75,7 @@ public class AddressController implements AddressSwaggerSupporter{
 		@AuthenticationPrincipal DefaultCurrentUser currentUser,
 		@PathVariable UUID addressId
 	) {
-		addressService.delete(currentUser.getUsername(), addressId);
+		addressService.delete(currentUser.getId(), addressId);
 		return empty();
 	}
 }

--- a/src/main/java/com/kt/controller/review/ReviewController.java
+++ b/src/main/java/com/kt/controller/review/ReviewController.java
@@ -41,7 +41,7 @@ public class ReviewController implements ReviewSwaggerSupporter {
 		@RequestBody ReviewRequest.Create request
 	) {
 		reviewService.create(
-			currentUser.getEmail(),
+			currentUser.getId(),
 			request.orderProductId(),
 			request.content()
 		);
@@ -83,7 +83,7 @@ public class ReviewController implements ReviewSwaggerSupporter {
 		@RequestBody ReviewRequest.Update request
 	) {
 		reviewService.update(
-			currentUser.getEmail(),
+			currentUser.getId(),
 			reviewId,
 			request.content()
 		);
@@ -95,7 +95,7 @@ public class ReviewController implements ReviewSwaggerSupporter {
 		@AuthenticationPrincipal DefaultCurrentUser currentUser,
 		@PathVariable UUID reviewId
 	) {
-		reviewService.delete(currentUser.getEmail(), reviewId);
+		reviewService.delete(currentUser.getId(), reviewId);
 		return empty();
 	}
 }

--- a/src/main/java/com/kt/domain/entity/OrderProductEntity.java
+++ b/src/main/java/com/kt/domain/entity/OrderProductEntity.java
@@ -40,6 +40,15 @@ public class OrderProductEntity extends BaseEntity {
 	public static OrderProductEntity create(
 		Long quantity,
 		Long unitPrice,
+		OrderEntity order,
+		ProductEntity product
+	) {
+		return new OrderProductEntity(quantity, unitPrice, CREATED, order, product);
+	}
+
+	public static OrderProductEntity create(
+		Long quantity,
+		Long unitPrice,
 		OrderProductStatus status,
 		OrderEntity order,
 		ProductEntity product

--- a/src/main/java/com/kt/domain/entity/ProductEntity.java
+++ b/src/main/java/com/kt/domain/entity/ProductEntity.java
@@ -2,8 +2,6 @@ package com.kt.domain.entity;
 
 import static lombok.AccessLevel.*;
 
-import java.util.UUID;
-
 import com.kt.constant.ProductStatus;
 import com.kt.domain.entity.common.BaseEntity;
 
@@ -11,9 +9,9 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToOne;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -35,11 +33,11 @@ public class ProductEntity extends BaseEntity {
 	@Enumerated(EnumType.STRING)
 	private ProductStatus status;
 
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "category_id", nullable = false)
 	private CategoryEntity category;
 
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "seller_id", nullable = false)
 	private SellerEntity seller;
 

--- a/src/main/java/com/kt/repository/product/ProductRepository.java
+++ b/src/main/java/com/kt/repository/product/ProductRepository.java
@@ -1,22 +1,35 @@
 package com.kt.repository.product;
 
+import java.util.Optional;
 import java.util.UUID;
 
-import com.kt.exception.CustomException;
-
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.kt.constant.message.ErrorCode;
 import com.kt.domain.entity.ProductEntity;
+import com.kt.exception.CustomException;
 
-import com.kt.repository.product.ProductRepositoryCustom;
+import jakarta.persistence.LockModeType;
 
 @Repository
 public interface ProductRepository extends JpaRepository<ProductEntity, UUID>, ProductRepositoryCustom {
 
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("SELECT p FROM product p WHERE p.id = :productId")
+	Optional<ProductEntity> findByIdWithLock(@Param("productId") UUID productId);
+
 	default ProductEntity findByIdOrThrow(UUID productId) {
 		return findById(productId).orElseThrow(
+			() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND)
+		);
+	}
+
+	default ProductEntity findByIdWithLockOrThrow(UUID productId) {
+		return findByIdWithLock(productId).orElseThrow(
 			() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND)
 		);
 	}

--- a/src/main/java/com/kt/service/AddressService.java
+++ b/src/main/java/com/kt/service/AddressService.java
@@ -8,13 +8,13 @@ import com.kt.domain.dto.response.AddressResponse;
 
 public interface AddressService {
 
-	UUID create(String email, AddressRequest request);
+	UUID create(UUID userId, AddressRequest request);
 
-	List<AddressResponse> getMyAddresses(String email);
+	List<AddressResponse> getMyAddresses(UUID userId);
 
-	AddressResponse getOne(String email, UUID addressId);
+	AddressResponse getOne(UUID userId, UUID addressId);
 
-	void update(String email, UUID addressId, AddressRequest request);
+	void update(UUID userId, UUID addressId, AddressRequest request);
 
-	void delete(String email, UUID addressId);
+	void delete(UUID userId, UUID addressId);
 }

--- a/src/main/java/com/kt/service/AddressServiceImpl.java
+++ b/src/main/java/com/kt/service/AddressServiceImpl.java
@@ -25,8 +25,8 @@ public class AddressServiceImpl implements AddressService {
 
 	@Override
 	@Transactional
-	public UUID create(String email, AddressRequest request) {
-		UserEntity user = userRepository.findByEmailOrThrow(email);
+	public UUID create(UUID userId, AddressRequest request) {
+		UserEntity user = userRepository.findByIdOrThrow(userId);
 
 		AddressEntity address = AddressEntity.create(
 			request.receiverName(),
@@ -42,8 +42,8 @@ public class AddressServiceImpl implements AddressService {
 	}
 
 	@Override
-	public List<AddressResponse> getMyAddresses(String email) {
-		UserEntity user = userRepository.findByEmailOrThrow(email);
+	public List<AddressResponse> getMyAddresses(UUID userId) {
+		UserEntity user = userRepository.findByIdOrThrow(userId);
 
 		return addressRepository.findAllByCreatedBy(user)
 			.stream()
@@ -60,8 +60,8 @@ public class AddressServiceImpl implements AddressService {
 	}
 
 	@Override
-	public AddressResponse getOne(String email, UUID addressId) {
-		UserEntity user = userRepository.findByEmailOrThrow(email);
+	public AddressResponse getOne(UUID userId, UUID addressId) {
+		UserEntity user = userRepository.findByIdOrThrow(userId);
 
 		AddressEntity address = addressRepository.findByIdAndCreatedByOrThrow(addressId, user);
 
@@ -78,8 +78,8 @@ public class AddressServiceImpl implements AddressService {
 
 	@Override
 	@Transactional
-	public void update(String email, UUID addressId, AddressRequest request) {
-		UserEntity user = userRepository.findByEmailOrThrow(email);
+	public void update(UUID userId, UUID addressId, AddressRequest request) {
+		UserEntity user = userRepository.findByIdOrThrow(userId);
 
 		AddressEntity address = addressRepository.findByIdAndCreatedByOrThrow(addressId, user);
 
@@ -95,8 +95,8 @@ public class AddressServiceImpl implements AddressService {
 
 	@Override
 	@Transactional
-	public void delete(String email, UUID addressId) {
-		UserEntity user = userRepository.findByEmailOrThrow(email);
+	public void delete(UUID userId, UUID addressId) {
+		UserEntity user = userRepository.findByIdOrThrow(userId);
 
 		AddressEntity address = addressRepository.findByIdAndCreatedByOrThrow(addressId, user);
 

--- a/src/main/java/com/kt/service/OrderPaymentService.java
+++ b/src/main/java/com/kt/service/OrderPaymentService.java
@@ -1,0 +1,23 @@
+package com.kt.service;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+
+import com.kt.domain.dto.request.OrderRequest;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class OrderPaymentService {
+
+	private final OrderService orderService;
+	// TODO: PayService 주입
+
+	public void orderPay(UUID userId, OrderRequest request) {
+		orderService.reduceStock(request.items());
+		orderService.createOrder(userId, request);
+		// TODO: PayService 결제 메서드 호출
+	}
+}

--- a/src/main/java/com/kt/service/OrderService.java
+++ b/src/main/java/com/kt/service/OrderService.java
@@ -22,6 +22,8 @@ public interface OrderService {
 
 	void reduceStock(UUID orderId);
 
+	void reduceStock(List<OrderRequest.Item> items);
+
 	void cancelOrderProduct(UUID userId, UUID orderProductId);
 
 	void changeOrderAddress(UUID userId, UUID orderId, OrderRequest.Update orderRequest);

--- a/src/main/java/com/kt/service/ReviewService.java
+++ b/src/main/java/com/kt/service/ReviewService.java
@@ -9,11 +9,11 @@ import com.kt.constant.searchtype.ProductSearchType;
 import com.kt.domain.dto.response.ReviewResponse;
 
 public interface ReviewService {
-	void create(String email, UUID orderProductId, String content);
+	void create(UUID userId, UUID orderProductId, String content);
 
-	void update(String email, UUID reviewId, String content);
+	void update(UUID userId, UUID reviewId, String content);
 
-	void delete(String email, UUID reviewId);
+	void delete(UUID userId, UUID reviewId);
 
 	ReviewResponse.Search getReview(UUID orderProductId);
 

--- a/src/test/java/com/kt/LockTest.java
+++ b/src/test/java/com/kt/LockTest.java
@@ -1,0 +1,171 @@
+package com.kt;
+
+import static com.kt.common.AddressCreator.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.kt.constant.AccountRole;
+import com.kt.constant.Gender;
+import com.kt.domain.dto.request.OrderRequest;
+import com.kt.domain.entity.AddressEntity;
+import com.kt.domain.entity.CategoryEntity;
+import com.kt.domain.entity.ProductEntity;
+import com.kt.domain.entity.SellerEntity;
+import com.kt.domain.entity.UserEntity;
+import com.kt.repository.AddressRepository;
+import com.kt.repository.CategoryRepository;
+import com.kt.repository.account.AccountRepository;
+import com.kt.repository.order.OrderRepository;
+import com.kt.repository.orderproduct.OrderProductRepository;
+import com.kt.repository.product.ProductRepository;
+import com.kt.service.OrderPaymentService;
+import com.kt.service.OrderService;
+
+import lombok.extern.slf4j.Slf4j;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@Slf4j
+public class LockTest {
+
+	private final long productStock1 = 10L;
+	private final long productStock2 = 10L;
+	@Autowired
+	private OrderPaymentService orderPaymentService;
+	@Autowired
+	private OrderService orderService;
+	@Autowired
+	private OrderRepository orderRepository;
+	@Autowired
+	private ProductRepository productRepository;
+	@Autowired
+	private CategoryRepository categoryRepository;
+	@Autowired
+	private AccountRepository accountRepository;
+	@Autowired
+	private AddressRepository addressRepository;
+	@Autowired
+	private OrderProductRepository orderProductRepository;
+	@Autowired
+	private PasswordEncoder passwordEncoder;
+	private ProductEntity product1;
+	private ProductEntity product2;
+
+	private static UserEntity createUser(int i) {
+		return UserEntity.create(
+			"사용자" + i,
+			"user" + i + "@email.com",
+			"password",
+			AccountRole.MEMBER,
+			Gender.MALE,
+			LocalDate.now(),
+			"010-1234-1234"
+		);
+	}
+
+	@AfterEach
+	void cleanUp() {
+		// 외래키 제약조건을 고려하여 역순으로 삭제
+		orderProductRepository.deleteAll();
+		productRepository.deleteAll(); // 상품 삭제
+		orderRepository.deleteAll();  // 주문 먼저 삭제
+		addressRepository.deleteAll(); // 주소 삭제
+		categoryRepository.deleteAll(); // 카테고리 삭제
+		accountRepository.deleteAll();  // 계정 삭제
+	}
+
+	@BeforeEach
+	void setup() {
+		CategoryEntity category = CategoryEntity.create("카테고리", null);
+		categoryRepository.save(category);
+		SellerEntity seller = SellerEntity.create(
+			"판매자",
+			"seller@email.com",
+			passwordEncoder.encode("password"),
+			"가게명",
+			"010-1234-1234",
+			Gender.MALE
+		);
+		accountRepository.save(seller);
+		product1 = ProductEntity.create(
+			"상품1", 100_000L, productStock1, category, seller
+		);
+		product2 = ProductEntity.create(
+			"상품2", 100_000L, productStock2, category, seller
+		);
+		productRepository.saveAll(List.of(product1, product2));
+		productRepository.flush();
+	}
+
+	@Test
+	void 사용자_100명이_동시에_product1_상품에_대해서_주문_시도() throws InterruptedException {
+		int repeatCount = 100;
+		List<UserEntity> users = new ArrayList<>();
+		List<AddressEntity> addresses = new ArrayList<>();
+		for (int i = 0; i < repeatCount; i++) {
+			UserEntity user = createUser(i);
+			AddressEntity address = createAddress(user);
+			users.add(user);
+			addresses.add(address);
+		}
+		accountRepository.saveAll(users);
+		addressRepository.saveAll(addresses);
+		System.out.println("============== setup ==============");
+		OrderRequest.Item item = new OrderRequest.Item(
+			product1.getId(),
+			1L,
+			UUID.randomUUID()
+		);
+
+		// 동시에 주문해야하니까 쓰레드를 100개
+		ExecutorService executorService = Executors.newFixedThreadPool(repeatCount);
+		CountDownLatch countDownLatch = new CountDownLatch(repeatCount);
+		AtomicInteger successCount = new AtomicInteger(0);
+		AtomicInteger failureCount = new AtomicInteger(0);
+
+		for (int i = 0; i < repeatCount; i++) {
+			int finalI = i;
+			executorService.submit(() -> {
+				try {
+					System.out.println(String.format("===== 사용자 %d 주문 시도 =====", finalI));
+					OrderRequest request = new OrderRequest(
+						List.of(item),
+						addresses.get(finalI).getId()
+					);
+					orderPaymentService.orderPay(users.get(finalI).getId(), request);
+					successCount.incrementAndGet();
+				} catch (RuntimeException e) {
+					e.printStackTrace();
+					failureCount.incrementAndGet();
+				} finally {
+					countDownLatch.countDown();
+				}
+			});
+		}
+
+		countDownLatch.await();
+		executorService.shutdown();
+
+		ProductEntity foundProduct = productRepository.findById(product1.getId()).orElse(null);
+
+		assertThat(successCount.get()).isEqualTo((int)productStock1);
+		assertThat(failureCount.get()).isEqualTo(repeatCount - (int)productStock1);
+		assertThat(foundProduct.getStock()).isEqualTo(0);
+	}
+}

--- a/src/test/java/com/kt/api/addresses/AddressCreateTest.java
+++ b/src/test/java/com/kt/api/addresses/AddressCreateTest.java
@@ -5,8 +5,6 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-import com.kt.common.UserEntityCreator;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,6 +16,7 @@ import org.springframework.test.web.servlet.ResultActions;
 
 import com.kt.common.AddressCreator;
 import com.kt.common.MockMvcTest;
+import com.kt.common.UserEntityCreator;
 import com.kt.domain.dto.request.AddressRequest;
 import com.kt.domain.entity.AddressEntity;
 import com.kt.domain.entity.UserEntity;
@@ -62,7 +61,7 @@ class AddressCreateTest extends MockMvcTest {
 			post("/api/addresses")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(validRequest))
-				.with(user(getMemberUserDetails(testUser.getEmail())))
+				.with(user(getMemberUserDetails(testUser.getId())))
 		);
 
 		// then

--- a/src/test/java/com/kt/api/addresses/AddressSearchTest.java
+++ b/src/test/java/com/kt/api/addresses/AddressSearchTest.java
@@ -5,8 +5,6 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-import com.kt.common.UserEntityCreator;
-
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -15,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.web.servlet.ResultActions;
 
 import com.kt.common.MockMvcTest;
+import com.kt.common.UserEntityCreator;
 import com.kt.domain.entity.AddressEntity;
 import com.kt.domain.entity.UserEntity;
 import com.kt.repository.AddressRepository;
@@ -40,7 +39,7 @@ class AddressSearchTest extends MockMvcTest {
 	void 주소_목록조회_성공__주소없을때_빈리스트_반환() throws Exception {
 		// when
 		ResultActions actions = mockMvc.perform(get("/api/addresses")
-			.with(user(getMemberUserDetails(testUser.getEmail())))
+			.with(user(getMemberUserDetails(testUser.getId())))
 		);
 
 		// then
@@ -79,7 +78,7 @@ class AddressSearchTest extends MockMvcTest {
 		// when
 		ResultActions actions = mockMvc.perform(
 			get("/api/addresses")
-				.with(user(getMemberUserDetails(testUser.getEmail())))
+				.with(user(getMemberUserDetails(testUser.getId())))
 		);
 
 		// then

--- a/src/test/java/com/kt/api/addresses/AddressUpdateTest.java
+++ b/src/test/java/com/kt/api/addresses/AddressUpdateTest.java
@@ -5,8 +5,6 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-import com.kt.common.UserEntityCreator;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -19,6 +17,7 @@ import org.springframework.test.web.servlet.ResultActions;
 
 import com.kt.common.AddressCreator;
 import com.kt.common.MockMvcTest;
+import com.kt.common.UserEntityCreator;
 import com.kt.domain.dto.request.AddressRequest;
 import com.kt.domain.entity.AddressEntity;
 import com.kt.domain.entity.UserEntity;
@@ -59,7 +58,7 @@ class AddressUpdateTest extends MockMvcTest {
 
 		ResultActions actions = mockMvc.perform(
 			put("/api/addresses/{addressId}", address.getId())
-				.with(user(getMemberUserDetails(testUser.getEmail())))
+				.with(user(getMemberUserDetails(testUser.getId())))
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request))
 		);

--- a/src/test/java/com/kt/api/product/ProductReviewTest.java
+++ b/src/test/java/com/kt/api/product/ProductReviewTest.java
@@ -5,16 +5,15 @@ import static com.kt.common.ProductEntityCreator.*;
 
 import java.util.List;
 
-import com.kt.common.UserEntityCreator;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import com.kt.common.AddressCreator;
 import com.kt.common.MockMvcTest;
-import com.kt.constant.OrderProductStatus;
 import com.kt.common.SellerEntityCreator;
+import com.kt.common.UserEntityCreator;
+import com.kt.constant.OrderProductStatus;
 import com.kt.domain.dto.request.OrderRequest;
 import com.kt.domain.entity.AddressEntity;
 import com.kt.domain.entity.CategoryEntity;

--- a/src/test/java/com/kt/api/product/ProductReviewTest.java
+++ b/src/test/java/com/kt/api/product/ProductReviewTest.java
@@ -23,9 +23,9 @@ import com.kt.domain.entity.SellerEntity;
 import com.kt.domain.entity.UserEntity;
 import com.kt.repository.AddressRepository;
 import com.kt.repository.CategoryRepository;
-import com.kt.repository.seller.SellerRepository;
 import com.kt.repository.orderproduct.OrderProductRepository;
 import com.kt.repository.product.ProductRepository;
+import com.kt.repository.seller.SellerRepository;
 import com.kt.repository.user.UserRepository;
 import com.kt.service.OrderService;
 import com.kt.service.ReviewService;
@@ -94,7 +94,7 @@ public class ProductReviewTest extends MockMvcTest {
 		List<OrderProductEntity> list = orderProductRepository.findAll().stream().toList();
 		for (int i = 0; i < 3; i++) {
 			OrderProductEntity orderProduct = list.get(i);
-			reviewService.create(testMember.getMobile(), orderProduct.getId(), "리뷰 내용: 리뷰" + i);
+			reviewService.create(testMember.getId(), orderProduct.getId(), "리뷰 내용: 리뷰" + i);
 		}
 	}
 }

--- a/src/test/java/com/kt/api/review/ReviewCreateTest.java
+++ b/src/test/java/com/kt/api/review/ReviewCreateTest.java
@@ -1,13 +1,9 @@
 package com.kt.api.review;
 
-import com.kt.common.SellerEntityCreator;
-import com.kt.domain.entity.SellerEntity;
-import com.kt.repository.seller.SellerRepository;
-
-import static com.kt.common.CurrentUserCreator.getMemberUserDetails;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static com.kt.common.CurrentUserCreator.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -22,6 +18,7 @@ import com.kt.common.MockMvcTest;
 import com.kt.common.OrderProductCreator;
 import com.kt.common.ProductCreator;
 import com.kt.common.ReceiverCreator;
+import com.kt.common.SellerEntityCreator;
 import com.kt.common.UserEntityCreator;
 import com.kt.constant.OrderProductStatus;
 import com.kt.domain.dto.request.ReviewRequest;
@@ -31,12 +28,14 @@ import com.kt.domain.entity.OrderProductEntity;
 import com.kt.domain.entity.ProductEntity;
 import com.kt.domain.entity.ReceiverVO;
 import com.kt.domain.entity.ReviewEntity;
+import com.kt.domain.entity.SellerEntity;
 import com.kt.domain.entity.UserEntity;
 import com.kt.repository.CategoryRepository;
 import com.kt.repository.order.OrderRepository;
 import com.kt.repository.orderproduct.OrderProductRepository;
 import com.kt.repository.product.ProductRepository;
 import com.kt.repository.review.ReviewRepository;
+import com.kt.repository.seller.SellerRepository;
 import com.kt.repository.user.UserRepository;
 
 @DisplayName("상품 리뷰 작성 - POST /api/orderproducts/{orderProductId}/reviews")
@@ -100,7 +99,7 @@ public class ReviewCreateTest extends MockMvcTest {
 		// when
 		ResultActions actions = mockMvc.perform(
 			post("/api/reviews")
-				.with(user(getMemberUserDetails(testMember.getEmail())))
+				.with(user(getMemberUserDetails(testMember.getId())))
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(json)
 		);

--- a/src/test/java/com/kt/api/review/ReviewDeleteTest.java
+++ b/src/test/java/com/kt/api/review/ReviewDeleteTest.java
@@ -1,13 +1,10 @@
 package com.kt.api.review;
 
-import com.kt.common.SellerEntityCreator;
-import com.kt.domain.entity.SellerEntity;
-
+import static com.kt.common.CurrentUserCreator.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-import static com.kt.common.CurrentUserCreator.*;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -20,6 +17,7 @@ import com.kt.common.MockMvcTest;
 import com.kt.common.OrderProductCreator;
 import com.kt.common.ProductCreator;
 import com.kt.common.ReceiverCreator;
+import com.kt.common.SellerEntityCreator;
 import com.kt.common.UserEntityCreator;
 import com.kt.constant.ReviewStatus;
 import com.kt.domain.entity.CategoryEntity;
@@ -28,6 +26,7 @@ import com.kt.domain.entity.OrderProductEntity;
 import com.kt.domain.entity.ProductEntity;
 import com.kt.domain.entity.ReceiverVO;
 import com.kt.domain.entity.ReviewEntity;
+import com.kt.domain.entity.SellerEntity;
 import com.kt.domain.entity.UserEntity;
 import com.kt.repository.CategoryRepository;
 import com.kt.repository.order.OrderRepository;
@@ -94,7 +93,7 @@ public class ReviewDeleteTest extends MockMvcTest {
 		// when
 		ResultActions actions = mockMvc.perform(
 			delete("/api/reviews/{reviewId}", review.getId())
-				.with(user(getMemberUserDetails(testMember.getEmail())))
+				.with(user(getMemberUserDetails(testMember.getId())))
 		);
 
 		// then

--- a/src/test/java/com/kt/api/review/ReviewUpdateTest.java
+++ b/src/test/java/com/kt/api/review/ReviewUpdateTest.java
@@ -1,13 +1,10 @@
 package com.kt.api.review;
 
-import com.kt.common.SellerEntityCreator;
-import com.kt.domain.entity.SellerEntity;
-
-import static com.kt.common.CurrentUserCreator.getMemberUserDetails;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static com.kt.common.CurrentUserCreator.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -21,6 +18,7 @@ import com.kt.common.MockMvcTest;
 import com.kt.common.OrderProductCreator;
 import com.kt.common.ProductCreator;
 import com.kt.common.ReceiverCreator;
+import com.kt.common.SellerEntityCreator;
 import com.kt.common.UserEntityCreator;
 import com.kt.domain.dto.request.ReviewRequest;
 import com.kt.domain.entity.CategoryEntity;
@@ -29,6 +27,7 @@ import com.kt.domain.entity.OrderProductEntity;
 import com.kt.domain.entity.ProductEntity;
 import com.kt.domain.entity.ReceiverVO;
 import com.kt.domain.entity.ReviewEntity;
+import com.kt.domain.entity.SellerEntity;
 import com.kt.domain.entity.UserEntity;
 import com.kt.repository.CategoryRepository;
 import com.kt.repository.order.OrderRepository;
@@ -99,7 +98,7 @@ public class ReviewUpdateTest extends MockMvcTest {
 		// when
 		ResultActions actions = mockMvc.perform(
 			patch("/api/reviews/{reviewId}", review.getId())
-				.with(user(getMemberUserDetails(testMember.getEmail())))
+				.with(user(getMemberUserDetails(testMember.getId())))
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(updateJson)
 		);

--- a/src/test/java/com/kt/service/OrderServiceTest.java
+++ b/src/test/java/com/kt/service/OrderServiceTest.java
@@ -5,10 +5,6 @@ import static org.assertj.core.api.Assertions.*;
 import java.util.List;
 import java.util.UUID;
 
-import com.kt.common.SellerEntityCreator;
-import com.kt.domain.entity.PaymentEntity;
-import com.kt.domain.entity.SellerEntity;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -22,6 +18,7 @@ import com.kt.common.CategoryEntityCreator;
 import com.kt.common.CourierEntityCreator;
 import com.kt.common.ProductEntityCreator;
 import com.kt.common.ReceiverCreator;
+import com.kt.common.SellerEntityCreator;
 import com.kt.common.UserEntityCreator;
 import com.kt.constant.OrderProductStatus;
 import com.kt.constant.message.ErrorCode;
@@ -33,6 +30,7 @@ import com.kt.domain.entity.CourierEntity;
 import com.kt.domain.entity.OrderEntity;
 import com.kt.domain.entity.OrderProductEntity;
 import com.kt.domain.entity.ProductEntity;
+import com.kt.domain.entity.SellerEntity;
 import com.kt.domain.entity.ShippingDetailEntity;
 import com.kt.domain.entity.UserEntity;
 import com.kt.exception.CustomException;
@@ -155,11 +153,14 @@ class OrderServiceTest {
 		OrderRequest orderRequest = new OrderRequest(items, address.getId());
 
 		// when, then
-		assertThatThrownBy(() ->
-			orderService.createOrder(
-				testUser.getId(),
-				orderRequest
-			)
+		assertThatThrownBy(() -> {
+				orderService.checkStock(orderRequest.items());
+				orderService.createOrder(
+					testUser.getId(),
+					orderRequest
+				);
+				orderService.reduceStock(orderRequest.items());
+			}
 		)
 			.isInstanceOf(CustomException.class)
 			.hasMessageContaining("PRODUCT_NOT_FOUND");
@@ -179,11 +180,14 @@ class OrderServiceTest {
 		OrderRequest orderRequest = new OrderRequest(items, address.getId());
 
 		// when, then
-		assertThatThrownBy(() ->
-			orderService.createOrder(
+		assertThatThrownBy(() -> {
+				orderService.checkStock(orderRequest.items());
+				orderService.createOrder(
 					testUser.getId(),
 					orderRequest
-				)
+				);
+				orderService.reduceStock(orderRequest.items());
+			}
 		)
 			.isInstanceOf(CustomException.class)
 			.hasMessageContaining("STOCK_NOT_ENOUGH");

--- a/src/test/java/com/kt/service/ReviewServiceTest.java
+++ b/src/test/java/com/kt/service/ReviewServiceTest.java
@@ -97,7 +97,7 @@ class ReviewServiceTest {
 		// given
 		testOrderProduct.updateStatus(OrderProductStatus.PURCHASE_CONFIRMED);
 		// when
-		reviewService.create(testUser.getEmail(), testOrderProduct.getId(), "테스트리뷰내용");
+		reviewService.create(testUser.getId(), testOrderProduct.getId(), "테스트리뷰내용");
 		// // then
 		Optional<ReviewEntity> saved = reviewRepository
 			.findAll()
@@ -121,7 +121,7 @@ class ReviewServiceTest {
 		// when and then
 		assertThatThrownBy(
 			() -> reviewService.create(
-				testUser.getEmail(),
+				testUser.getId(),
 				testOrderProduct.getId(),
 				"테스트리뷰내용"
 			)
@@ -138,7 +138,7 @@ class ReviewServiceTest {
 		reviewRepository.save(review);
 
 		// when
-		reviewService.update(testUser.getEmail(), review.getId(), "변경된테스트리뷰내용");
+		reviewService.update(testUser.getId(), review.getId(), "변경된테스트리뷰내용");
 
 		// then
 		Assertions.assertEquals("변경된테스트리뷰내용", review.getContent());
@@ -152,7 +152,7 @@ class ReviewServiceTest {
 		reviewRepository.save(review);
 
 		// when
-		reviewService.delete(testUser.getEmail(), review.getId());
+		reviewService.delete(testUser.getId(), review.getId());
 
 		// then
 		Assertions.assertEquals(ReviewStatus.REMOVED, review.getStatus());


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- resolves: #이슈번호, #이슈번호 -->
resolves:

## 📝작업 내용

기본 프로젝트 당시 서비스에서 UserEntity를 찾기 위해 email을 사용했던 로직을 userId를 사용하는것으로 변경합니다.

변경 대상 메서드
- OrderService - createOrder (민서님이 작업하셨었네요..)
- ReviewService - create, update, delete

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->



## 💬리뷰 요구사항(선택)
<img width="848" height="335" alt="image" src="https://github.com/user-attachments/assets/277e2798-f7d5-4f92-a2ff-00b2906b2c93" />
@oneokiwa AddressService 메서드도 아직 email로 사용자를 검색하고 있는데 같이 작업할까요?

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->