### PR TITLE
[FEAT] OpenAIClient 빈 등록 설정 개선

### DIFF
--- a/src/main/java/com/kt/ai/OpenAIClientConfiguration.java
+++ b/src/main/java/com/kt/ai/OpenAIClientConfiguration.java
@@ -1,0 +1,19 @@
+package com.kt.ai;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.support.RestClientAdapter;
+import org.springframework.web.service.invoker.HttpServiceProxyFactory;
+
+@Configuration
+public class OpenAIClientConfiguration {
+
+	@Bean
+	public OpenAIClient openAiClient() {
+		RestClient restClient = RestClient.builder().baseUrl("https://api.openai.com/v1").build();
+		RestClientAdapter adapter = RestClientAdapter.create(restClient);
+		HttpServiceProxyFactory factory = HttpServiceProxyFactory.builderFor(adapter).build();
+		return factory.createClient(OpenAIClient.class);
+	}
+}

--- a/src/main/java/com/kt/common/processor/HttpInterfaceBeanFactoryPostProcessor.java
+++ b/src/main/java/com/kt/common/processor/HttpInterfaceBeanFactoryPostProcessor.java
@@ -13,7 +13,6 @@ import org.springframework.core.env.Environment;
 import org.springframework.core.type.filter.AnnotationTypeFilter;
 import org.springframework.http.converter.StringHttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
-import org.springframework.stereotype.Component;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestClient;
@@ -23,7 +22,7 @@ import org.springframework.web.service.invoker.HttpServiceProxyFactory;
 
 import com.kt.common.interceptor.SimpleApiLoggingInterceptor;
 
-@Component
+//@Component
 public class HttpInterfaceBeanFactoryPostProcessor implements BeanFactoryPostProcessor {
 	private static final String BASE_PACKAGE = "com.kt";
 	private static final String SUFFIX_CLIENT = "Client";


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- resolves: #이슈번호, #이슈번호 -->
resolves:

## 📝작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

벡터스토어 강의 내용 실습하면서 강사님께서 진행하신 OpenAIClient 빈 등록 설정 과정에서 HttpInterfaceBeanFactoryPostProcessor를 만드셨는데, 찾아보니 더 간단히 해결할 수 있는 방법이 있더군요. 실제로 실습해보면서 문제없이 동작했습니다. 해당 클래스로 교체하는 걸로 한번 검토해보면 좋을것 같아요. @l-lyun 

다음 포스팅 자료 참고했습니다.
https://velog.io/@gnivy303/Spring-boot-3.2%EC%97%90%EC%84%9C-RestClient-%EC%99%80-HTTP-Interface-%EB%A5%BC-%ED%99%9C%EC%9A%A9%ED%95%9C-%EC%99%B8%EB%B6%80-API-%ED%98%B8%EC%B6%9C

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->