### PR TITLE
[FEAT] 벡터스토어 <-> 챗봇 연동

### DIFF
--- a/src/main/java/com/kt/ai/AIChatSessionStore.java
+++ b/src/main/java/com/kt/ai/AIChatSessionStore.java
@@ -1,0 +1,44 @@
+package com.kt.ai;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+
+import com.kt.constant.redis.RedisKey;
+import com.kt.infra.redis.RedisCache;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class AIChatSessionStore {
+	private final RedisCache redisCache;
+
+	public String getOrCreate(UUID userId) {
+		String key = RedisKey.AI_CHAT_SESSION.key(userId);
+		String conversationId = redisCache.get(key, String.class);
+
+		if (conversationId == null) {
+			redisCache.set(RedisKey.AI_CHAT_SESSION, userId, UUID.randomUUID().toString());
+		}
+
+		return conversationId;
+	}
+
+	public int increaseFail(UUID userId) {
+		String key = RedisKey.AI_CHAT_FAIL.key(userId);
+		Integer count = redisCache.get(key, Integer.class);
+
+		if (count == null)
+			count = 0;
+
+		count++;
+
+		redisCache.set(RedisKey.AI_CHAT_FAIL, userId, count);
+		return count;
+	}
+
+	public void clear(UUID userId) {
+		redisCache.delete(RedisKey.AI_CHAT_SESSION.key(userId));
+	}
+}

--- a/src/main/java/com/kt/ai/DefaultVectorApi.java
+++ b/src/main/java/com/kt/ai/DefaultVectorApi.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 
 import com.kt.ai.dto.request.OpenAIRequest;
+import com.kt.ai.dto.response.OpenAIResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -70,6 +71,15 @@ public class DefaultVectorApi implements VectorApi {
 		openAIClient.deleteFile(
 			fileId,
 			token()
+		);
+	}
+
+	@Override
+	public OpenAIResponse.Search search(String vectorStoreId, String question) {
+		return openAIClient.search(
+			vectorStoreId,
+			token(),
+			new OpenAIRequest.Search(question)
 		);
 	}
 }

--- a/src/main/java/com/kt/ai/RAGRetriever.java
+++ b/src/main/java/com/kt/ai/RAGRetriever.java
@@ -1,0 +1,42 @@
+package com.kt.ai;
+
+import java.util.Comparator;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
+import com.kt.ai.dto.mapper.AIChatMapper;
+import com.kt.ai.dto.response.OpenAIResponse;
+import com.kt.constant.VectorType;
+import com.kt.domain.entity.VectorStoreEntity;
+import com.kt.repository.vector.VectorStoreRepository;
+
+import lombok.AllArgsConstructor;
+
+@Component
+@AllArgsConstructor
+public class RAGRetriever {
+
+	private final VectorApi vectorApi;
+	private final VectorStoreRepository vectorStoreRepository;
+
+	public AIChatMapper.VectorSearchResult retrieve(String question) {
+		VectorStoreEntity vectorStore = vectorStoreRepository.findByTypeOrThrow(VectorType.FAQ);
+		OpenAIResponse.Search response = vectorApi.search(vectorStore.getStoreId(), question);
+
+		var top = response.data().stream()
+			.max(Comparator.comparingDouble(OpenAIResponse.SearchData::score))
+			.orElse(null);
+
+		if (top == null) {
+			return new AIChatMapper.VectorSearchResult(0, null, null);
+		}
+
+		String joinedContent = top.content().stream()
+			.map(OpenAIResponse.Content::text)
+			.filter(t -> t != null && !t.isBlank())
+			.collect(Collectors.joining("\n"));
+
+		return new AIChatMapper.VectorSearchResult(top.score(), joinedContent, top.fileId());
+	}
+}

--- a/src/main/java/com/kt/ai/VectorApi.java
+++ b/src/main/java/com/kt/ai/VectorApi.java
@@ -1,5 +1,7 @@
 package com.kt.ai;
 
+import com.kt.ai.dto.response.OpenAIResponse;
+
 public interface VectorApi {
 	/**
 	 *
@@ -12,4 +14,6 @@ public interface VectorApi {
 	String uploadFile(String vectorStoreId, byte[] json);
 
 	void delete(String vectorStoreId, String fileId);
+
+	OpenAIResponse.Search search(String vectorStoreId, String question);
 }

--- a/src/main/java/com/kt/ai/client/FAQChatClient.java
+++ b/src/main/java/com/kt/ai/client/FAQChatClient.java
@@ -2,6 +2,8 @@ package com.kt.ai.client;
 
 import org.springframework.stereotype.Component;
 
+import com.kt.ai.dto.mapper.AIChatMapper;
+
 import lombok.RequiredArgsConstructor;
 
 @Component
@@ -10,9 +12,18 @@ public class FAQChatClient {
 
 	private final BaseChatClient baseChatClient;
 
-	public String ask(String userMessage, String conversationId) {
+	public String ask(String question, AIChatMapper.VectorSearchResult rag, String conversationId) {
 		return baseChatClient.prompt(conversationId)
-			.user(userMessage)
+			.system("""
+				당신은 고객센터 FAQ AI입니다.
+				아래 자료 안에서만 답변하세요.
+				추측 금지, 모르면 "확인 후 안내드릴게요." 라고 답하세요.
+				
+				📌 참고 자료:
+				%s
+				""".formatted(rag)
+			)
+			.user(question)
 			.call()
 			.content();
 	}

--- a/src/main/java/com/kt/ai/controller/FAQAdminController.java
+++ b/src/main/java/com/kt/ai/controller/FAQAdminController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.kt.ai.dto.request.FAQRequest;
-import com.kt.ai.service.FAQService;
+import com.kt.ai.service.AdminFAQService;
 import com.kt.common.api.ApiResult;
 
 import jakarta.validation.Valid;
@@ -24,20 +24,20 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class FAQAdminController {
 
-	private final FAQService faqService;
+	private final AdminFAQService adminFaqService;
 
 	@PostMapping
 	public ResponseEntity<ApiResult<Void>> createFAQ(
 		@RequestBody @Valid FAQRequest.Create request
 	) throws Exception {
-		faqService.create(request.title(), request.content(), request.category());
+		adminFaqService.create(request.title(), request.content(), request.category());
 
 		return empty();
 	}
 
 	@DeleteMapping("/{faqId}")
 	public ResponseEntity<ApiResult<Void>> deleteFAQ(@PathVariable UUID faqId) {
-		faqService.delete(faqId);
+		adminFaqService.delete(faqId);
 		return empty();
 	}
 

--- a/src/main/java/com/kt/ai/controller/FAQController.java
+++ b/src/main/java/com/kt/ai/controller/FAQController.java
@@ -1,14 +1,13 @@
 package com.kt.ai.controller;
 
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.kt.ai.client.FAQChatClient;
 import com.kt.ai.service.RAGService;
+import com.kt.security.DefaultCurrentUser;
 
 import lombok.RequiredArgsConstructor;
 
@@ -21,14 +20,11 @@ public class FAQController {
 
 	@PostMapping("/faq")
 	public String askFAQ(
-		@RequestParam String userId,
+		@AuthenticationPrincipal DefaultCurrentUser defaultCurrentUser,
 		@RequestBody String question
 	) {
 
-		// TODO: 실제 채팅방 ID로 변경 필요
-		String conversationId = "faq:" + userId;
-
-		return ragService.askFAQ(question, conversationId);
+		return ragService.askFAQ(defaultCurrentUser.getId(), question);
 	}
 
 }

--- a/src/main/java/com/kt/ai/controller/FAQController.java
+++ b/src/main/java/com/kt/ai/controller/FAQController.java
@@ -1,11 +1,14 @@
 package com.kt.ai.controller;
 
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.kt.ai.client.FAQChatClient;
+import com.kt.ai.service.RAGService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -14,16 +17,18 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class FAQController {
 
-	private final FAQChatClient faqChatClient;
+	private final RAGService ragService;
 
-	@GetMapping("/faq")
-	public String ask(
+	@PostMapping("/faq")
+	public String askFAQ(
 		@RequestParam String userId,
-		@RequestParam String message
+		@RequestBody String question
 	) {
+
 		// TODO: 실제 채팅방 ID로 변경 필요
 		String conversationId = "faq:" + userId;
 
-		return faqChatClient.ask(message, conversationId);
+		return ragService.askFAQ(question, conversationId);
 	}
+
 }

--- a/src/main/java/com/kt/ai/dto/mapper/AIChatMapper.java
+++ b/src/main/java/com/kt/ai/dto/mapper/AIChatMapper.java
@@ -1,0 +1,12 @@
+package com.kt.ai.dto.mapper;
+
+public class AIChatMapper {
+	public record VectorSearchResult(
+		double score,
+		String content,
+		String fileId
+	) {
+
+	}
+
+}

--- a/src/main/java/com/kt/ai/service/AdminFAQService.java
+++ b/src/main/java/com/kt/ai/service/AdminFAQService.java
@@ -4,7 +4,7 @@ import java.util.UUID;
 
 import com.kt.constant.FAQCategory;
 
-public interface FAQService {
+public interface AdminFAQService {
 
 	void create(String title, String Content, FAQCategory category) throws Exception;
 

--- a/src/main/java/com/kt/ai/service/AdminFAQServiceImpl.java
+++ b/src/main/java/com/kt/ai/service/AdminFAQServiceImpl.java
@@ -20,7 +20,7 @@ import lombok.RequiredArgsConstructor;
 @Service
 @Transactional
 @RequiredArgsConstructor
-public class FAQServiceImpl implements FAQService {
+public class AdminFAQServiceImpl implements AdminFAQService {
 	private final FAQRepository faqRepository;
 	private final VectorApi vectorApi;
 	private final VectorStoreRepository vectorStoreRepository;

--- a/src/main/java/com/kt/ai/service/RAGService.java
+++ b/src/main/java/com/kt/ai/service/RAGService.java
@@ -1,5 +1,8 @@
 package com.kt.ai.service;
 
+import java.util.UUID;
+
 public interface RAGService {
-	String askFAQ(String question, String conversationId);
+	String askFAQ(UUID userId, String question);
+
 }

--- a/src/main/java/com/kt/ai/service/RAGService.java
+++ b/src/main/java/com/kt/ai/service/RAGService.java
@@ -1,0 +1,5 @@
+package com.kt.ai.service;
+
+public interface RAGService {
+	String askFAQ(String question, String conversationId);
+}

--- a/src/main/java/com/kt/ai/service/RAGServiceImpl.java
+++ b/src/main/java/com/kt/ai/service/RAGServiceImpl.java
@@ -1,0 +1,71 @@
+package com.kt.ai.service;
+
+import java.util.stream.Collectors;
+
+import org.springframework.ai.chat.client.DefaultChatClient;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kt.ai.OpenAIClient;
+import com.kt.ai.OpenAIProperties;
+import com.kt.ai.client.BaseChatClient;
+import com.kt.ai.client.FAQChatClient;
+import com.kt.ai.dto.request.OpenAIRequest;
+import com.kt.constant.VectorType;
+import com.kt.constant.message.ErrorCode;
+import com.kt.domain.entity.VectorStoreEntity;
+import com.kt.exception.CustomException;
+import com.kt.repository.vector.VectorStoreRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class RAGServiceImpl implements RAGService {
+
+	private final OpenAIClient openAIClient;
+	private final OpenAIProperties openAIProperties;
+	private final VectorStoreRepository vectorStoreRepository;
+	private final BaseChatClient chatClient;
+
+	public String askFAQ(String question, String conversationId) {
+		VectorStoreEntity vectorStore = vectorStoreRepository.findByTypeOrThrow(VectorType.FAQ);
+
+		var store = vectorStoreRepository.findByType(VectorType.FAQ)
+			.orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_VECTOR_STORE));
+
+		var response = openAIClient.search(
+			store.getStoreId(),
+			"Bearer " + openAIProperties.apiKey(),
+			new OpenAIRequest.Search(question)
+		);
+
+		if (response.data() == null || response.data().isEmpty()) {
+			return "관련 FAQ를 찾지 못했어요. 😥\n"
+				+ "조금 더 구체적으로 질문해주시겠어요?\n"
+				+ "또는 1:1 상담 연결을 도와드릴 수 있어요!";
+		}
+
+		var context = response.data().stream()
+			.flatMap(d -> d.content().stream())
+			.map(c -> c.text())
+			.limit(5)
+			.collect(Collectors.joining("\n----\n"));
+
+		System.out.println(context);
+		return chatClient.prompt(conversationId)
+			.system("""
+				당신은 고객센터 FAQ AI입니다.
+				아래 자료 안에서만 답변하세요.
+				추측 금지, 모르면 "확인 후 안내드릴게요." 라고 답하세요.
+				
+				📌 참고 자료:
+				%s
+				""".formatted(context)
+			)
+			.user(question)
+			.call()
+			.content();
+	}
+}

--- a/src/main/java/com/kt/constant/message/ErrorCode.java
+++ b/src/main/java/com/kt/constant/message/ErrorCode.java
@@ -70,6 +70,7 @@ public enum ErrorCode {
 	INVALID_REFUND_REASON(HttpStatus.BAD_REQUEST, "이유는 반드시 작성해야 합니다."),
 	NOT_FOUND_VECTOR_STORE(HttpStatus.NOT_FOUND, "벡터스토어가 존재하지 않습니다."),
 	NOT_FOUND_FAQ(HttpStatus.NOT_FOUND, "FAQ가 존재하지 않습니다."),
+	NOT_FOUND_VECTOR_TYPE(HttpStatus.NOT_FOUND, "챗봇 문의 타입이 존재하지 않습니다."),
 	CART_NOT_FOUND(HttpStatus.NOT_FOUND, "장바구니가 존재하지 않습니다."),
 	CART_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "장바구니 상품을 찾을 수 없습니다."),
 	INVALID_CART_ITEM_QUANTITY(HttpStatus.BAD_REQUEST, "장바구니 상품 수량은 1 이상이어야 합니다."),

--- a/src/main/java/com/kt/constant/redis/RedisKey.java
+++ b/src/main/java/com/kt/constant/redis/RedisKey.java
@@ -8,7 +8,10 @@ import java.time.Duration;
 public enum RedisKey {
 	SIGNUP_CODE("signup:code:", Duration.ofMinutes(3)),
 	SIGNUP_VERIFIED("signup:verified:", Duration.ofMinutes(5)),
-	REFRESH_TOKEN("refresh-token:", Duration.ofHours(24));
+	REFRESH_TOKEN("refresh-token:", Duration.ofHours(24)),
+	AI_CHAT_SESSION("ai-chat-session:%s", Duration.ofHours(24)),
+	AI_CHAT_FAIL("ai-chat-fail:%s", Duration.ofHours(24)),
+	;
 
 	private final String prefix;
 

--- a/src/main/java/com/kt/domain/entity/FAQEntity.java
+++ b/src/main/java/com/kt/domain/entity/FAQEntity.java
@@ -34,7 +34,7 @@ public class FAQEntity extends BaseEntity {
 		this.category = category;
 	}
 
-	public static FAQEntity create(String title, String content, FAQCategory category, String fileId) {
+	public static FAQEntity create(String title, String content, FAQCategory category) {
 		return new FAQEntity(title, content, category);
 	}
 

--- a/src/main/java/com/kt/domain/entity/FAQEntity.java
+++ b/src/main/java/com/kt/domain/entity/FAQEntity.java
@@ -34,7 +34,7 @@ public class FAQEntity extends BaseEntity {
 		this.category = category;
 	}
 
-	public static FAQEntity create(String title, String content, FAQCategory category) {
+	public static FAQEntity create(String title, String content, FAQCategory category, String fileId) {
 		return new FAQEntity(title, content, category);
 	}
 

--- a/src/main/java/com/kt/repository/vector/VectorStoreRepository.java
+++ b/src/main/java/com/kt/repository/vector/VectorStoreRepository.java
@@ -7,7 +7,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import com.kt.constant.VectorType;
+import com.kt.constant.message.ErrorCode;
 import com.kt.domain.entity.VectorStoreEntity;
+import com.kt.exception.CustomException;
 
 @Repository
 public interface VectorStoreRepository extends JpaRepository<VectorStoreEntity, UUID> {
@@ -15,4 +17,10 @@ public interface VectorStoreRepository extends JpaRepository<VectorStoreEntity, 
 	boolean existsByType(VectorType type);
 
 	Optional<VectorStoreEntity> findByType(VectorType type);
+
+	default VectorStoreEntity findByTypeOrThrow(VectorType type) {
+		return findByType(type).orElseThrow(
+			() -> new CustomException(ErrorCode.NOT_FOUND_VECTOR_TYPE)
+		);
+	}
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -43,7 +43,6 @@ spring:
         max-redirects: 3
   ai:
     openai:
-      base-url: https://api.openai.com/v1
       api-key: ${OPENAI_API_KEY}
       chat:
         options:


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- resolves: #이슈번호, #이슈번호 -->
resolves: #226 

## 📝작업 내용

- 벡터스토어 챗봇 연동 작업했습니다.
Admin -> AdminFAQController에서 FAQ Create시 벡터스토어에도 저장되며,
User -> FAQController -> RAGService 통해 벡터스토어와 통신 이후 LLM에 결과 전달해 
응답 받는 구조 완성했습니다.

오늘자 작업 간단했는데 환경변수 이슈로 404가 계속 터져서 일정이 지연됐네요..
늦어서 죄송합니다!

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

### 스크린샷 (선택)

<img width="1174" height="1032" alt="image" src="https://github.com/user-attachments/assets/9cedd5ed-6abd-441d-b143-8c01a3a4ea19" />


## 💬리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->