### PR TITLE
[FEAT] AI 챗봇 redis 사용 및 코드 책임 분리

### DIFF
--- a/src/main/java/com/kt/ai/AIChatSessionStore.java
+++ b/src/main/java/com/kt/ai/AIChatSessionStore.java
@@ -1,0 +1,31 @@
+package com.kt.ai;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+
+import com.kt.constant.redis.RedisKey;
+import com.kt.infra.redis.RedisCache;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class AIChatSessionStore {
+	private final RedisCache redisCache;
+
+	public String getOrCreate(UUID userId) {
+		String key = RedisKey.AI_CHAT_SESSION.key(userId);
+		String conversationId = redisCache.get(key, String.class);
+
+		if (conversationId == null) {
+			redisCache.set(RedisKey.AI_CHAT_SESSION, userId, UUID.randomUUID().toString());
+		}
+
+		return conversationId;
+	}
+
+	public void clear(UUID userId) {
+		redisCache.delete(RedisKey.AI_CHAT_SESSION.key(userId));
+	}
+}

--- a/src/main/java/com/kt/ai/AIChatSessionStore.java
+++ b/src/main/java/com/kt/ai/AIChatSessionStore.java
@@ -25,6 +25,19 @@ public class AIChatSessionStore {
 		return conversationId;
 	}
 
+	public int increaseFail(UUID userId) {
+		String key = RedisKey.AI_CHAT_FAIL.key(userId);
+		Integer count = redisCache.get(key, Integer.class);
+
+		if (count == null)
+			count = 0;
+
+		count++;
+
+		redisCache.set(RedisKey.AI_CHAT_FAIL, userId, count);
+		return count;
+	}
+
 	public void clear(UUID userId) {
 		redisCache.delete(RedisKey.AI_CHAT_SESSION.key(userId));
 	}

--- a/src/main/java/com/kt/ai/DefaultVectorApi.java
+++ b/src/main/java/com/kt/ai/DefaultVectorApi.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 
 import com.kt.ai.dto.request.OpenAIRequest;
+import com.kt.ai.dto.response.OpenAIResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -70,6 +71,15 @@ public class DefaultVectorApi implements VectorApi {
 		openAIClient.deleteFile(
 			fileId,
 			token()
+		);
+	}
+
+	@Override
+	public OpenAIResponse.Search search(String vectorStoreId, String question) {
+		return openAIClient.search(
+			vectorStoreId,
+			token(),
+			new OpenAIRequest.Search(question)
 		);
 	}
 }

--- a/src/main/java/com/kt/ai/RAGRetriever.java
+++ b/src/main/java/com/kt/ai/RAGRetriever.java
@@ -1,0 +1,43 @@
+package com.kt.ai;
+
+import java.util.Comparator;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
+import com.kt.ai.dto.mapper.AIChatMapper;
+import com.kt.ai.dto.response.OpenAIResponse;
+import com.kt.constant.VectorType;
+import com.kt.domain.entity.VectorStoreEntity;
+import com.kt.repository.vector.VectorStoreRepository;
+
+import lombok.AllArgsConstructor;
+
+@Component
+@AllArgsConstructor
+public class RAGRetriever {
+
+	private final DefaultVectorApi vectorApi;
+	private final VectorStoreRepository vectorStoreRepository;
+
+	public AIChatMapper.VectorSearchResult retrieve(String question) {
+		VectorStoreEntity vectorStore = vectorStoreRepository.findByTypeOrThrow(VectorType.FAQ);
+		OpenAIResponse.Search response = vectorApi.search(vectorStore.getStoreId(), question);
+
+		var top = response.data().stream()
+			.max(Comparator.comparingDouble(OpenAIResponse.SearchData::score))
+			.orElse(null);
+
+		if (top == null) {
+			return new AIChatMapper.VectorSearchResult(0, null, null);
+		}
+
+		String joinedContent = top.content().stream()
+			.map(OpenAIResponse.Content::text)
+			.filter(t -> t != null && !t.isBlank())
+			.collect(Collectors.joining("\n"));
+
+		System.out.println("joinedContent: " + joinedContent);
+		return new AIChatMapper.VectorSearchResult(top.score(), joinedContent, top.fileId());
+	}
+}

--- a/src/main/java/com/kt/ai/RAGRetriever.java
+++ b/src/main/java/com/kt/ai/RAGRetriever.java
@@ -37,7 +37,6 @@ public class RAGRetriever {
 			.filter(t -> t != null && !t.isBlank())
 			.collect(Collectors.joining("\n"));
 
-		System.out.println("joinedContent: " + joinedContent);
 		return new AIChatMapper.VectorSearchResult(top.score(), joinedContent, top.fileId());
 	}
 }

--- a/src/main/java/com/kt/ai/RAGRetriever.java
+++ b/src/main/java/com/kt/ai/RAGRetriever.java
@@ -17,7 +17,7 @@ import lombok.AllArgsConstructor;
 @AllArgsConstructor
 public class RAGRetriever {
 
-	private final DefaultVectorApi vectorApi;
+	private final VectorApi vectorApi;
 	private final VectorStoreRepository vectorStoreRepository;
 
 	public AIChatMapper.VectorSearchResult retrieve(String question) {

--- a/src/main/java/com/kt/ai/VectorApi.java
+++ b/src/main/java/com/kt/ai/VectorApi.java
@@ -1,5 +1,7 @@
 package com.kt.ai;
 
+import com.kt.ai.dto.response.OpenAIResponse;
+
 public interface VectorApi {
 	/**
 	 *
@@ -12,4 +14,6 @@ public interface VectorApi {
 	String uploadFile(String vectorStoreId, byte[] json);
 
 	void delete(String vectorStoreId, String fileId);
+
+	OpenAIResponse.Search search(String vectorStoreId, String question);
 }

--- a/src/main/java/com/kt/ai/client/FAQChatClient.java
+++ b/src/main/java/com/kt/ai/client/FAQChatClient.java
@@ -2,6 +2,8 @@ package com.kt.ai.client;
 
 import org.springframework.stereotype.Component;
 
+import com.kt.ai.dto.mapper.AIChatMapper;
+
 import lombok.RequiredArgsConstructor;
 
 @Component
@@ -10,9 +12,18 @@ public class FAQChatClient {
 
 	private final BaseChatClient baseChatClient;
 
-	public String ask(String userMessage, String conversationId) {
+	public String ask(String question, AIChatMapper.VectorSearchResult rag, String conversationId) {
 		return baseChatClient.prompt(conversationId)
-			.user(userMessage)
+			.system("""
+				당신은 고객센터 FAQ AI입니다.
+				아래 자료 안에서만 답변하세요.
+				추측 금지, 모르면 "확인 후 안내드릴게요." 라고 답하세요.
+				
+				📌 참고 자료:
+				%s
+				""".formatted(rag)
+			)
+			.user(question)
 			.call()
 			.content();
 	}

--- a/src/main/java/com/kt/ai/controller/FAQController.java
+++ b/src/main/java/com/kt/ai/controller/FAQController.java
@@ -1,14 +1,13 @@
 package com.kt.ai.controller;
 
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.kt.ai.client.FAQChatClient;
 import com.kt.ai.service.RAGService;
+import com.kt.security.DefaultCurrentUser;
 
 import lombok.RequiredArgsConstructor;
 
@@ -21,14 +20,11 @@ public class FAQController {
 
 	@PostMapping("/faq")
 	public String askFAQ(
-		@RequestParam String userId,
+		@AuthenticationPrincipal DefaultCurrentUser defaultCurrentUser,
 		@RequestBody String question
 	) {
 
-		// TODO: 실제 채팅방 ID로 변경 필요
-		String conversationId = "faq:" + userId;
-
-		return ragService.askFAQ(question, conversationId);
+		return ragService.askFAQ(defaultCurrentUser.getId(), question);
 	}
 
 }

--- a/src/main/java/com/kt/ai/dto/mapper/AIChatMapper.java
+++ b/src/main/java/com/kt/ai/dto/mapper/AIChatMapper.java
@@ -1,0 +1,12 @@
+package com.kt.ai.dto.mapper;
+
+public class AIChatMapper {
+	public record VectorSearchResult(
+		double score,
+		String content,
+		String fileId
+	) {
+
+	}
+
+}

--- a/src/main/java/com/kt/ai/service/RAGService.java
+++ b/src/main/java/com/kt/ai/service/RAGService.java
@@ -1,5 +1,8 @@
 package com.kt.ai.service;
 
+import java.util.UUID;
+
 public interface RAGService {
-	String askFAQ(String question, String conversationId);
+	String askFAQ(UUID userId, String question);
+
 }

--- a/src/main/java/com/kt/ai/service/RAGServiceImpl.java
+++ b/src/main/java/com/kt/ai/service/RAGServiceImpl.java
@@ -28,12 +28,9 @@ public class RAGServiceImpl implements RAGService {
 
 		String conversationId = chatSessionStore.getOrCreate(userId);
 		AIChatMapper.VectorSearchResult rag = ragRetriever.retrieve(question);
-		System.out.println("Conversation Id: " + conversationId);
-		System.out.println("rag.score() = " + rag.score());
 
 		if (rag.score() < THRESHOLD) {
 			int failCnt = chatSessionStore.increaseFail(userId);
-			System.out.println("failCnt = " + failCnt);
 			if (failCnt >= MAX_FAIL_COUNT) {
 				chatSessionStore.clear(userId);
 				return "정확한 답변이 어려워 상담사에게 연결해드릴게요.";

--- a/src/main/java/com/kt/ai/service/RAGServiceImpl.java
+++ b/src/main/java/com/kt/ai/service/RAGServiceImpl.java
@@ -30,7 +30,6 @@ public class RAGServiceImpl implements RAGService {
 	private final BaseChatClient chatClient;
 
 	public String askFAQ(String question, String conversationId) {
-		VectorStoreEntity vectorStore = vectorStoreRepository.findByTypeOrThrow(VectorType.FAQ);
 
 		var store = vectorStoreRepository.findByType(VectorType.FAQ)
 			.orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_VECTOR_STORE));

--- a/src/main/java/com/kt/ai/service/RAGServiceImpl.java
+++ b/src/main/java/com/kt/ai/service/RAGServiceImpl.java
@@ -1,21 +1,14 @@
 package com.kt.ai.service;
 
-import java.util.stream.Collectors;
+import java.util.UUID;
 
-import org.springframework.ai.chat.client.DefaultChatClient;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.kt.ai.OpenAIClient;
-import com.kt.ai.OpenAIProperties;
-import com.kt.ai.client.BaseChatClient;
+import com.kt.ai.AIChatSessionStore;
+import com.kt.ai.RAGRetriever;
 import com.kt.ai.client.FAQChatClient;
-import com.kt.ai.dto.request.OpenAIRequest;
-import com.kt.constant.VectorType;
-import com.kt.constant.message.ErrorCode;
-import com.kt.domain.entity.VectorStoreEntity;
-import com.kt.exception.CustomException;
-import com.kt.repository.vector.VectorStoreRepository;
+import com.kt.ai.dto.mapper.AIChatMapper;
 
 import lombok.RequiredArgsConstructor;
 
@@ -24,47 +17,30 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class RAGServiceImpl implements RAGService {
 
-	private final OpenAIClient openAIClient;
-	private final OpenAIProperties openAIProperties;
-	private final VectorStoreRepository vectorStoreRepository;
-	private final BaseChatClient chatClient;
+	private static final double THRESHOLD = 0.5;
+	private static final int MAX_FAIL_COUNT = 3;
+	private final FAQChatClient chatClient;
+	private final AIChatSessionStore chatSessionStore;
+	private final RAGRetriever ragRetriever;
 
-	public String askFAQ(String question, String conversationId) {
+	@Override
+	public String askFAQ(UUID userId, String question) {
 
-		var store = vectorStoreRepository.findByType(VectorType.FAQ)
-			.orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_VECTOR_STORE));
+		String conversationId = chatSessionStore.getOrCreate(userId);
+		AIChatMapper.VectorSearchResult rag = ragRetriever.retrieve(question);
+		System.out.println("Conversation Id: " + conversationId);
+		System.out.println("rag.score() = " + rag.score());
 
-		var response = openAIClient.search(
-			store.getStoreId(),
-			"Bearer " + openAIProperties.apiKey(),
-			new OpenAIRequest.Search(question)
-		);
+		if (rag.score() < THRESHOLD) {
+			int failCnt = chatSessionStore.increaseFail(userId);
+			System.out.println("failCnt = " + failCnt);
+			if (failCnt >= MAX_FAIL_COUNT) {
+				chatSessionStore.clear(userId);
+				return "정확한 답변이 어려워 상담사에게 연결해드릴게요.";
+			}
 
-		if (response.data() == null || response.data().isEmpty()) {
-			return "관련 FAQ를 찾지 못했어요. 😥\n"
-				+ "조금 더 구체적으로 질문해주시겠어요?\n"
-				+ "또는 1:1 상담 연결을 도와드릴 수 있어요!";
 		}
 
-		var context = response.data().stream()
-			.flatMap(d -> d.content().stream())
-			.map(c -> c.text())
-			.limit(5)
-			.collect(Collectors.joining("\n----\n"));
-
-		System.out.println(context);
-		return chatClient.prompt(conversationId)
-			.system("""
-				당신은 고객센터 FAQ AI입니다.
-				아래 자료 안에서만 답변하세요.
-				추측 금지, 모르면 "확인 후 안내드릴게요." 라고 답하세요.
-				
-				📌 참고 자료:
-				%s
-				""".formatted(context)
-			)
-			.user(question)
-			.call()
-			.content();
+		return chatClient.ask(question, rag, conversationId);
 	}
 }

--- a/src/main/java/com/kt/constant/redis/RedisKey.java
+++ b/src/main/java/com/kt/constant/redis/RedisKey.java
@@ -8,7 +8,10 @@ import java.time.Duration;
 public enum RedisKey {
 	SIGNUP_CODE("signup:code:", Duration.ofMinutes(3)),
 	SIGNUP_VERIFIED("signup:verified:", Duration.ofMinutes(5)),
-	REFRESH_TOKEN("refresh-token:", Duration.ofHours(24));
+	REFRESH_TOKEN("refresh-token:", Duration.ofHours(24)),
+	AI_CHAT_SESSION("ai-chat-session:%s", Duration.ofHours(24)),
+	AI_CHAT_FAIL("ai-chat-fail:%s", Duration.ofHours(24)),
+	;
 
 	private final String prefix;
 


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- resolves: #이슈번호, #이슈번호 -->
resolves: #243 

## 📝작업 내용

### Redis 사용
- **Redis 기반 FAQ 챗봇 세션/실패 횟수 저장**
  - AI_CHAT_SESSION: 대화 여부 저장 (24시간)
  - AI_CHAT_FAIL: 실패 횟수 저장 (3회 이상 시 상담 안내)
   - RAGService 내에서 일정 score 이하 일시 적절한 응답이 아님으로 판단, 레디스 내 대화Id로 실패 횟수 카운팅합니다.
   - 차후 3회 실패 시 관리자와 채팅 연결로 이어지려고 합니다.

- **사용자 질문**
  - RAGRetriever 검색
  - score 낮음 → Redis fail++ → 3회 ↑ 상담 연결 안내
  - score 높음 → FAQChatClient로 답변 생성

### 코드 책임 분리
- 기존 RAGService 내 혼재하던 로직 분리하였습니다.
  - VectorApi에 search 의존성 추가하여 RAGService의 책임 축소

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

### 스크린샷 (선택)

<img width="1537" height="585" alt="image" src="https://github.com/user-attachments/assets/f0f2a846-5ec0-4d3a-887d-f26dd99fd396" />


## 💬리뷰 요구사항(선택)
- 현재 유사도가 제대로 나오지 않고 있습니다. 제대로 된 질문과 이상한 질문의 유사도가 크게 다르지 않아 탐구 필요합니다.

### TODO
- 채팅 시스템 연동
- 질문 정확도 향상


<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->