### PR TITLE
 [FEAT] 주문-결제 유스케이스 개발

### DIFF
--- a/src/main/java/com/kt/domain/entity/OrderProductEntity.java
+++ b/src/main/java/com/kt/domain/entity/OrderProductEntity.java
@@ -40,6 +40,15 @@ public class OrderProductEntity extends BaseEntity {
 	public static OrderProductEntity create(
 		Long quantity,
 		Long unitPrice,
+		OrderEntity order,
+		ProductEntity product
+	) {
+		return new OrderProductEntity(quantity, unitPrice, CREATED, order, product);
+	}
+
+	public static OrderProductEntity create(
+		Long quantity,
+		Long unitPrice,
 		OrderProductStatus status,
 		OrderEntity order,
 		ProductEntity product

--- a/src/main/java/com/kt/service/OrderPayUseCase.java
+++ b/src/main/java/com/kt/service/OrderPayUseCase.java
@@ -1,0 +1,27 @@
+package com.kt.service;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+
+import com.kt.domain.dto.request.OrderRequest;
+import com.kt.domain.entity.OrderEntity;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class OrderPayUseCase {
+
+	private final OrderService orderService;
+	private final PayService payService;
+
+	public void orderPay(String email, List<OrderRequest.Item> items, UUID addressId) {
+		orderService.checkStock(items);
+		OrderEntity order = orderService.createOrder(email, items, addressId);
+		orderService.reduceStock(order.getId());
+
+		payService.processPayment(orderId, amount);
+	}
+}

--- a/src/main/java/com/kt/service/OrderPayUseCase.java
+++ b/src/main/java/com/kt/service/OrderPayUseCase.java
@@ -1,12 +1,10 @@
 package com.kt.service;
 
-import java.util.List;
 import java.util.UUID;
 
 import org.springframework.stereotype.Component;
 
 import com.kt.domain.dto.request.OrderRequest;
-import com.kt.domain.entity.OrderEntity;
 
 import lombok.RequiredArgsConstructor;
 
@@ -15,13 +13,11 @@ import lombok.RequiredArgsConstructor;
 public class OrderPayUseCase {
 
 	private final OrderService orderService;
-	private final PayService payService;
+	// TODO: PayService 주입
 
-	public void orderPay(String email, List<OrderRequest.Item> items, UUID addressId) {
-		orderService.checkStock(items);
-		OrderEntity order = orderService.createOrder(email, items, addressId);
-		orderService.reduceStock(order.getId());
-
-		payService.processPayment(orderId, amount);
+	public void orderPay(UUID userId, OrderRequest request) {
+		orderService.reduceStock(request.items()); // 1. 재고 차감
+		orderService.createOrder(userId, request); // 2. 주문 생성
+		// TODO: PayService 결제 메서드 호출 // 3. 결제
 	}
 }

--- a/src/main/java/com/kt/service/OrderPaymentService.java
+++ b/src/main/java/com/kt/service/OrderPaymentService.java
@@ -10,14 +10,14 @@ import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
-public class OrderPayUseCase {
+public class OrderPaymentService {
 
 	private final OrderService orderService;
 	// TODO: PayService 주입
 
 	public void orderPay(UUID userId, OrderRequest request) {
-		orderService.reduceStock(request.items()); // 1. 재고 차감
-		orderService.createOrder(userId, request); // 2. 주문 생성
-		// TODO: PayService 결제 메서드 호출 // 3. 결제
+		orderService.reduceStock(request.items());
+		orderService.createOrder(userId, request);
+		// TODO: PayService 결제 메서드 호출
 	}
 }

--- a/src/main/java/com/kt/service/OrderService.java
+++ b/src/main/java/com/kt/service/OrderService.java
@@ -22,6 +22,8 @@ public interface OrderService {
 
 	void reduceStock(UUID orderId);
 
+	void reduceStock(List<OrderRequest.Item> items);
+
 	void cancelOrderProduct(UUID userId, UUID orderProductId);
 
 	void changeOrderAddress(UUID userId, UUID orderId, OrderRequest.Update orderRequest);

--- a/src/test/java/com/kt/LockTest.java
+++ b/src/test/java/com/kt/LockTest.java
@@ -34,6 +34,7 @@ import com.kt.repository.account.AccountRepository;
 import com.kt.repository.order.OrderRepository;
 import com.kt.repository.orderproduct.OrderProductRepository;
 import com.kt.repository.product.ProductRepository;
+import com.kt.service.OrderPayUseCase;
 import com.kt.service.OrderService;
 
 import lombok.extern.slf4j.Slf4j;
@@ -45,6 +46,8 @@ public class LockTest {
 
 	private final long productStock1 = 10L;
 	private final long productStock2 = 10L;
+	@Autowired
+	private OrderPayUseCase orderPayUseCase;
 	@Autowired
 	private OrderService orderService;
 	@Autowired
@@ -145,7 +148,7 @@ public class LockTest {
 						List.of(item),
 						addresses.get(finalI).getId()
 					);
-					orderService.createOrder(users.get(finalI).getId(), request);
+					orderPayUseCase.orderPay(users.get(finalI).getId(), request);
 					successCount.incrementAndGet();
 				} catch (RuntimeException e) {
 					e.printStackTrace();

--- a/src/test/java/com/kt/LockTest.java
+++ b/src/test/java/com/kt/LockTest.java
@@ -34,7 +34,7 @@ import com.kt.repository.account.AccountRepository;
 import com.kt.repository.order.OrderRepository;
 import com.kt.repository.orderproduct.OrderProductRepository;
 import com.kt.repository.product.ProductRepository;
-import com.kt.service.OrderPayUseCase;
+import com.kt.service.OrderPaymentService;
 import com.kt.service.OrderService;
 
 import lombok.extern.slf4j.Slf4j;
@@ -47,7 +47,7 @@ public class LockTest {
 	private final long productStock1 = 10L;
 	private final long productStock2 = 10L;
 	@Autowired
-	private OrderPayUseCase orderPayUseCase;
+	private OrderPaymentService orderPaymentService;
 	@Autowired
 	private OrderService orderService;
 	@Autowired
@@ -148,7 +148,7 @@ public class LockTest {
 						List.of(item),
 						addresses.get(finalI).getId()
 					);
-					orderPayUseCase.orderPay(users.get(finalI).getId(), request);
+					orderPaymentService.orderPay(users.get(finalI).getId(), request);
 					successCount.incrementAndGet();
 				} catch (RuntimeException e) {
 					e.printStackTrace();

--- a/src/test/java/com/kt/service/OrderServiceTest.java
+++ b/src/test/java/com/kt/service/OrderServiceTest.java
@@ -5,10 +5,6 @@ import static org.assertj.core.api.Assertions.*;
 import java.util.List;
 import java.util.UUID;
 
-import com.kt.common.SellerEntityCreator;
-import com.kt.domain.entity.PaymentEntity;
-import com.kt.domain.entity.SellerEntity;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -22,6 +18,7 @@ import com.kt.common.CategoryEntityCreator;
 import com.kt.common.CourierEntityCreator;
 import com.kt.common.ProductEntityCreator;
 import com.kt.common.ReceiverCreator;
+import com.kt.common.SellerEntityCreator;
 import com.kt.common.UserEntityCreator;
 import com.kt.constant.OrderProductStatus;
 import com.kt.constant.message.ErrorCode;
@@ -33,6 +30,7 @@ import com.kt.domain.entity.CourierEntity;
 import com.kt.domain.entity.OrderEntity;
 import com.kt.domain.entity.OrderProductEntity;
 import com.kt.domain.entity.ProductEntity;
+import com.kt.domain.entity.SellerEntity;
 import com.kt.domain.entity.ShippingDetailEntity;
 import com.kt.domain.entity.UserEntity;
 import com.kt.exception.CustomException;
@@ -155,11 +153,14 @@ class OrderServiceTest {
 		OrderRequest orderRequest = new OrderRequest(items, address.getId());
 
 		// when, then
-		assertThatThrownBy(() ->
-			orderService.createOrder(
-				testUser.getId(),
-				orderRequest
-			)
+		assertThatThrownBy(() -> {
+				orderService.checkStock(orderRequest.items());
+				orderService.createOrder(
+					testUser.getId(),
+					orderRequest
+				);
+				orderService.reduceStock(orderRequest.items());
+			}
 		)
 			.isInstanceOf(CustomException.class)
 			.hasMessageContaining("PRODUCT_NOT_FOUND");
@@ -179,11 +180,14 @@ class OrderServiceTest {
 		OrderRequest orderRequest = new OrderRequest(items, address.getId());
 
 		// when, then
-		assertThatThrownBy(() ->
-			orderService.createOrder(
+		assertThatThrownBy(() -> {
+				orderService.checkStock(orderRequest.items());
+				orderService.createOrder(
 					testUser.getId(),
 					orderRequest
-				)
+				);
+				orderService.reduceStock(orderRequest.items());
+			}
 		)
 			.isInstanceOf(CustomException.class)
 			.hasMessageContaining("STOCK_NOT_ENOUGH");


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- resolves: #이슈번호, #이슈번호 -->
resolves:

## 📝작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
금일 데일리스크럼 때 도현님이 말씀하신대로 선 재고 차감 이후에 결제하는 방법으로 했을 때도 테스트가 통과했습니다.

주문-결제 유스케이스에서 다음 메서드가 순차적으로 실행됩니다. 각 메서드 마다 트랜잭션이 분리되어 실행됩니다. 

1. 재고차감 (reduceStock) (트랜잭션1)
2. 주문 생성(createOrder) (트랜잭션2)
3. 결제 (pay) (트랜잭션3) 결제 서비스는 아직 없는 관계로 TODO 처리 했습니다.

### 스크린샷 (선택)

사진도 첨부하면 이해하는데 도움이 될 것 같아 함께 첨부합니다. 

### 주문-결제 프로세스 수정
피그잼 주문-결제 프로세스 수정했습니다.
<img width="697" height="334" alt="image" src="https://github.com/user-attachments/assets/10010320-a458-41da-9068-75442c115369" />


### 주문-결제에서 동시 트래픽 발생 시 락 제어 과정
피그잼에도 추가해놨습니다.
<img width="768" height="757" alt="image" src="https://github.com/user-attachments/assets/492666b2-c995-4e84-9d3c-b72ea787a3ee" />


## 💬리뷰 요구사항(선택)

저는 일단 주문-결제 관련 유스케이스 클래스 명을 OrderPayUseCase로 지었는데, 민서님은 장바구니-주문 관련된 유스케이스 클래스를 OrderApplicationService라고 지으셨더라구요. 네이밍 방식을 어떻게 하면 좋을까요?

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->