### PR TITLE
[FEAT] 토큰 재발급 API & Test 추가 및 토큰 저장, 비교 로직 수정

### DIFF
--- a/src/main/java/com/kt/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/kt/config/jwt/JwtTokenProvider.java
@@ -34,14 +34,16 @@ public class JwtTokenProvider {
 	private static final String TOKEN_PREFIX = "Bearer ";
 	private static final String ROLE_CLAIM_KEY = "role";
 	private static final String EMAIL_CLAIM_KEY = "email";
-
+	private static final String JWT_ID_KEY = "jti";
 	public String create(UUID id, String email, AccountRole role, TokenType tokenType) {
 		Date issuedAt = new Date();
 		Duration validTime = tokenType == TokenType.ACCESS ?
 			jwtProperties.getAccessValidTime() : jwtProperties.getRefreshValidTime();
 		Date expireAt = new Date(issuedAt.getTime() + validTime.toMillis());
+		String randomUUID = UUID.randomUUID().toString();
 		return Jwts.builder()
 			.subject(id.toString())
+			.claim(JWT_ID_KEY, randomUUID)
 			.claim(ROLE_CLAIM_KEY, role.name())
 			.claim(EMAIL_CLAIM_KEY, email)
 			.issuedAt(issuedAt)
@@ -75,6 +77,10 @@ public class JwtTokenProvider {
 
 	public String getAccountId(String token) {
 		return getClaims(token).getSubject();
+	}
+
+	public String getJti(String token) {
+		return getClaims(token).get(JWT_ID_KEY, String.class);
 	}
 
 	private DefaultCurrentUser toCurrentUser(String token) {

--- a/src/main/java/com/kt/controller/auth/AuthController.java
+++ b/src/main/java/com/kt/controller/auth/AuthController.java
@@ -3,6 +3,8 @@ package com.kt.controller.auth;
 import com.kt.common.support.SwaggerAssistance;
 import com.kt.domain.dto.request.PasswordManagementRequest;
 
+import com.kt.domain.dto.request.TokenReissueRequest;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
@@ -29,7 +31,7 @@ import static com.kt.common.api.ApiResult.*;
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
-public class AuthController extends SwaggerAssistance {
+public class AuthController implements AuthSwaggerSupporter {
 
 	private final AuthService authService;
 
@@ -132,6 +134,19 @@ public class AuthController extends SwaggerAssistance {
 	) {
 		authService.requestPasswordUpdate(request);
 		return empty();
+	}
+
+	@PostMapping("/token/reissue")
+	public ResponseEntity<ApiResult<TokenResponse>> reissueToken(
+		@RequestBody TokenReissueRequest request
+	) {
+		Pair<String, String> tokens = authService.reissueToken(request);
+		return wrap(
+			new TokenResponse(
+				tokens.getFirst(),
+				tokens.getSecond()
+			)
+		);
 	}
 
 }

--- a/src/main/java/com/kt/controller/auth/AuthSwaggerSupporter.java
+++ b/src/main/java/com/kt/controller/auth/AuthSwaggerSupporter.java
@@ -1,0 +1,75 @@
+package com.kt.controller.auth;
+
+import com.kt.common.api.ApiResult;
+import com.kt.common.support.SwaggerSupporter;
+
+import com.kt.domain.dto.request.LoginRequest;
+import com.kt.domain.dto.request.PasswordManagementRequest;
+import com.kt.domain.dto.request.SignupRequest;
+
+import com.kt.domain.dto.request.TokenReissueRequest;
+import com.kt.domain.dto.response.TokenResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "Auth", description = "인증 관련 API")
+public interface AuthSwaggerSupporter extends SwaggerSupporter {
+
+	@Operation(
+		summary = "이메일 인증 코드 전송",
+		description = "요청된 이메일로 인증 번호 전송 API"
+	)
+	ResponseEntity<ApiResult<Void>> sendAuthCode(SignupRequest.SignupEmail request);
+
+	@Operation(
+		summary = "이메일 인증 코드 검증",
+		description = "이메일로 전송된 인증 코드 검증 API"
+	)
+	ResponseEntity<ApiResult<Void>> verifyAuthCode(SignupRequest.VerifySignupCode request);
+
+	@Operation(
+		summary = "유저 회원 가입",
+		description = "유저 회원 가입 API"
+	)
+	ResponseEntity<ApiResult<Void>> signupUser(SignupRequest.SignupUser request);
+
+	@Operation(
+		summary = "기사 회원 가입",
+		description = "기사 회원 가입 API"
+	)
+	ResponseEntity<ApiResult<Void>> signupCourier(SignupRequest.SignupCourier request);
+
+	@Operation(
+		summary = "계정 로그인",
+		description = "계정 로그인 API"
+	)
+	ResponseEntity<ApiResult<TokenResponse>> login(LoginRequest request);
+
+	@Operation(
+		summary = "비밀번호 초기화",
+		description = "비밀번호 초기화 API"
+	)
+	ResponseEntity<ApiResult<Void>> resetPassword(PasswordManagementRequest.PasswordReset request);
+
+	@Operation(
+		summary = "비밀번호 초기화 요청",
+		description = "비밀번호 초기화 요청 API"
+	)
+	ResponseEntity<ApiResult<Void>> requestPasswordReset(PasswordManagementRequest.PasswordReset request);
+
+	@Operation(
+		summary = "비밀번호 변경 요청",
+		description = "비밀번호 변경 요청 API"
+	)
+	ResponseEntity<ApiResult<Void>> requestPasswordUpdate(PasswordManagementRequest.PasswordUpdate request);
+
+	@Operation(
+		summary = "토큰 재발급 요청",
+		description = "토큰 재발급 요청 API"
+	)
+	ResponseEntity<ApiResult<TokenResponse>> reissueToken(TokenReissueRequest request);
+
+}

--- a/src/test/java/com/kt/api/auth/AuthTokenReissueTest.java
+++ b/src/test/java/com/kt/api/auth/AuthTokenReissueTest.java
@@ -1,0 +1,107 @@
+package com.kt.api.auth;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.kt.common.MockMvcTest;
+
+import com.kt.common.UserEntityCreator;
+import com.kt.config.jwt.JwtTokenProvider;
+import com.kt.constant.TokenType;
+import com.kt.constant.redis.RedisKey;
+import com.kt.domain.dto.request.TokenReissueRequest;
+import com.kt.domain.entity.UserEntity;
+import com.kt.infra.redis.RedisCache;
+import com.kt.repository.user.UserRepository;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@Slf4j
+@ActiveProfiles("test")
+@DisplayName("계정로그인 - POST /api/auth/token/reissue")
+public class AuthTokenReissueTest extends MockMvcTest {
+
+	@Autowired
+	UserRepository userRepository;
+
+	@Autowired
+	PasswordEncoder passwordEncoder;
+
+	@Autowired
+	JwtTokenProvider jwtTokenProvider;
+
+	@Autowired
+	RedisCache redisCache;
+
+	UserEntity testUser;
+	String accessToken;
+	String refreshToken;
+
+	static final String EMAIL = "bjwnstkdbj@naver.com";
+	static final String PASSWORD = "123123!@";
+
+	@BeforeEach
+	void setup() {
+		testUser = UserEntityCreator.create(
+			EMAIL, passwordEncoder.encode(PASSWORD)
+		);
+		userRepository.save(testUser);
+
+		accessToken = jwtTokenProvider.create(
+			testUser.getId(),
+			testUser.getEmail(),
+			testUser.getRole(),
+			TokenType.ACCESS
+		);
+
+		refreshToken = jwtTokenProvider.create(
+			testUser.getId(),
+			testUser.getEmail(),
+			testUser.getRole(),
+			TokenType.REFRESH
+		);
+		String refreshJti = jwtTokenProvider.getJti(refreshToken);
+		redisCache.set(
+			RedisKey.REFRESH_TOKEN,
+			testUser.getId(),
+			refreshJti
+		);
+	}
+
+	@Test
+	void 토큰_재발급_성공() throws Exception {
+		TokenReissueRequest request = new TokenReissueRequest(refreshToken);
+
+		MvcResult result = mockMvc.perform(
+				post("/api/auth/token/reissue")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(request))
+			).andDo(print())
+			.andExpect(status().isOk())
+			.andReturn();
+		String response = result.getResponse().getContentAsString();
+		JsonNode json = objectMapper.readTree(response);
+
+		String reissuedAccessToken = json.get("data").get("accessToken").asText();
+		String reissuedRefreshToken = json.get("data").get("refreshToken").asText();
+		assertNotNull(reissuedAccessToken);
+		assertNotNull(reissuedRefreshToken);
+		assertNotEquals(accessToken, reissuedAccessToken);
+		assertNotEquals(refreshToken, reissuedRefreshToken);
+	}
+
+
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

resolves: #258 

## 📝작업 내용

토큰 재발급 API, Test 추가
토큰 Cache 저장 데이터 변경 및 토큰 비교 로직 수정 (Jwt claim -> jti claims 추가 및 저장 Value 수정)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->