### PR TITLE
[FEAT] 상품-재고 도메인 분리

### DIFF
--- a/src/main/java/com/kt/constant/message/ErrorCode.java
+++ b/src/main/java/com/kt/constant/message/ErrorCode.java
@@ -38,6 +38,7 @@ public enum ErrorCode {
 	REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 리뷰입니다."),
 	PARENT_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "부모 카테고리가 존재하지 않습니다."),
 	ORDER_PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 주문상품이 존재하지 않습니다."),
+	INVENTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 주문상품이 존재하지 않습니다."),
 	CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "카테고리가 존재하지 않습니다."),
 	CHILD_CATEGORY_EXISTS(HttpStatus.BAD_REQUEST, "자식 카테고리가 존재합니다."),
 	STOCK_NOT_ENOUGH(HttpStatus.BAD_REQUEST, "상품 재고가 없습니다."),

--- a/src/main/java/com/kt/domain/dto/response/ProductResponse.java
+++ b/src/main/java/com/kt/domain/dto/response/ProductResponse.java
@@ -3,6 +3,7 @@ package com.kt.domain.dto.response;
 import java.util.UUID;
 
 import com.kt.constant.ProductStatus;
+import com.kt.domain.entity.InventoryEntity;
 import com.kt.domain.entity.ProductEntity;
 import com.querydsl.core.annotations.QueryProjection;
 
@@ -29,14 +30,14 @@ public class ProductResponse {
 		Long stock
 	) {
 
-		public static Detail from(ProductEntity product) {
+		public static Detail from(ProductEntity product, InventoryEntity inventory) {
 			return new Detail(
 				product.getId(),
 				product.getName(),
 				product.getPrice(),
 				product.getStatus(),
 				product.getCategory().getId(),
-				product.getStock()
+				inventory.getStock()
 			);
 		}
 	}

--- a/src/main/java/com/kt/domain/entity/InventoryEntity.java
+++ b/src/main/java/com/kt/domain/entity/InventoryEntity.java
@@ -1,8 +1,11 @@
 package com.kt.domain.entity;
 
 import com.kt.domain.entity.common.BaseEntity;
+import com.kt.util.ValidationUtil;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,6 +16,20 @@ import lombok.NoArgsConstructor;
 public class InventoryEntity extends BaseEntity {
 
 	private Long stock;
+
+	@OneToOne
+	@JoinColumn(name = "product_id", nullable = false)
+	private ProductEntity productEntity;
+
+	protected InventoryEntity(ProductEntity productEntity, Long stock) {
+		this.stock = stock;
+		this.productEntity = productEntity;
+	}
+
+	public static InventoryEntity create(ProductEntity productEntity, Long stock) {
+		ValidationUtil.validatePositive(stock, "재고수량");
+		return new InventoryEntity(productEntity, stock);
+	}
 
 	public void addStock(Long quantity) {
 		this.stock += quantity;

--- a/src/main/java/com/kt/domain/entity/InventoryEntity.java
+++ b/src/main/java/com/kt/domain/entity/InventoryEntity.java
@@ -1,34 +1,32 @@
 package com.kt.domain.entity;
 
+import java.util.UUID;
+
 import com.kt.domain.entity.common.BaseEntity;
 import com.kt.util.ValidationUtil;
 
 import jakarta.persistence.Entity;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@Entity
+@Entity(name = "inventory")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class InventoryEntity extends BaseEntity {
 
 	private Long stock;
 
-	@OneToOne
-	@JoinColumn(name = "product_id", nullable = false)
-	private ProductEntity productEntity;
+	private UUID productId;
 
-	protected InventoryEntity(ProductEntity productEntity, Long stock) {
+	protected InventoryEntity(UUID productId, Long stock) {
 		this.stock = stock;
-		this.productEntity = productEntity;
+		this.productId = productId;
 	}
 
-	public static InventoryEntity create(ProductEntity productEntity, Long stock) {
+	public static InventoryEntity create(UUID productId, Long stock) {
 		ValidationUtil.validatePositive(stock, "재고수량");
-		return new InventoryEntity(productEntity, stock);
+		return new InventoryEntity(productId, stock);
 	}
 
 	public void addStock(Long quantity) {
@@ -37,5 +35,10 @@ public class InventoryEntity extends BaseEntity {
 
 	public void decreaseStock(Long quantity) {
 		this.stock -= quantity;
+	}
+
+	public void updateStock(Long stock) {
+		ValidationUtil.validatePositive(stock, "재고수량");
+		this.stock = stock;
 	}
 }

--- a/src/main/java/com/kt/domain/entity/InventoryEntity.java
+++ b/src/main/java/com/kt/domain/entity/InventoryEntity.java
@@ -1,0 +1,24 @@
+package com.kt.domain.entity;
+
+import com.kt.domain.entity.common.BaseEntity;
+
+import jakarta.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class InventoryEntity extends BaseEntity {
+
+	private Long stock;
+
+	public void addStock(Long quantity) {
+		this.stock += quantity;
+	}
+
+	public void decreaseStock(Long quantity) {
+		this.stock -= quantity;
+	}
+}

--- a/src/main/java/com/kt/domain/entity/InventoryEntity.java
+++ b/src/main/java/com/kt/domain/entity/InventoryEntity.java
@@ -19,7 +19,7 @@ public class InventoryEntity extends BaseEntity {
 
 	private UUID productId;
 
-	protected InventoryEntity(UUID productId, Long stock) {
+	private InventoryEntity(UUID productId, Long stock) {
 		this.stock = stock;
 		this.productId = productId;
 	}

--- a/src/main/java/com/kt/domain/entity/OrderProductEntity.java
+++ b/src/main/java/com/kt/domain/entity/OrderProductEntity.java
@@ -86,7 +86,6 @@ public class OrderProductEntity extends BaseEntity {
 			throw new CustomException(ErrorCode.INVALID_FORCE_STATUS_TRANSITION);
 		}
 		this.status = OrderProductStatus.REFUND_COMPLETED; // TODO: 현재는 환불 승인 순간 환불 즉시 처리되고 바로 환불완료 상태가 된다. (승인==실행) 추후 배송기사 도입시 재설계 필요.
-		this.product.addStock(this.quantity);
 	}
 
 }

--- a/src/main/java/com/kt/domain/entity/ProductEntity.java
+++ b/src/main/java/com/kt/domain/entity/ProductEntity.java
@@ -26,9 +26,6 @@ public class ProductEntity extends BaseEntity {
 	@Column(nullable = false)
 	private Long price;
 
-	// @Column(nullable = false)
-	// private Long stock;
-
 	@Column(nullable = false)
 	@Enumerated(EnumType.STRING)
 	private ProductStatus status;
@@ -97,12 +94,6 @@ public class ProductEntity extends BaseEntity {
 		if (status == ProductStatus.IN_ACTIVATED) {
 			activate();
 		}
-	}
-
-	public void addStock(Long quantity) {
-	}
-
-	public void decreaseStock(Long quantity) {
 	}
 
 	public boolean isSellable() {

--- a/src/main/java/com/kt/domain/entity/ProductEntity.java
+++ b/src/main/java/com/kt/domain/entity/ProductEntity.java
@@ -26,8 +26,8 @@ public class ProductEntity extends BaseEntity {
 	@Column(nullable = false)
 	private Long price;
 
-	@Column(nullable = false)
-	private Long stock;
+	// @Column(nullable = false)
+	// private Long stock;
 
 	@Column(nullable = false)
 	@Enumerated(EnumType.STRING)
@@ -44,14 +44,12 @@ public class ProductEntity extends BaseEntity {
 	protected ProductEntity(
 		String name,
 		Long price,
-		Long stock,
 		ProductStatus status,
 		CategoryEntity category,
 		SellerEntity seller
 	) {
 		this.name = name;
 		this.price = price;
-		this.stock = stock;
 		this.status = status;
 		this.category = category;
 		this.seller = seller;
@@ -60,42 +58,21 @@ public class ProductEntity extends BaseEntity {
 	public static ProductEntity create(
 		final String name,
 		final Long price,
-		final Long stock,
 		final CategoryEntity category,
 		final SellerEntity seller
 	) {
 		return new ProductEntity(
 			name,
 			price,
-			stock,
 			ProductStatus.ACTIVATED,
 			category,
 			seller
 		);
 	}
 
-	public static ProductEntity create(
-		final String name,
-		final Long price,
-		final Long stock,
-		final ProductStatus status,
-		final CategoryEntity category,
-		final SellerEntity seller
-	) {
-		return new ProductEntity(
-			name,
-			price,
-			stock,
-			status,
-			category,
-			seller
-		);
-	}
-
-	public void update(String name, Long price, Long stock, CategoryEntity category) {
+	public void update(String name, Long price, CategoryEntity category) {
 		this.name = name;
 		this.price = price;
-		this.stock = stock;
 		this.category = category;
 	}
 
@@ -123,11 +100,9 @@ public class ProductEntity extends BaseEntity {
 	}
 
 	public void addStock(Long quantity) {
-		this.stock += quantity;
 	}
 
 	public void decreaseStock(Long quantity) {
-		this.stock -= quantity;
 	}
 
 	public boolean isSellable() {

--- a/src/main/java/com/kt/repository/inventory/InventoryRepository.java
+++ b/src/main/java/com/kt/repository/inventory/InventoryRepository.java
@@ -1,10 +1,23 @@
 package com.kt.repository.inventory;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import com.kt.constant.message.ErrorCode;
+import com.kt.domain.entity.InventoryEntity;
+import com.kt.exception.CustomException;
+
 @Repository
-public interface InventoryRepository extends JpaRepository<InventoryRepository, UUID> {
+public interface InventoryRepository extends JpaRepository<InventoryEntity, UUID> {
+
+	Optional<InventoryEntity> findByProductId(UUID productId);
+
+	default InventoryEntity findByProductIdOrThrow(UUID productId) {
+		return findByProductId(productId).orElseThrow(
+			() -> new CustomException(ErrorCode.INVENTORY_NOT_FOUND)
+		);
+	}
 }

--- a/src/main/java/com/kt/repository/inventory/InventoryRepository.java
+++ b/src/main/java/com/kt/repository/inventory/InventoryRepository.java
@@ -1,0 +1,10 @@
+package com.kt.repository.inventory;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface InventoryRepository extends JpaRepository<InventoryRepository, UUID> {
+}

--- a/src/main/java/com/kt/repository/inventory/InventoryRepository.java
+++ b/src/main/java/com/kt/repository/inventory/InventoryRepository.java
@@ -4,14 +4,28 @@ import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import com.kt.constant.message.ErrorCode;
 import com.kt.domain.entity.InventoryEntity;
 import com.kt.exception.CustomException;
 
+import jakarta.persistence.LockModeType;
+
 @Repository
 public interface InventoryRepository extends JpaRepository<InventoryEntity, UUID> {
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("SELECT i FROM inventory i WHERE i.productId = :productId")
+	Optional<InventoryEntity> findByProductIdWithLock(UUID productId);
+
+	default InventoryEntity findByProductIdWithLockOrThrow(UUID productId) {
+		return findByProductIdWithLock(productId).orElseThrow(
+			() -> new CustomException(ErrorCode.INVENTORY_NOT_FOUND)
+		);
+	}
 
 	Optional<InventoryEntity> findByProductId(UUID productId);
 

--- a/src/main/java/com/kt/repository/product/ProductRepository.java
+++ b/src/main/java/com/kt/repository/product/ProductRepository.java
@@ -1,35 +1,19 @@
 package com.kt.repository.product;
 
-import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.kt.constant.message.ErrorCode;
 import com.kt.domain.entity.ProductEntity;
 import com.kt.exception.CustomException;
 
-import jakarta.persistence.LockModeType;
-
 @Repository
 public interface ProductRepository extends JpaRepository<ProductEntity, UUID>, ProductRepositoryCustom {
 
-	@Lock(LockModeType.PESSIMISTIC_WRITE)
-	@Query("SELECT p FROM product p WHERE p.id = :productId")
-	Optional<ProductEntity> findByIdWithLock(@Param("productId") UUID productId);
-
 	default ProductEntity findByIdOrThrow(UUID productId) {
 		return findById(productId).orElseThrow(
-			() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND)
-		);
-	}
-
-	default ProductEntity findByIdWithLockOrThrow(UUID productId) {
-		return findByIdWithLock(productId).orElseThrow(
 			() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND)
 		);
 	}

--- a/src/main/java/com/kt/repository/product/ProductRepositoryImpl.java
+++ b/src/main/java/com/kt/repository/product/ProductRepositoryImpl.java
@@ -7,12 +7,13 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
-import com.kt.constant.ProductStatus;
 import com.kt.constant.AccountRole;
+import com.kt.constant.ProductStatus;
 import com.kt.constant.searchtype.ProductSearchType;
 import com.kt.domain.dto.response.ProductResponse;
 import com.kt.domain.dto.response.QProductResponse_Search;
 import com.kt.domain.entity.QCategoryEntity;
+import com.kt.domain.entity.QInventoryEntity;
 import com.kt.domain.entity.QProductEntity;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -26,6 +27,7 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
 	private final JPAQueryFactory jpaQueryFactory;
 	private final QProductEntity product = QProductEntity.productEntity;
 	private final QCategoryEntity category = QCategoryEntity.categoryEntity;
+	private final QInventoryEntity inventory = QInventoryEntity.inventoryEntity;
 
 	@Override
 	public Page<ProductResponse.Search> search(
@@ -46,10 +48,11 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
 				product.price,
 				product.status,
 				product.category.id,
-				product.stock
+				inventory.stock
 			))
 			.from(product)
 			.join(category).on(category.id.eq(product.category.id))
+			.join(inventory).on(inventory.productId.eq(product.id))
 			.where(booleanBuilder)
 			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize())
@@ -58,6 +61,7 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
 		int total = jpaQueryFactory.select(product.id)
 			.from(product)
 			.join(category).on(category.id.eq(product.category.id))
+			.join(inventory).on(inventory.productId.eq(product.id))
 			.where(booleanBuilder)
 			.fetch().size();
 
@@ -83,10 +87,11 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
 				product.price,
 				product.status,
 				product.category.id,
-				product.stock
+				inventory.stock
 			))
 			.from(product)
 			.join(category).on(category.id.eq(product.category.id))
+			.join(inventory).on(inventory.productId.eq(product.id))
 			.where(booleanBuilder)
 			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize())
@@ -95,6 +100,7 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
 		int total = jpaQueryFactory.select(product.id)
 			.from(product)
 			.join(category).on(category.id.eq(product.category.id))
+			.join(inventory).on(inventory.productId.eq(product.id))
 			.where(booleanBuilder)
 			.fetch().size();
 

--- a/src/main/java/com/kt/service/InventoryService.java
+++ b/src/main/java/com/kt/service/InventoryService.java
@@ -1,0 +1,9 @@
+package com.kt.service;
+
+import java.util.List;
+
+import com.kt.domain.dto.request.OrderRequest;
+
+public interface InventoryService {
+	void reduceStock(List<OrderRequest.Item> items);
+}

--- a/src/main/java/com/kt/service/InventoryServiceImpl.java
+++ b/src/main/java/com/kt/service/InventoryServiceImpl.java
@@ -1,0 +1,34 @@
+package com.kt.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kt.constant.message.ErrorCode;
+import com.kt.domain.dto.request.OrderRequest;
+import com.kt.domain.entity.InventoryEntity;
+import com.kt.exception.CustomException;
+import com.kt.repository.inventory.InventoryRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class InventoryServiceImpl implements InventoryService {
+
+	private final InventoryRepository inventoryRepository;
+
+	@Override
+	public void reduceStock(List<OrderRequest.Item> items) {
+		for (OrderRequest.Item item : items) {
+			InventoryEntity inventory = inventoryRepository.findByProductIdWithLockOrThrow(item.productId());
+
+			if (inventory.getStock() < item.quantity()) {
+				throw new CustomException(ErrorCode.STOCK_NOT_ENOUGH);
+			}
+			inventory.decreaseStock(item.quantity());
+		}
+	}
+}

--- a/src/main/java/com/kt/service/OrderPaymentService.java
+++ b/src/main/java/com/kt/service/OrderPaymentService.java
@@ -13,10 +13,12 @@ import lombok.RequiredArgsConstructor;
 public class OrderPaymentService {
 
 	private final OrderService orderService;
+	private final InventoryService inventoryService;
 	// TODO: PayService 주입
 
 	public void orderPay(UUID userId, OrderRequest request) {
-		orderService.reduceStock(request.items());
+		// TODO: PayService 결제 가능 여부 확인(페이 잔액 검사)
+		inventoryService.reduceStock(request.items());
 		orderService.createOrder(userId, request);
 		// TODO: PayService 결제 메서드 호출
 	}

--- a/src/main/java/com/kt/service/OrderService.java
+++ b/src/main/java/com/kt/service/OrderService.java
@@ -20,8 +20,6 @@ public interface OrderService {
 		OrderRequest request
 	);
 
-	void reduceStock(UUID orderId);
-
 	void reduceStock(List<OrderRequest.Item> items);
 
 	void cancelOrderProduct(UUID userId, UUID orderProductId);

--- a/src/main/java/com/kt/service/OrderServiceImpl.java
+++ b/src/main/java/com/kt/service/OrderServiceImpl.java
@@ -117,7 +117,7 @@ public class OrderServiceImpl implements OrderService {
 
 	public void reduceStock(List<OrderRequest.Item> items) {
 		for (OrderRequest.Item item : items) {
-			InventoryEntity inventory = inventoryRepository.findByProductIdOrThrow(item.productId());
+			InventoryEntity inventory = inventoryRepository.findByProductIdWithLockOrThrow(item.productId());
 
 			if (inventory.getStock() < item.quantity()) {
 				throw new CustomException(ErrorCode.STOCK_NOT_ENOUGH);

--- a/src/main/java/com/kt/service/OrderServiceImpl.java
+++ b/src/main/java/com/kt/service/OrderServiceImpl.java
@@ -16,6 +16,7 @@ import com.kt.constant.message.ErrorCode;
 import com.kt.domain.dto.request.OrderRequest;
 import com.kt.domain.dto.response.OrderResponse;
 import com.kt.domain.entity.AddressEntity;
+import com.kt.domain.entity.InventoryEntity;
 import com.kt.domain.entity.OrderEntity;
 import com.kt.domain.entity.OrderProductEntity;
 import com.kt.domain.entity.PayEntity;
@@ -29,6 +30,7 @@ import com.kt.repository.AddressRepository;
 import com.kt.repository.PayRepository;
 import com.kt.repository.PaymentRepository;
 import com.kt.repository.ShippingDetailRepository;
+import com.kt.repository.inventory.InventoryRepository;
 import com.kt.repository.order.OrderRepository;
 import com.kt.repository.orderproduct.OrderProductRepository;
 import com.kt.repository.product.ProductRepository;
@@ -43,6 +45,7 @@ public class OrderServiceImpl implements OrderService {
 
 	private final UserRepository userRepository;
 	private final ProductRepository productRepository;
+	private final InventoryRepository inventoryRepository;
 	private final OrderRepository orderRepository;
 	private final OrderProductRepository orderProductRepository;
 	private final ShippingDetailRepository shippingDetailRepository;
@@ -60,9 +63,10 @@ public class OrderServiceImpl implements OrderService {
 	// 비관적 락을 사용하여 재고 확인
 	public void checkStock(List<OrderRequest.Item> items) {
 		for (OrderRequest.Item item : items) {
-			ProductEntity product = productRepository.findByIdWithLockOrThrow(item.productId());
+			productRepository.findByIdOrThrow(item.productId());
+			InventoryEntity inventory = inventoryRepository.findByProductIdOrThrow(item.productId());
 
-			if (product.getStock() < item.quantity()) {
+			if (inventory.getStock() < item.quantity()) {
 				throw new CustomException(ErrorCode.STOCK_NOT_ENOUGH);
 			}
 
@@ -111,33 +115,14 @@ public class OrderServiceImpl implements OrderService {
 		return order;
 	}
 
-	// TODO: 삭제
-	@Transactional
-	public void reduceStock(UUID orderId) {
-		List<OrderProductEntity> orderProducts =
-			orderProductRepository.findAllByOrderId(orderId);
-
-		for (OrderProductEntity orderProduct : orderProducts) {
-			ProductEntity product = productRepository.findByIdWithLockOrThrow(orderProduct.getProduct().getId());
-			Long quantity = orderProduct.getQuantity();
-
-			if (product.getStock() < quantity) {
-				throw new CustomException(ErrorCode.STOCK_NOT_ENOUGH);
-			}
-
-			product.decreaseStock(quantity);
-			orderProduct.updateStatus(OrderProductStatus.PENDING_APPROVE);
-		}
-	}
-
 	public void reduceStock(List<OrderRequest.Item> items) {
 		for (OrderRequest.Item item : items) {
-			ProductEntity product = productRepository.findByIdWithLockOrThrow(item.productId());
+			InventoryEntity inventory = inventoryRepository.findByProductIdOrThrow(item.productId());
 
-			if (product.getStock() < item.quantity()) {
+			if (inventory.getStock() < item.quantity()) {
 				throw new CustomException(ErrorCode.STOCK_NOT_ENOUGH);
 			}
-			product.decreaseStock(item.quantity());
+			inventory.decreaseStock(item.quantity());
 		}
 	}
 

--- a/src/main/java/com/kt/service/OrderServiceImpl.java
+++ b/src/main/java/com/kt/service/OrderServiceImpl.java
@@ -145,7 +145,8 @@ public class OrderServiceImpl implements OrderService {
 		}
 
 		ProductEntity product = orderProduct.getProduct();
-		product.addStock(orderProduct.getQuantity());
+		InventoryEntity inventory = inventoryRepository.findByProductIdOrThrow(product.getId());
+		inventory.addStock(orderProduct.getQuantity());
 
 		PaymentEntity payment = paymentRepository.findByOrderProduct(orderProduct)
 			.orElseThrow(() -> new CustomException(ErrorCode.PAYMENT_NOT_FOUND));

--- a/src/main/java/com/kt/service/ProductServiceImpl.java
+++ b/src/main/java/com/kt/service/ProductServiceImpl.java
@@ -1,6 +1,5 @@
 package com.kt.service;
 
-import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.domain.Page;
@@ -8,21 +7,18 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.kt.constant.ProductStatus;
 import com.kt.constant.AccountRole;
+import com.kt.constant.ProductStatus;
 import com.kt.constant.message.ErrorCode;
 import com.kt.constant.searchtype.ProductSearchType;
 import com.kt.domain.dto.response.ProductResponse;
-import com.kt.domain.entity.CategoryEntity;
+import com.kt.domain.entity.InventoryEntity;
 import com.kt.domain.entity.ProductEntity;
-import com.kt.domain.entity.SellerEntity;
 import com.kt.exception.CustomException;
-import com.kt.repository.CategoryRepository;
+import com.kt.repository.inventory.InventoryRepository;
 import com.kt.repository.product.ProductRepository;
 
 import lombok.RequiredArgsConstructor;
-
-import com.kt.repository.seller.SellerRepository;
 
 @Service
 @RequiredArgsConstructor
@@ -30,6 +26,7 @@ import com.kt.repository.seller.SellerRepository;
 public class ProductServiceImpl implements ProductService {
 
 	private final ProductRepository productRepository;
+	private final InventoryRepository inventoryRepository;
 
 	@Override
 	public Page<ProductResponse.Search> search(AccountRole role, String keyword, ProductSearchType type,
@@ -44,8 +41,9 @@ public class ProductServiceImpl implements ProductService {
 		if (role == AccountRole.MEMBER && product.getStatus() != ProductStatus.ACTIVATED) {
 			throw new CustomException(ErrorCode.PRODUCT_NOT_FOUND);
 		}
+		InventoryEntity inventory = inventoryRepository.findByProductIdOrThrow(productId);
 
-		return ProductResponse.Detail.from(product);
+		return ProductResponse.Detail.from(product, inventory);
 	}
 
 }

--- a/src/main/java/com/kt/service/RefundServiceImpl.java
+++ b/src/main/java/com/kt/service/RefundServiceImpl.java
@@ -9,6 +9,7 @@ import com.kt.constant.OrderProductStatus;
 import com.kt.constant.PaymentStatus;
 import com.kt.constant.RefundStatus;
 import com.kt.constant.message.ErrorCode;
+import com.kt.domain.entity.InventoryEntity;
 import com.kt.domain.entity.OrderEntity;
 import com.kt.domain.entity.OrderProductEntity;
 import com.kt.domain.entity.PaymentEntity;
@@ -16,6 +17,7 @@ import com.kt.domain.entity.RefundHistoryEntity;
 import com.kt.domain.entity.UserEntity;
 import com.kt.exception.CustomException;
 import com.kt.repository.PaymentRepository;
+import com.kt.repository.inventory.InventoryRepository;
 import com.kt.repository.orderproduct.OrderProductRepository;
 import com.kt.repository.refund.RefundHistoryRepository;
 import com.kt.repository.user.UserRepository;
@@ -28,6 +30,7 @@ public class RefundServiceImpl implements RefundService {
 
 	private final UserRepository userRepository;
 	private final OrderProductRepository orderProductRepository;
+	private final InventoryRepository inventoryRepository;
 	private final PaymentRepository paymentRepository;
 	private final RefundHistoryRepository refundHistoryRepository;
 

--- a/src/main/java/com/kt/service/RefundServiceImpl.java
+++ b/src/main/java/com/kt/service/RefundServiceImpl.java
@@ -9,7 +9,6 @@ import com.kt.constant.OrderProductStatus;
 import com.kt.constant.PaymentStatus;
 import com.kt.constant.RefundStatus;
 import com.kt.constant.message.ErrorCode;
-import com.kt.domain.entity.InventoryEntity;
 import com.kt.domain.entity.OrderEntity;
 import com.kt.domain.entity.OrderProductEntity;
 import com.kt.domain.entity.PaymentEntity;
@@ -17,7 +16,6 @@ import com.kt.domain.entity.RefundHistoryEntity;
 import com.kt.domain.entity.UserEntity;
 import com.kt.exception.CustomException;
 import com.kt.repository.PaymentRepository;
-import com.kt.repository.inventory.InventoryRepository;
 import com.kt.repository.orderproduct.OrderProductRepository;
 import com.kt.repository.refund.RefundHistoryRepository;
 import com.kt.repository.user.UserRepository;
@@ -30,7 +28,6 @@ public class RefundServiceImpl implements RefundService {
 
 	private final UserRepository userRepository;
 	private final OrderProductRepository orderProductRepository;
-	private final InventoryRepository inventoryRepository;
 	private final PaymentRepository paymentRepository;
 	private final RefundHistoryRepository refundHistoryRepository;
 
@@ -61,9 +58,9 @@ public class RefundServiceImpl implements RefundService {
 		}
 
 		boolean alreadyRequested = refundHistoryRepository.existsByOrderProductAndStatus(
-				orderProduct,
-				RefundStatus.REQUESTED
-			);
+			orderProduct,
+			RefundStatus.REQUESTED
+		);
 
 		if (alreadyRequested) {
 			throw new CustomException(ErrorCode.REFUND_ALREADY_REQUESTED);

--- a/src/main/java/com/kt/service/admin/AdminProductServiceImpl.java
+++ b/src/main/java/com/kt/service/admin/AdminProductServiceImpl.java
@@ -2,24 +2,23 @@ package com.kt.service.admin;
 
 import java.util.UUID;
 
-import com.kt.constant.AccountRole;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.kt.constant.AccountRole;
 import com.kt.constant.ProductStatus;
 import com.kt.constant.message.ErrorCode;
 import com.kt.constant.searchtype.ProductSearchType;
 import com.kt.domain.dto.response.ProductResponse;
+import com.kt.domain.entity.InventoryEntity;
 import com.kt.domain.entity.ProductEntity;
 import com.kt.exception.CustomException;
+import com.kt.repository.inventory.InventoryRepository;
 import com.kt.repository.product.ProductRepository;
 
 import lombok.RequiredArgsConstructor;
-
-import com.kt.repository.seller.SellerRepository;
 
 @Service
 @RequiredArgsConstructor
@@ -27,6 +26,7 @@ import com.kt.repository.seller.SellerRepository;
 public class AdminProductServiceImpl implements AdminProductService {
 
 	private final ProductRepository productRepository;
+	private final InventoryRepository inventoryRepository;
 
 	@Override
 	public void delete(UUID productId) {
@@ -48,6 +48,7 @@ public class AdminProductServiceImpl implements AdminProductService {
 			throw new CustomException(ErrorCode.PRODUCT_NOT_FOUND);
 		}
 
-		return ProductResponse.Detail.from(product);
+		InventoryEntity inventory = inventoryRepository.findByProductIdOrThrow(productId);
+		return ProductResponse.Detail.from(product, inventory);
 	}
 }

--- a/src/main/java/com/kt/service/seller/SellerOrderServiceImpl.java
+++ b/src/main/java/com/kt/service/seller/SellerOrderServiceImpl.java
@@ -9,10 +9,11 @@ import org.springframework.stereotype.Service;
 import com.kt.constant.OrderProductStatus;
 import com.kt.constant.message.ErrorCode;
 import com.kt.domain.dto.response.SellerOrderResponse;
+import com.kt.domain.entity.InventoryEntity;
 import com.kt.domain.entity.OrderProductEntity;
 import com.kt.domain.entity.ProductEntity;
-import com.kt.domain.entity.SellerEntity;
 import com.kt.exception.CustomException;
+import com.kt.repository.inventory.InventoryRepository;
 import com.kt.repository.orderproduct.OrderProductRepository;
 import com.kt.repository.seller.SellerRepository;
 import com.kt.util.Preconditions;
@@ -27,6 +28,7 @@ public class SellerOrderServiceImpl implements SellerOrderService {
 
 	private final SellerRepository sellerRepository;
 	private final OrderProductRepository orderProductRepository;
+	private final InventoryRepository inventoryRepository;
 
 	@Override
 	public void cancelOrderProduct(UUID orderProductId, UUID sellerId) {
@@ -41,7 +43,8 @@ public class SellerOrderServiceImpl implements SellerOrderService {
 		}
 
 		ProductEntity product = orderProduct.getProduct();
-		product.addStock(orderProduct.getQuantity());
+		InventoryEntity inventory = inventoryRepository.findByProductIdOrThrow(product.getId());
+		inventory.addStock(orderProduct.getQuantity());
 		orderProduct.cancel();
 	}
 

--- a/src/main/java/com/kt/service/seller/SellerProductServiceImpl.java
+++ b/src/main/java/com/kt/service/seller/SellerProductServiceImpl.java
@@ -37,7 +37,7 @@ public class SellerProductServiceImpl implements SellerProductService {
 		CategoryEntity category = categoryRepository.findByIdOrThrow(categoryId);
 		SellerEntity seller = sellerRepository.findByIdOrThrow(sellerId);
 
-		ProductEntity product = ProductEntity.create(name, price, stock, category, seller);
+		ProductEntity product = ProductEntity.create(name, price, category, seller);
 		InventoryEntity inventory = InventoryEntity.create(product.getId(), stock);
 		productRepository.save(product);
 		inventoryRepository.save(inventory);
@@ -50,7 +50,7 @@ public class SellerProductServiceImpl implements SellerProductService {
 		inventory.updateStock(stock);
 		Preconditions.validate(product.getSeller().getId() == sellerId, ErrorCode.ORDER_PRODUCT_NOT_OWNER);
 		CategoryEntity category = categoryRepository.findByIdOrThrow(categoryId);
-		product.update(name, price, stock, category);
+		product.update(name, price, category);
 	}
 
 	@Override
@@ -108,7 +108,8 @@ public class SellerProductServiceImpl implements SellerProductService {
 	public ProductResponse.Detail detail(UUID productId, UUID sellerId) {
 		ProductEntity product = productRepository.findByIdOrThrow(productId);
 		Preconditions.validate(product.getSeller().getId() == sellerId, ErrorCode.ORDER_PRODUCT_NOT_OWNER);
-		return ProductResponse.Detail.from(product);
+		InventoryEntity inventory = inventoryRepository.findByProductIdOrThrow(productId);
+		return ProductResponse.Detail.from(product, inventory);
 	}
 
 }

--- a/src/test/java/com/kt/LockTest.java
+++ b/src/test/java/com/kt/LockTest.java
@@ -45,7 +45,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class LockTest {
 
-	private final long productStock1 = 10L;
+	private final long productStock1 = 1000L;
 	private final long productStock2 = 10L;
 	@Autowired
 	private OrderPaymentService orderPaymentService;
@@ -171,5 +171,121 @@ public class LockTest {
 		assertThat(successCount.get()).isEqualTo((int)productStock1);
 		assertThat(failureCount.get()).isEqualTo(repeatCount - (int)productStock1);
 		assertThat(foundInventory.getStock()).isEqualTo(0);
+	}
+
+	@Test
+	void 사용자_100명이_동시에_product1_상품에_대해서_주문_시도하고_다른_사용자가_동시에_상품_조회()
+		throws InterruptedException {
+		int orderCount = 100;  // 주문하는 사용자 수
+		int queryCount = 5000;   // 조회하는 사용자 수
+
+		// 주문하는 사용자 100명 생성
+		List<UserEntity> orderUsers = new ArrayList<>();
+		List<AddressEntity> orderAddresses = new ArrayList<>();
+		for (int i = 0; i < orderCount; i++) {
+			UserEntity user = createUser(i);
+			AddressEntity address = createAddress(user);
+			orderUsers.add(user);
+			orderAddresses.add(address);
+		}
+		accountRepository.saveAll(orderUsers);
+		addressRepository.saveAll(orderAddresses);
+
+		// 조회하는 사용자 10명 생성 (실제로는 조회에 사용자가 필요없지만 명확성을 위해)
+		List<UserEntity> queryUsers = new ArrayList<>();
+		for (int i = 0; i < queryCount; i++) {
+			UserEntity user = createUser(i + orderCount);
+			queryUsers.add(user);
+		}
+		accountRepository.saveAll(queryUsers);
+
+		System.out.println("============== setup ==============");
+		OrderRequest.Item item = new OrderRequest.Item(
+			product1.getId(),
+			1L,
+			UUID.randomUUID()
+		);
+
+		// 주문 100개 + 조회 10개 = 총 110개의 작업을 동시에 실행
+		int totalTasks = orderCount + queryCount;
+		ExecutorService executorService = Executors.newFixedThreadPool(totalTasks);
+		CountDownLatch countDownLatch = new CountDownLatch(totalTasks);
+		AtomicInteger successCount = new AtomicInteger(0);
+		AtomicInteger failureCount = new AtomicInteger(0);
+
+		// 조회 요청 시간 측정을 위한 변수들
+		java.util.concurrent.atomic.AtomicLong totalQueryTime = new java.util.concurrent.atomic.AtomicLong(0);
+		java.util.concurrent.atomic.AtomicLong minQueryTime = new java.util.concurrent.atomic.AtomicLong(Long.MAX_VALUE);
+		java.util.concurrent.atomic.AtomicLong maxQueryTime = new java.util.concurrent.atomic.AtomicLong(0);
+
+		// 주문 요청 100개를 동시에 submit
+		for (int i = 0; i < orderCount; i++) {
+			int finalI = i;
+			executorService.submit(() -> {
+				try {
+					// System.out.println(String.format("===== 사용자 %d 주문 시도 =====", finalI));
+					OrderRequest request = new OrderRequest(
+						List.of(item),
+						orderAddresses.get(finalI).getId()
+					);
+					orderPaymentService.orderPay(orderUsers.get(finalI).getId(), request);
+					successCount.incrementAndGet();
+				} catch (RuntimeException e) {
+					e.printStackTrace();
+					failureCount.incrementAndGet();
+				} finally {
+					countDownLatch.countDown();
+				}
+			});
+		}
+
+		// 상품 조회 요청 10개를 동시에 submit
+		for (int j = 0; j < queryCount; j++) {
+			int finalJ = j;
+			executorService.submit(() -> {
+				try {
+					long startTime = System.currentTimeMillis();
+					System.out.println(String.format("===== 사용자 %d 상품 조회 시도 =====", finalJ + orderCount));
+					productRepository.findByIdOrThrow(product1.getId());
+					long endTime = System.currentTimeMillis();
+					long queryTime = endTime - startTime;
+
+					// 총 시간 누적
+					totalQueryTime.addAndGet(queryTime);
+
+					// 최소 시간 갱신
+					minQueryTime.updateAndGet(current -> Math.min(current, queryTime));
+
+					// 최대 시간 갱신
+					maxQueryTime.updateAndGet(current -> Math.max(current, queryTime));
+
+					System.out.println(String.format("===== 사용자 %d 상품 조회 완료 (소요시간: %dms) =====",
+						finalJ + orderCount, queryTime));
+				} catch (RuntimeException e) {
+					e.printStackTrace();
+				} finally {
+					countDownLatch.countDown();
+				}
+			});
+		}
+
+		countDownLatch.await();
+		executorService.shutdown();
+
+		InventoryEntity foundInventory = inventoryRepository.findByProductIdOrThrow(product1.getId());
+
+		// 조회 요청 시간 통계 출력
+		long avgQueryTime = queryCount > 0 ? totalQueryTime.get() / queryCount : 0;
+		System.out.println("\n============== 조회 요청 시간 통계 ==============");
+		System.out.println(String.format("총 조회 요청 수: %d", queryCount));
+		System.out.println(String.format("총 소요 시간: %dms", totalQueryTime.get()));
+		System.out.println(String.format("평균 소요 시간: %dms", avgQueryTime));
+		System.out.println(String.format("최소 소요 시간: %dms", minQueryTime.get() == Long.MAX_VALUE ? 0 : minQueryTime.get()));
+		System.out.println(String.format("최대 소요 시간: %dms", maxQueryTime.get()));
+		System.out.println("==============================================\n");
+
+		assertThat(successCount.get()).isEqualTo((int)orderCount);
+		assertThat(failureCount.get()).isEqualTo(0);
+		assertThat(foundInventory.getStock()).isEqualTo(productStock1 - orderCount);
 	}
 }

--- a/src/test/java/com/kt/LockTest.java
+++ b/src/test/java/com/kt/LockTest.java
@@ -213,8 +213,7 @@ public class LockTest {
 		System.out.println("============== setup ==============");
 		OrderRequest.Item item = new OrderRequest.Item(
 			product1.getId(),
-			1L,
-			UUID.randomUUID()
+			1L
 		);
 
 		// 주문 100개 + 조회 10개 = 총 110개의 작업을 동시에 실행

--- a/src/test/java/com/kt/api/admin/product/ProductSearchTest.java
+++ b/src/test/java/com/kt/api/admin/product/ProductSearchTest.java
@@ -7,24 +7,27 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
-import com.kt.constant.AccountRole;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import com.kt.common.SellerEntityCreator;
-import com.kt.domain.entity.SellerEntity;
-import com.kt.repository.seller.SellerRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.web.servlet.ResultActions;
 
 import com.kt.common.MockMvcTest;
+import com.kt.common.SellerEntityCreator;
+import com.kt.constant.AccountRole;
 import com.kt.domain.entity.CategoryEntity;
+import com.kt.domain.entity.InventoryEntity;
 import com.kt.domain.entity.ProductEntity;
+import com.kt.domain.entity.SellerEntity;
 import com.kt.repository.CategoryRepository;
+import com.kt.repository.inventory.InventoryRepository;
 import com.kt.repository.product.ProductRepository;
+import com.kt.repository.seller.SellerRepository;
 import com.kt.security.DefaultCurrentUser;
 
 @DisplayName("상품 조회 (어드민) - GET /api/admin/products")
@@ -34,6 +37,8 @@ public class ProductSearchTest extends MockMvcTest {
 
 	@Autowired
 	ProductRepository productRepository;
+	@Autowired
+	InventoryRepository inventoryRepository;
 	@Autowired
 	SellerRepository sellerRepository;
 
@@ -68,6 +73,13 @@ public class ProductSearchTest extends MockMvcTest {
 		}
 
 		productRepository.saveAll(products);
+
+		List<InventoryEntity> inventories = new ArrayList<>();
+		for (ProductEntity product : products) {
+			InventoryEntity inventory = InventoryEntity.create(product.getId(), 1000L);
+			inventories.add(inventory);
+		}
+		inventoryRepository.saveAll(inventories);
 	}
 
 	@Test

--- a/src/test/java/com/kt/api/order/OrderCancelTest.java
+++ b/src/test/java/com/kt/api/order/OrderCancelTest.java
@@ -11,35 +11,35 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.util.List;
 
-import com.kt.common.UserEntityCreator;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import com.kt.common.SellerEntityCreator;
-import com.kt.domain.entity.PaymentEntity;
-import com.kt.domain.entity.SellerEntity;
-import com.kt.repository.PaymentRepository;
-import com.kt.repository.seller.SellerRepository;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.web.servlet.ResultActions;
 
 import com.kt.common.AddressCreator;
 import com.kt.common.MockMvcTest;
+import com.kt.common.SellerEntityCreator;
+import com.kt.common.UserEntityCreator;
 import com.kt.constant.OrderProductStatus;
 import com.kt.domain.dto.request.OrderRequest;
 import com.kt.domain.entity.AddressEntity;
 import com.kt.domain.entity.CategoryEntity;
+import com.kt.domain.entity.InventoryEntity;
 import com.kt.domain.entity.OrderEntity;
 import com.kt.domain.entity.OrderProductEntity;
+import com.kt.domain.entity.PaymentEntity;
 import com.kt.domain.entity.ProductEntity;
+import com.kt.domain.entity.SellerEntity;
 import com.kt.domain.entity.UserEntity;
 import com.kt.repository.AddressRepository;
 import com.kt.repository.CategoryRepository;
+import com.kt.repository.PaymentRepository;
+import com.kt.repository.inventory.InventoryRepository;
 import com.kt.repository.order.OrderRepository;
 import com.kt.repository.orderproduct.OrderProductRepository;
 import com.kt.repository.product.ProductRepository;
+import com.kt.repository.seller.SellerRepository;
 import com.kt.repository.user.UserRepository;
 import com.kt.service.OrderService;
 
@@ -50,6 +50,8 @@ public class OrderCancelTest extends MockMvcTest {
 	CategoryRepository categoryRepository;
 	@Autowired
 	ProductRepository productRepository;
+	@Autowired
+	InventoryRepository inventoryRepository;
 	@Autowired
 	OrderService orderService;
 	@Autowired
@@ -84,6 +86,9 @@ public class OrderCancelTest extends MockMvcTest {
 
 		testProduct = createProduct(category, testSeller);
 		productRepository.save(testProduct);
+
+		InventoryEntity inventory = InventoryEntity.create(testProduct.getId(), 10L);
+		inventoryRepository.save(inventory);
 
 		testAddress = addressRepository.save(AddressCreator.createAddress(testMember));
 
@@ -147,9 +152,9 @@ public class OrderCancelTest extends MockMvcTest {
 		OrderEntity saved = orderRepository.findAll().stream().findFirst().orElseThrow();
 
 		saved.getOrderProducts().get(0)
-		.updateStatus(OrderProductStatus.SHIPPING_READY);
+			.updateStatus(OrderProductStatus.SHIPPING_READY);
 
-		if(saved.getOrderProducts().size() > 1) {
+		if (saved.getOrderProducts().size() > 1) {
 			saved.getOrderProducts().subList(1, saved.getOrderProducts().size())
 				.forEach(orderProduct ->
 					orderProduct.updateStatus(OrderProductStatus.SHIPPING)

--- a/src/test/java/com/kt/api/product/ProductDetailTest.java
+++ b/src/test/java/com/kt/api/product/ProductDetailTest.java
@@ -13,17 +13,17 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
-import com.kt.common.SellerEntityCreator;
-import com.kt.domain.entity.SellerEntity;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.web.servlet.ResultActions;
 
 import com.kt.common.MockMvcTest;
+import com.kt.common.SellerEntityCreator;
 import com.kt.domain.entity.CategoryEntity;
+import com.kt.domain.entity.InventoryEntity;
 import com.kt.domain.entity.ProductEntity;
+import com.kt.domain.entity.SellerEntity;
 import com.kt.repository.CategoryRepository;
+import com.kt.repository.inventory.InventoryRepository;
 import com.kt.repository.product.ProductRepository;
 import com.kt.repository.seller.SellerRepository;
 
@@ -35,6 +35,9 @@ public class ProductDetailTest extends MockMvcTest {
 
 	@Autowired
 	ProductRepository productRepository;
+	@Autowired
+	InventoryRepository inventoryRepository;
+
 	@Autowired
 	SellerRepository sellerRepository;
 
@@ -54,10 +57,14 @@ public class ProductDetailTest extends MockMvcTest {
 
 		activatedProduct = createProduct(testCategory, testSeller);
 		productRepository.save(activatedProduct);
+		InventoryEntity inventory1 = InventoryEntity.create(activatedProduct.getId(), 10L);
+		inventoryRepository.save(inventory1);
 
 		inActivatedProduct = createProduct(testCategory, testSeller);
 		inActivatedProduct.inActivate();
 		productRepository.save(inActivatedProduct);
+		InventoryEntity inventory2 = InventoryEntity.create(inActivatedProduct.getId(), 10L);
+		inventoryRepository.save(inventory2);
 	}
 
 	@Test

--- a/src/test/java/com/kt/api/product/ProductSearchTest.java
+++ b/src/test/java/com/kt/api/product/ProductSearchTest.java
@@ -10,22 +10,23 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
-import com.kt.common.SellerEntityCreator;
-import com.kt.domain.entity.SellerEntity;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.web.servlet.ResultActions;
 
 import com.kt.common.MockMvcTest;
+import com.kt.common.SellerEntityCreator;
 import com.kt.constant.ProductStatus;
 import com.kt.domain.entity.CategoryEntity;
+import com.kt.domain.entity.InventoryEntity;
 import com.kt.domain.entity.ProductEntity;
+import com.kt.domain.entity.SellerEntity;
 import com.kt.repository.CategoryRepository;
+import com.kt.repository.inventory.InventoryRepository;
 import com.kt.repository.product.ProductRepository;
 import com.kt.repository.seller.SellerRepository;
 
@@ -34,7 +35,8 @@ public class ProductSearchTest extends MockMvcTest {
 
 	@Autowired
 	CategoryRepository categoryRepository;
-
+	@Autowired
+	InventoryRepository inventoryRepository;
 	@Autowired
 	ProductRepository productRepository;
 	@Autowired
@@ -66,6 +68,13 @@ public class ProductSearchTest extends MockMvcTest {
 		}
 
 		productRepository.saveAll(products);
+
+		List<InventoryEntity> inventories = new ArrayList<>();
+		for (ProductEntity product : products) {
+			InventoryEntity inventory = InventoryEntity.create(product.getId(), 1000L);
+			inventories.add(inventory);
+		}
+		inventoryRepository.saveAll(inventories);
 	}
 
 	@Test

--- a/src/test/java/com/kt/api/refund/RefundConfirmTest.java
+++ b/src/test/java/com/kt/api/refund/RefundConfirmTest.java
@@ -1,6 +1,5 @@
 package com.kt.api.refund;
 
-
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -11,20 +10,33 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.kt.common.*;
-import com.kt.constant.*;
-import com.kt.domain.entity.*;
-import com.kt.repository.*;
+import com.kt.common.CategoryEntityCreator;
+import com.kt.common.MockMvcTest;
+import com.kt.common.OrderEntityCreator;
+import com.kt.common.ProductEntityCreator;
+import com.kt.common.SellerEntityCreator;
+import com.kt.common.UserEntityCreator;
+import com.kt.constant.AccountRole;
+import com.kt.constant.OrderProductStatus;
+import com.kt.domain.entity.CategoryEntity;
+import com.kt.domain.entity.InventoryEntity;
+import com.kt.domain.entity.OrderEntity;
+import com.kt.domain.entity.OrderProductEntity;
+import com.kt.domain.entity.PaymentEntity;
+import com.kt.domain.entity.ProductEntity;
+import com.kt.domain.entity.SellerEntity;
+import com.kt.domain.entity.UserEntity;
+import com.kt.repository.CategoryRepository;
+import com.kt.repository.PaymentRepository;
+import com.kt.repository.inventory.InventoryRepository;
 import com.kt.repository.order.OrderRepository;
 import com.kt.repository.orderproduct.OrderProductRepository;
 import com.kt.repository.product.ProductRepository;
@@ -49,6 +61,8 @@ public class RefundConfirmTest extends MockMvcTest {
 	@Autowired
 	ProductRepository productRepository;
 	@Autowired
+	InventoryRepository inventoryRepository;
+	@Autowired
 	OrderRepository orderRepository;
 	@Autowired
 	OrderProductRepository orderProductRepository;
@@ -71,6 +85,9 @@ public class RefundConfirmTest extends MockMvcTest {
 		ProductEntity product = productRepository.save(
 			ProductEntityCreator.createProduct(category, seller)
 		);
+
+		InventoryEntity inventory = InventoryEntity.create(product.getId(), 10L);
+		inventoryRepository.save(inventory);
 
 		OrderEntity order = orderRepository.save(
 			OrderEntityCreator.createOrderEntity(member)

--- a/src/test/java/com/kt/api/seller/order/OrderCancelTest.java
+++ b/src/test/java/com/kt/api/seller/order/OrderCancelTest.java
@@ -1,24 +1,12 @@
 package com.kt.api.seller.order;
 
-import com.kt.common.CurrentUserCreator;
-import com.kt.common.MockMvcTest;
-import com.kt.common.SellerEntityCreator;
-import com.kt.common.UserEntityCreator;
-import com.kt.constant.OrderProductStatus;
-import com.kt.domain.entity.CategoryEntity;
-import com.kt.domain.entity.OrderEntity;
-import com.kt.domain.entity.OrderProductEntity;
-import com.kt.domain.entity.ProductEntity;
-import com.kt.domain.entity.ReceiverVO;
-import com.kt.domain.entity.SellerEntity;
-import com.kt.domain.entity.UserEntity;
-import com.kt.repository.CategoryRepository;
-import com.kt.repository.order.OrderRepository;
-import com.kt.repository.orderproduct.OrderProductRepository;
-import com.kt.repository.product.ProductRepository;
-import com.kt.repository.seller.SellerRepository;
-import com.kt.repository.user.UserRepository;
-import com.kt.security.DefaultCurrentUser;
+import static com.kt.common.CategoryEntityCreator.*;
+import static com.kt.common.ProductEntityCreator.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -26,15 +14,27 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.web.servlet.ResultActions;
 
-import static com.kt.common.CategoryEntityCreator.createCategory;
-import static com.kt.common.ProductEntityCreator.createProduct;
-import static com.kt.common.SellerEntityCreator.createSeller;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import com.kt.common.CurrentUserCreator;
+import com.kt.common.MockMvcTest;
+import com.kt.common.SellerEntityCreator;
+import com.kt.common.UserEntityCreator;
+import com.kt.constant.OrderProductStatus;
+import com.kt.domain.entity.CategoryEntity;
+import com.kt.domain.entity.InventoryEntity;
+import com.kt.domain.entity.OrderEntity;
+import com.kt.domain.entity.OrderProductEntity;
+import com.kt.domain.entity.ProductEntity;
+import com.kt.domain.entity.ReceiverVO;
+import com.kt.domain.entity.SellerEntity;
+import com.kt.domain.entity.UserEntity;
+import com.kt.repository.CategoryRepository;
+import com.kt.repository.inventory.InventoryRepository;
+import com.kt.repository.order.OrderRepository;
+import com.kt.repository.orderproduct.OrderProductRepository;
+import com.kt.repository.product.ProductRepository;
+import com.kt.repository.seller.SellerRepository;
+import com.kt.repository.user.UserRepository;
+import com.kt.security.DefaultCurrentUser;
 
 @DisplayName("판매자 주문 상품 취소 - PATCH /api/seller/orders/{orderProductId}/cancel")
 public class OrderCancelTest extends MockMvcTest {
@@ -43,6 +43,8 @@ public class OrderCancelTest extends MockMvcTest {
 	private OrderProductRepository orderProductRepository;
 	@Autowired
 	private ProductRepository productRepository;
+	@Autowired
+	private InventoryRepository inventoryRepository;
 	@Autowired
 	private CategoryRepository categoryRepository;
 	@Autowired
@@ -77,6 +79,8 @@ public class OrderCancelTest extends MockMvcTest {
 
 		ProductEntity product = createProduct(testCategory, testSeller);
 		productRepository.save(product);
+		InventoryEntity inventory = InventoryEntity.create(product.getId(), 10L);
+		inventoryRepository.save(inventory);
 		testOrderProduct = orderProductRepository.save(
 			OrderProductEntity.create(1L, product.getPrice(), OrderProductStatus.CREATED, testOrder, product));
 	}

--- a/src/test/java/com/kt/api/seller/product/ProductDetailTest.java
+++ b/src/test/java/com/kt/api/seller/product/ProductDetailTest.java
@@ -1,18 +1,14 @@
 package com.kt.api.seller.product;
 
-import com.kt.common.CurrentUserCreator;
-import com.kt.common.MockMvcTest;
-import com.kt.common.SellerEntityCreator;
-import com.kt.common.UserEntityCreator;
-import com.kt.domain.entity.CategoryEntity;
-import com.kt.domain.entity.ProductEntity;
-import com.kt.domain.entity.SellerEntity;
-import com.kt.domain.entity.UserEntity;
-import com.kt.repository.CategoryRepository;
-import com.kt.repository.product.ProductRepository;
-import com.kt.repository.seller.SellerRepository;
-import com.kt.repository.user.UserRepository;
-import com.kt.security.DefaultCurrentUser;
+import static com.kt.common.CategoryEntityCreator.*;
+import static com.kt.common.ProductEntityCreator.*;
+import static com.kt.common.SellerEntityCreator.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.UUID;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -20,22 +16,29 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.web.servlet.ResultActions;
 
-import java.util.UUID;
-
-import static com.kt.common.CategoryEntityCreator.createCategory;
-import static com.kt.common.ProductEntityCreator.createProduct;
-import static com.kt.common.SellerEntityCreator.createSeller;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import com.kt.common.CurrentUserCreator;
+import com.kt.common.MockMvcTest;
+import com.kt.common.SellerEntityCreator;
+import com.kt.common.UserEntityCreator;
+import com.kt.domain.entity.CategoryEntity;
+import com.kt.domain.entity.InventoryEntity;
+import com.kt.domain.entity.ProductEntity;
+import com.kt.domain.entity.SellerEntity;
+import com.kt.domain.entity.UserEntity;
+import com.kt.repository.CategoryRepository;
+import com.kt.repository.inventory.InventoryRepository;
+import com.kt.repository.product.ProductRepository;
+import com.kt.repository.seller.SellerRepository;
+import com.kt.repository.user.UserRepository;
+import com.kt.security.DefaultCurrentUser;
 
 @DisplayName("판매자 상품 상세 조회 - GET /api/seller/products/{productId}")
 public class ProductDetailTest extends MockMvcTest {
 
 	@Autowired
 	private ProductRepository productRepository;
+	@Autowired
+	private InventoryRepository inventoryRepository;
 	@Autowired
 	private CategoryRepository categoryRepository;
 	@Autowired
@@ -67,6 +70,8 @@ public class ProductDetailTest extends MockMvcTest {
 		// given
 		ProductEntity product = createProduct(testCategory, testSeller);
 		productRepository.save(product);
+		InventoryEntity inventory = InventoryEntity.create(product.getId(), 10L);
+		inventoryRepository.save(inventory);
 
 		// when
 		ResultActions actions = mockMvc.perform(get("/api/seller/products/{productId}", product.getId())

--- a/src/test/java/com/kt/api/seller/product/ProductSearchTest.java
+++ b/src/test/java/com/kt/api/seller/product/ProductSearchTest.java
@@ -1,18 +1,14 @@
 package com.kt.api.seller.product;
 
-import com.kt.common.CurrentUserCreator;
-import com.kt.common.MockMvcTest;
-import com.kt.common.SellerEntityCreator;
-import com.kt.common.UserEntityCreator;
-import com.kt.domain.entity.CategoryEntity;
-import com.kt.domain.entity.ProductEntity;
-import com.kt.domain.entity.SellerEntity;
-import com.kt.domain.entity.UserEntity;
-import com.kt.repository.CategoryRepository;
-import com.kt.repository.product.ProductRepository;
-import com.kt.repository.seller.SellerRepository;
-import com.kt.repository.user.UserRepository;
-import com.kt.security.DefaultCurrentUser;
+import static com.kt.common.CategoryEntityCreator.*;
+import static com.kt.common.ProductEntityCreator.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -20,22 +16,29 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.web.servlet.ResultActions;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import static com.kt.common.CategoryEntityCreator.createCategory;
-import static com.kt.common.ProductEntityCreator.createProduct;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import com.kt.common.CurrentUserCreator;
+import com.kt.common.MockMvcTest;
+import com.kt.common.SellerEntityCreator;
+import com.kt.common.UserEntityCreator;
+import com.kt.domain.entity.CategoryEntity;
+import com.kt.domain.entity.InventoryEntity;
+import com.kt.domain.entity.ProductEntity;
+import com.kt.domain.entity.SellerEntity;
+import com.kt.domain.entity.UserEntity;
+import com.kt.repository.CategoryRepository;
+import com.kt.repository.inventory.InventoryRepository;
+import com.kt.repository.product.ProductRepository;
+import com.kt.repository.seller.SellerRepository;
+import com.kt.repository.user.UserRepository;
+import com.kt.security.DefaultCurrentUser;
 
 @DisplayName("판매자 상품 목록 조회 - GET /api/seller/products")
 public class ProductSearchTest extends MockMvcTest {
 
 	@Autowired
 	private ProductRepository productRepository;
+	@Autowired
+	private InventoryRepository inventoryRepository;
 	@Autowired
 	private CategoryRepository categoryRepository;
 	@Autowired
@@ -73,6 +76,12 @@ public class ProductSearchTest extends MockMvcTest {
 			products.add(inactiveProduct);
 		}
 		productRepository.saveAll(products);
+		List<InventoryEntity> inventories = new ArrayList<>();
+		for (ProductEntity product : products) {
+			InventoryEntity inventory = InventoryEntity.create(product.getId(), 1000L);
+			inventories.add(inventory);
+		}
+		inventoryRepository.saveAll(inventories);
 	}
 
 	@Test

--- a/src/test/java/com/kt/common/ProductCreator.java
+++ b/src/test/java/com/kt/common/ProductCreator.java
@@ -2,15 +2,13 @@ package com.kt.common;
 
 import com.kt.domain.entity.CategoryEntity;
 import com.kt.domain.entity.ProductEntity;
-
 import com.kt.domain.entity.SellerEntity;
 
 public class ProductCreator {
-	public static ProductEntity createProduct(CategoryEntity category, SellerEntity seller){
+	public static ProductEntity createProduct(CategoryEntity category, SellerEntity seller) {
 		return ProductEntity.create(
 			"테스트상품명",
 			1000L,
-			5L,
 			category,
 			seller
 		);

--- a/src/test/java/com/kt/common/ProductEntityCreator.java
+++ b/src/test/java/com/kt/common/ProductEntityCreator.java
@@ -4,7 +4,6 @@ import java.util.UUID;
 
 import com.kt.domain.entity.CategoryEntity;
 import com.kt.domain.entity.ProductEntity;
-
 import com.kt.domain.entity.SellerEntity;
 
 public class ProductEntityCreator {
@@ -12,7 +11,6 @@ public class ProductEntityCreator {
 	public static ProductEntity createProduct(CategoryEntity category, SellerEntity seller) {
 		return ProductEntity.create(
 			"상품" + UUID.randomUUID(),
-			1000L,
 			1000L,
 			category,
 			seller

--- a/src/test/java/com/kt/domain/entity/CartEntityTest.java
+++ b/src/test/java/com/kt/domain/entity/CartEntityTest.java
@@ -1,16 +1,14 @@
 package com.kt.domain.entity;
 
-
 import java.time.LocalDate;
-
-import com.kt.common.SellerEntityCreator;
-import com.kt.constant.AccountRole;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ActiveProfiles;
 
+import com.kt.common.SellerEntityCreator;
+import com.kt.constant.AccountRole;
 import com.kt.constant.Gender;
 
 @ActiveProfiles("test")
@@ -37,7 +35,6 @@ class CartEntityTest {
 		testProduct = ProductEntity.create(
 			"테스트상품명",
 			1000L,
-			5L,
 			testCategory,
 			testSeller
 		);

--- a/src/test/java/com/kt/domain/entity/InventoryEntityTest.java
+++ b/src/test/java/com/kt/domain/entity/InventoryEntityTest.java
@@ -1,0 +1,56 @@
+package com.kt.domain.entity;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.kt.common.SellerEntityCreator;
+import com.kt.exception.FieldValidationException;
+
+@ActiveProfiles("test")
+class InventoryEntityTest {
+
+	private ProductEntity testProduct;
+
+	@BeforeEach
+	void setup() {
+		CategoryEntity category = CategoryEntity.create(
+			"테스트카테고리",
+			null
+		);
+
+		SellerEntity seller = SellerEntityCreator.createSeller();
+
+		testProduct = ProductEntity.create(
+			"테스트상품",
+			15_000L,
+			10L,
+			category,
+			seller
+		);
+	}
+
+	@Test
+	void 객체생성_성공() {
+		InventoryEntity inventory = InventoryEntity.create(
+			testProduct,
+			1L
+		);
+
+	}
+
+	@Test
+	void 객체생성_실패__재고값_음수() {
+		assertThrowsExactly(
+			FieldValidationException.class,
+			() -> {
+				InventoryEntity.create(
+					testProduct,
+					-1L
+				);
+			}
+		);
+	}
+}

--- a/src/test/java/com/kt/domain/entity/InventoryEntityTest.java
+++ b/src/test/java/com/kt/domain/entity/InventoryEntityTest.java
@@ -26,7 +26,6 @@ class InventoryEntityTest {
 		testProduct = ProductEntity.create(
 			"테스트상품",
 			15_000L,
-			10L,
 			category,
 			seller
 		);

--- a/src/test/java/com/kt/domain/entity/InventoryEntityTest.java
+++ b/src/test/java/com/kt/domain/entity/InventoryEntityTest.java
@@ -35,7 +35,7 @@ class InventoryEntityTest {
 	@Test
 	void 객체생성_성공() {
 		InventoryEntity inventory = InventoryEntity.create(
-			testProduct,
+			testProduct.getId(),
 			1L
 		);
 
@@ -47,7 +47,7 @@ class InventoryEntityTest {
 			FieldValidationException.class,
 			() -> {
 				InventoryEntity.create(
-					testProduct,
+					testProduct.getId(),
 					-1L
 				);
 			}

--- a/src/test/java/com/kt/domain/entity/OrderProductEntityTest.java
+++ b/src/test/java/com/kt/domain/entity/OrderProductEntityTest.java
@@ -50,7 +50,6 @@ class OrderProductEntityTest {
 		ProductEntity product = ProductEntity.create(
 			"테스트상품",
 			15_000L,
-			10L,
 			category,
 			seller
 		);

--- a/src/test/java/com/kt/domain/entity/PaymentEntityTest.java
+++ b/src/test/java/com/kt/domain/entity/PaymentEntityTest.java
@@ -4,12 +4,12 @@ import static org.assertj.core.api.Assertions.*;
 
 import java.time.LocalDate;
 
-import com.kt.common.SellerEntityCreator;
-import com.kt.constant.AccountRole;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ActiveProfiles;
 
+import com.kt.common.SellerEntityCreator;
+import com.kt.constant.AccountRole;
 import com.kt.constant.Gender;
 import com.kt.constant.OrderProductStatus;
 
@@ -54,7 +54,6 @@ class PaymentEntityTest {
 		ProductEntity product = ProductEntity.create(
 			"테스트상품명",
 			1000L,
-			5L,
 			testCategory,
 			testSeller
 		);

--- a/src/test/java/com/kt/domain/entity/ProductEntityTest.java
+++ b/src/test/java/com/kt/domain/entity/ProductEntityTest.java
@@ -2,18 +2,16 @@ package com.kt.domain.entity;
 
 import static org.assertj.core.api.Assertions.*;
 
-import com.kt.common.SellerEntityCreator;
-import com.kt.constant.Gender;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ActiveProfiles;
 
-import com.kt.constant.ProductStatus;
+import com.kt.common.SellerEntityCreator;
 
 @ActiveProfiles("test")
 class ProductEntityTest {
 
 	@Test
-	void 객체생성_성공(){
+	void 객체생성_성공() {
 		CategoryEntity testCategory = CategoryEntity.create(
 			"테스트카테고리",
 			null
@@ -24,7 +22,6 @@ class ProductEntityTest {
 		ProductEntity comparisonProduct = ProductEntity.create(
 			"테스트상품명",
 			1000L,
-			5L,
 			testCategory,
 			testSeller
 		);
@@ -32,7 +29,6 @@ class ProductEntityTest {
 		ProductEntity subjectProduct = ProductEntity.create(
 			"테스트상품명",
 			1000L,
-			5L,
 			testCategory,
 			testSeller
 		);

--- a/src/test/java/com/kt/domain/entity/ProductInventoryLazyLoadingTest.java
+++ b/src/test/java/com/kt/domain/entity/ProductInventoryLazyLoadingTest.java
@@ -1,0 +1,117 @@
+package com.kt.domain.entity;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kt.constant.Gender;
+import com.kt.repository.product.ProductRepository;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class ProductInventoryLazyLoadingTest {
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Autowired
+	private ProductRepository productRepository;
+
+	@Autowired
+	private PasswordEncoder passwordEncoder;
+
+	private ProductEntity product;
+	private CategoryEntity category;
+	private SellerEntity seller;
+
+	@BeforeEach
+	void setUp() {
+		// Category 생성
+		category = CategoryEntity.create("테스트 카테고리", null);
+		entityManager.persist(category);
+
+		// Seller 생성
+		seller = SellerEntity.create(
+			"테스트 판매자",
+			"test@seller.com",
+			passwordEncoder.encode("password"),
+			"테스트 상점",
+			"010-1234-5678",
+			Gender.MALE);
+		entityManager.persist(seller);
+
+		// Product 생성
+		product = ProductEntity.create(
+			"테스트 상품",
+			10000L,
+			100L,
+			category,
+			seller
+		);
+		entityManager.persist(product);
+
+		// Inventory 생성
+		InventoryEntity inventory = InventoryEntity.create(product.getId(), 100L);
+		entityManager.persist(inventory);
+
+		entityManager.flush();
+		entityManager.clear();
+	}
+
+	@Test
+	@DisplayName("ProductEntity 조회 시 InventoryEntity LAZY 로딩 테스트")
+	void testLazyLoading() {
+		System.out.println("========== ProductEntity 조회 시작 ==========");
+
+		// ProductEntity만 조회
+		ProductEntity foundProduct = productRepository.findByIdOrThrow(product.getId());
+
+		System.out.println("========== ProductEntity 조회 완료 ==========");
+		System.out.println("Product Name: " + foundProduct.getName());
+
+		assertThat(foundProduct).isNotNull();
+		assertThat(foundProduct.getName()).isEqualTo("테스트 상품");
+
+		System.out.println("========== InventoryEntity 접근 시작 ==========");
+
+		// Inventory에 접근할 때 쿼리가 발생하는지 확인
+		// InventoryEntity inventory = foundProduct.getInventory();
+		// System.out.println("Inventory Stock: " + inventory.getStock());
+
+		System.out.println("========== InventoryEntity 접근 완료 ==========");
+
+		// assertThat(inventory).isNotNull();
+		// assertThat(inventory.getStock()).isEqualTo(100L);
+	}
+
+	@Test
+	@DisplayName("ProductEntity 조회 후 Inventory 미접근 시 쿼리 발생 확인")
+	void testNoInventoryAccess() {
+		System.out.println("========== ProductEntity 조회 시작 (Inventory 미접근) ==========");
+
+		// ProductEntity만 조회
+		ProductEntity foundProduct = productRepository.findByIdOrThrow(product.getId());
+
+		System.out.println("========== ProductEntity 조회 완료 ==========");
+		System.out.println("Product Name: " + foundProduct.getName());
+
+		assertThat(foundProduct).isNotNull();
+		assertThat(foundProduct.getName()).isEqualTo("테스트 상품");
+
+		// Inventory에 접근하지 않고 테스트 종료
+		System.out.println("========== 테스트 종료 (Inventory 미접근) ==========");
+	}
+}
+
+

--- a/src/test/java/com/kt/domain/entity/ProductInventoryLazyLoadingTest.java
+++ b/src/test/java/com/kt/domain/entity/ProductInventoryLazyLoadingTest.java
@@ -55,7 +55,6 @@ class ProductInventoryLazyLoadingTest {
 		product = ProductEntity.create(
 			"테스트 상품",
 			10000L,
-			100L,
 			category,
 			seller
 		);

--- a/src/test/java/com/kt/domain/entity/RefundHistoryEntityTest.java
+++ b/src/test/java/com/kt/domain/entity/RefundHistoryEntityTest.java
@@ -13,7 +13,6 @@ import com.kt.constant.Gender;
 import com.kt.constant.OrderProductStatus;
 import com.kt.constant.RefundStatus;
 
-
 @ActiveProfiles("test")
 class RefundHistoryEntityTest {
 	@Test
@@ -53,7 +52,6 @@ class RefundHistoryEntityTest {
 		ProductEntity product = ProductEntity.create(
 			"테스트상품",
 			15_000L,
-			10L,
 			category,
 			seller
 		);

--- a/src/test/java/com/kt/domain/entity/ShippingDetailEntityTest.java
+++ b/src/test/java/com/kt/domain/entity/ShippingDetailEntityTest.java
@@ -2,16 +2,15 @@ package com.kt.domain.entity;
 
 import java.time.LocalDate;
 
-import com.kt.common.SellerEntityCreator;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ActiveProfiles;
 
+import com.kt.common.SellerEntityCreator;
+import com.kt.constant.AccountRole;
 import com.kt.constant.Gender;
 import com.kt.constant.OrderProductStatus;
-import com.kt.constant.AccountRole;
 
 @ActiveProfiles("test")
 class ShippingDetailEntityTest {
@@ -55,7 +54,6 @@ class ShippingDetailEntityTest {
 		ProductEntity product = ProductEntity.create(
 			"테스트상품명",
 			1000L,
-			5L,
 			tempCategory,
 			testSeller
 		);

--- a/src/test/java/com/kt/service/OrderServiceTest.java
+++ b/src/test/java/com/kt/service/OrderServiceTest.java
@@ -56,6 +56,8 @@ class OrderServiceTest {
 	@Autowired
 	OrderService orderService;
 	@Autowired
+	InventoryService inventoryService;
+	@Autowired
 	UserRepository userRepository;
 	@Autowired
 	ProductRepository productRepository;
@@ -165,7 +167,7 @@ class OrderServiceTest {
 					testUser.getId(),
 					orderRequest
 				);
-				orderService.reduceStock(orderRequest.items());
+				inventoryService.reduceStock(orderRequest.items());
 			}
 		)
 			.isInstanceOf(CustomException.class)
@@ -194,7 +196,7 @@ class OrderServiceTest {
 					testUser.getId(),
 					orderRequest
 				);
-				orderService.reduceStock(orderRequest.items());
+				inventoryService.reduceStock(orderRequest.items());
 			}
 		)
 			.isInstanceOf(CustomException.class)

--- a/src/test/java/com/kt/service/ProductServiceTest.java
+++ b/src/test/java/com/kt/service/ProductServiceTest.java
@@ -68,7 +68,6 @@ class ProductServiceTest {
 			ProductEntity product = ProductEntity.create(
 				"상품" + i,
 				1000L,
-				10L,
 				category,
 				testSeller
 			);
@@ -106,7 +105,6 @@ class ProductServiceTest {
 			ProductEntity product = ProductEntity.create(
 				"상품" + i,
 				1000L,
-				10L,
 				categoryDog,
 				testSeller
 			);
@@ -117,7 +115,6 @@ class ProductServiceTest {
 			ProductEntity product = ProductEntity.create(
 				"상품" + i,
 				1000L,
-				10L,
 				categorySports,
 				testSeller
 			);
@@ -157,7 +154,6 @@ class ProductServiceTest {
 			ProductEntity product = ProductEntity.create(
 				"상품" + i,
 				1000L,
-				10L,
 				categorySports,
 				testSeller
 			);
@@ -192,8 +188,10 @@ class ProductServiceTest {
 		// given
 		CategoryEntity categorySports = CategoryEntity.create("운동", null);
 		categoryRepository.save(categorySports);
-		ProductEntity product = ProductEntity.create("상품", 1000L, 10L, categorySports, testSeller);
+		ProductEntity product = ProductEntity.create("상품", 1000L, categorySports, testSeller);
 		productRepository.save(product);
+		InventoryEntity inventory = InventoryEntity.create(product.getId(), 10L);
+		inventoryRepository.save(inventory);
 
 		// when
 		ProductResponse.Detail detail = productService.detail(AccountRole.ADMIN, product.getId());

--- a/src/test/java/com/kt/service/ProductServiceTest.java
+++ b/src/test/java/com/kt/service/ProductServiceTest.java
@@ -5,14 +5,7 @@ import static org.assertj.core.api.Assertions.*;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.kt.common.SellerEntityCreator;
-import com.kt.domain.entity.SellerEntity;
-import com.kt.repository.account.AccountRepository;
-
 import org.junit.jupiter.api.BeforeEach;
-
-import com.kt.constant.AccountRole;
-
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -21,13 +14,17 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.kt.constant.ProductStatus;
+import com.kt.common.SellerEntityCreator;
+import com.kt.constant.AccountRole;
 import com.kt.constant.searchtype.ProductSearchType;
-import com.kt.domain.dto.request.ProductRequest;
 import com.kt.domain.dto.response.ProductResponse;
 import com.kt.domain.entity.CategoryEntity;
+import com.kt.domain.entity.InventoryEntity;
 import com.kt.domain.entity.ProductEntity;
+import com.kt.domain.entity.SellerEntity;
 import com.kt.repository.CategoryRepository;
+import com.kt.repository.account.AccountRepository;
+import com.kt.repository.inventory.InventoryRepository;
 import com.kt.repository.product.ProductRepository;
 import com.kt.repository.seller.SellerRepository;
 
@@ -38,15 +35,18 @@ class ProductServiceTest {
 
 	private final ProductService productService;
 	private final ProductRepository productRepository;
+	private final InventoryRepository inventoryRepository;
 	private final CategoryRepository categoryRepository;
 	private final SellerRepository sellerRepository;
 	private SellerEntity testSeller;
 
 	@Autowired
 	ProductServiceTest(ProductService productService, ProductRepository productRepository,
+		InventoryRepository inventoryRepository,
 		CategoryRepository categoryRepository, AccountRepository accountRepository, SellerRepository sellerRepository) {
 		this.productService = productService;
 		this.productRepository = productRepository;
+		this.inventoryRepository = inventoryRepository;
 		this.categoryRepository = categoryRepository;
 		this.sellerRepository = sellerRepository;
 	}
@@ -75,6 +75,13 @@ class ProductServiceTest {
 			products.add(product);
 		}
 		productRepository.saveAll(products);
+
+		List<InventoryEntity> inventories = new ArrayList<>();
+		for (ProductEntity product : products) {
+			InventoryEntity inventory = InventoryEntity.create(product.getId(), 10L);
+			inventories.add(inventory);
+		}
+		inventoryRepository.saveAll(inventories);
 
 		// when
 		PageRequest pageRequest = PageRequest.of(1, 10);
@@ -118,6 +125,13 @@ class ProductServiceTest {
 		}
 		productRepository.saveAll(products);
 
+		List<InventoryEntity> inventories = new ArrayList<>();
+		for (ProductEntity product : products) {
+			InventoryEntity inventory = InventoryEntity.create(product.getId(), 10L);
+			inventories.add(inventory);
+		}
+		inventoryRepository.saveAll(inventories);
+
 		// when
 		PageRequest pageRequest = PageRequest.of(0, 5);
 		Page<ProductResponse.Search> search = productService.search(
@@ -147,8 +161,16 @@ class ProductServiceTest {
 				categorySports,
 				testSeller
 			);
-			productRepository.save(product);
+			products.add(product);
 		}
+		productRepository.saveAll(products);
+
+		List<InventoryEntity> inventories = new ArrayList<>();
+		for (ProductEntity product : products) {
+			InventoryEntity inventory = InventoryEntity.create(product.getId(), 10L);
+			inventories.add(inventory);
+		}
+		inventoryRepository.saveAll(inventories);
 
 		// when
 		PageRequest pageRequest = PageRequest.of(0, 5);

--- a/src/test/java/com/kt/service/RefundServiceTest.java
+++ b/src/test/java/com/kt/service/RefundServiceTest.java
@@ -104,6 +104,7 @@ class RefundServiceTest {
 			);
 
 		order.addOrderProduct(orderProduct);
+		inventory.decreaseStock(quantity);
 		return orderProductRepository.save(orderProduct);
 	}
 
@@ -499,7 +500,7 @@ class RefundServiceTest {
 		);
 
 		// then
-		Long afterStock = inventoryRepository
+		long afterStock = inventoryRepository
 			.findByProductIdOrThrow(product.getId())
 			.getStock();
 

--- a/src/test/java/com/kt/service/RefundServiceTest.java
+++ b/src/test/java/com/kt/service/RefundServiceTest.java
@@ -22,6 +22,7 @@ import com.kt.constant.PaymentStatus;
 import com.kt.constant.RefundStatus;
 import com.kt.constant.message.ErrorCode;
 import com.kt.domain.entity.CategoryEntity;
+import com.kt.domain.entity.InventoryEntity;
 import com.kt.domain.entity.OrderEntity;
 import com.kt.domain.entity.OrderProductEntity;
 import com.kt.domain.entity.PayEntity;
@@ -34,6 +35,7 @@ import com.kt.exception.CustomException;
 import com.kt.repository.CategoryRepository;
 import com.kt.repository.PayRepository;
 import com.kt.repository.PaymentRepository;
+import com.kt.repository.inventory.InventoryRepository;
 import com.kt.repository.order.OrderRepository;
 import com.kt.repository.orderproduct.OrderProductRepository;
 import com.kt.repository.product.ProductRepository;
@@ -62,6 +64,8 @@ class RefundServiceTest {
 	@Autowired
 	ProductRepository productRepository;
 	@Autowired
+	InventoryRepository inventoryRepository;
+	@Autowired
 	PaymentRepository paymentRepository;
 	@Autowired
 	UserRepository userRepository;
@@ -76,7 +80,6 @@ class RefundServiceTest {
 	SellerEntity testSeller;
 	OrderProductEntity testOrderProduct;
 
-
 	OrderProductEntity createOrderProduct(
 		OrderEntity order,
 		CategoryEntity category,
@@ -87,6 +90,9 @@ class RefundServiceTest {
 			productRepository.save(
 				ProductEntityCreator.createProduct(category, seller)
 			);
+
+		InventoryEntity inventory = InventoryEntity.create(product.getId(), 10L);
+		inventoryRepository.save(inventory);
 
 		OrderProductEntity orderProduct =
 			OrderProductEntity.create(
@@ -198,7 +204,6 @@ class RefundServiceTest {
 			.hasMessageContaining(ErrorCode.ORDER_ACCESS_NOT_ALLOWED.name());
 	}
 
-
 	@Test
 	void 환불_승인__성공() {
 		// given
@@ -286,7 +291,6 @@ class RefundServiceTest {
 			.isEqualTo(PaymentStatus.REFUND_COMPLETED);
 	}
 
-
 	@Test
 	void 환불_승인__실패__이미_완료됨() {
 		// given
@@ -338,7 +342,6 @@ class RefundServiceTest {
 		).isInstanceOf(CustomException.class)
 			.hasMessageContaining(ErrorCode.AUTH_PERMISSION_DENIED.name());
 	}
-
 
 	@Test
 	void 환불_거부__성공() {
@@ -427,7 +430,6 @@ class RefundServiceTest {
 			.isEqualByComparingTo(beforeBalance);
 	}
 
-
 	@Test
 	void 배송전_주문취소__Pay_잔액_복구_성공() {
 		// given
@@ -477,7 +479,9 @@ class RefundServiceTest {
 		long quantity = testOrderProduct.getQuantity();
 		ProductEntity product = testOrderProduct.getProduct();
 
-		long beforeStock = product.getStock();
+		long beforeStock = inventoryRepository
+			.findByProductIdOrThrow(product.getId())
+			.getStock();
 
 		refundService.requestRefund(
 			testUser.getId(),
@@ -495,13 +499,12 @@ class RefundServiceTest {
 		);
 
 		// then
-		ProductEntity afterProduct =
-			productRepository.findById(product.getId())
-				.orElseThrow();
+		Long afterStock = inventoryRepository
+			.findByProductIdOrThrow(product.getId())
+			.getStock();
 
-		assertThat(afterProduct.getStock())
+		assertThat(afterStock)
 			.isEqualTo(beforeStock + quantity);
 	}
-
 
 }

--- a/src/test/java/com/kt/service/UserServiceTest.java
+++ b/src/test/java/com/kt/service/UserServiceTest.java
@@ -4,14 +4,6 @@ import static org.assertj.core.api.Assertions.*;
 
 import java.time.LocalDate;
 
-import com.kt.common.SellerEntityCreator;
-import com.kt.domain.entity.AdminEntity;
-import com.kt.domain.entity.SellerEntity;
-import com.kt.repository.account.AccountRepository;
-import com.kt.constant.AccountRole;
-
-import com.kt.repository.admin.AdminRepository;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -23,27 +15,32 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.kt.common.SellerEntityCreator;
+import com.kt.constant.AccountRole;
 import com.kt.constant.Gender;
 import com.kt.constant.OrderProductStatus;
 import com.kt.constant.UserStatus;
 import com.kt.domain.dto.request.UserRequest;
 import com.kt.domain.dto.response.OrderProductResponse;
 import com.kt.domain.dto.response.UserResponse;
+import com.kt.domain.entity.AdminEntity;
 import com.kt.domain.entity.CategoryEntity;
 import com.kt.domain.entity.OrderEntity;
 import com.kt.domain.entity.OrderProductEntity;
 import com.kt.domain.entity.ProductEntity;
 import com.kt.domain.entity.ReceiverVO;
 import com.kt.domain.entity.ReviewEntity;
+import com.kt.domain.entity.SellerEntity;
 import com.kt.domain.entity.UserEntity;
 import com.kt.repository.CategoryRepository;
+import com.kt.repository.account.AccountRepository;
+import com.kt.repository.admin.AdminRepository;
 import com.kt.repository.order.OrderRepository;
 import com.kt.repository.orderproduct.OrderProductRepository;
 import com.kt.repository.product.ProductRepository;
 import com.kt.repository.review.ReviewRepository;
-import com.kt.repository.user.UserRepository;
-
 import com.kt.repository.seller.SellerRepository;
+import com.kt.repository.user.UserRepository;
 
 @Transactional
 @SpringBootTest
@@ -149,7 +146,6 @@ class UserServiceTest {
 		testProduct = ProductEntity.create(
 			"테스트상품명",
 			1000L,
-			5L,
 			category,
 			testSeller
 		);
@@ -173,7 +169,6 @@ class UserServiceTest {
 
 		ProductEntity product = ProductEntity.create(
 			"테스트물건",
-			3L,
 			3L,
 			category,
 			testSeller

--- a/src/test/java/com/kt/service/admin/AdminManagementServiceTest.java
+++ b/src/test/java/com/kt/service/admin/AdminManagementServiceTest.java
@@ -1,25 +1,11 @@
 package com.kt.service.admin;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.LocalDate;
 
-import com.kt.common.AdminCreator;
-import com.kt.common.SellerEntityCreator;
-import com.kt.domain.entity.AdminEntity;
-import com.kt.domain.entity.SellerEntity;
-import com.kt.repository.account.AccountRepository;
-
-import com.kt.repository.admin.AdminRepository;
-
-import lombok.extern.slf4j.Slf4j;
-
 import org.junit.jupiter.api.AfterEach;
-import com.kt.constant.AccountRole;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,24 +16,31 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.kt.common.AdminCreator;
+import com.kt.common.SellerEntityCreator;
+import com.kt.constant.AccountRole;
 import com.kt.constant.Gender;
 import com.kt.constant.OrderProductStatus;
 import com.kt.constant.UserStatus;
-import com.kt.constant.message.ErrorCode;
 import com.kt.domain.dto.response.UserResponse;
+import com.kt.domain.entity.AdminEntity;
 import com.kt.domain.entity.CategoryEntity;
 import com.kt.domain.entity.OrderEntity;
 import com.kt.domain.entity.OrderProductEntity;
 import com.kt.domain.entity.ProductEntity;
 import com.kt.domain.entity.ReceiverVO;
+import com.kt.domain.entity.SellerEntity;
 import com.kt.domain.entity.UserEntity;
-import com.kt.exception.CustomException;
 import com.kt.repository.CategoryRepository;
+import com.kt.repository.account.AccountRepository;
+import com.kt.repository.admin.AdminRepository;
 import com.kt.repository.order.OrderRepository;
 import com.kt.repository.orderproduct.OrderProductRepository;
 import com.kt.repository.product.ProductRepository;
 import com.kt.repository.review.ReviewRepository;
 import com.kt.repository.user.UserRepository;
+
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Transactional
@@ -147,7 +140,6 @@ class AdminManagementServiceTest {
 		testProduct = ProductEntity.create(
 			"테스트상품명",
 			1000L,
-			5L,
 			category,
 			testSeller
 		);
@@ -182,7 +174,6 @@ class AdminManagementServiceTest {
 
 		ProductEntity product = ProductEntity.create(
 			"테스트물건",
-			3L,
 			3L,
 			category,
 			testSeller

--- a/src/test/java/com/kt/service/admin/AdminOrderServiceTest.java
+++ b/src/test/java/com/kt/service/admin/AdminOrderServiceTest.java
@@ -1,12 +1,6 @@
 package com.kt.service.admin;
 
-import com.kt.common.SellerEntityCreator;
-import com.kt.domain.entity.SellerEntity;
-import com.kt.repository.admin.AdminRepository;
-import com.kt.repository.seller.SellerRepository;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.*;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -20,20 +14,26 @@ import org.springframework.transaction.annotation.Transactional;
 import com.kt.common.CategoryEntityCreator;
 import com.kt.common.ProductEntityCreator;
 import com.kt.common.ReceiverCreator;
+import com.kt.common.SellerEntityCreator;
 import com.kt.common.UserEntityCreator;
 import com.kt.constant.OrderProductStatus;
 import com.kt.constant.message.ErrorCode;
 import com.kt.domain.dto.response.AdminOrderResponse;
 import com.kt.domain.entity.CategoryEntity;
+import com.kt.domain.entity.InventoryEntity;
 import com.kt.domain.entity.OrderEntity;
 import com.kt.domain.entity.OrderProductEntity;
 import com.kt.domain.entity.ProductEntity;
+import com.kt.domain.entity.SellerEntity;
 import com.kt.domain.entity.UserEntity;
 import com.kt.exception.CustomException;
 import com.kt.repository.CategoryRepository;
+import com.kt.repository.admin.AdminRepository;
+import com.kt.repository.inventory.InventoryRepository;
 import com.kt.repository.order.OrderRepository;
 import com.kt.repository.orderproduct.OrderProductRepository;
 import com.kt.repository.product.ProductRepository;
+import com.kt.repository.seller.SellerRepository;
 import com.kt.repository.user.UserRepository;
 
 @Transactional
@@ -47,6 +47,8 @@ class AdminOrderServiceTest {
 	UserRepository userRepository;
 	@Autowired
 	ProductRepository productRepository;
+	@Autowired
+	InventoryRepository inventoryRepository;
 	@Autowired
 	OrderRepository orderRepository;
 	@Autowired
@@ -88,8 +90,10 @@ class AdminOrderServiceTest {
 
 		productRepository.save(product);
 
-		product.decreaseStock(quantity);
-		productRepository.save(product);
+		InventoryEntity inventory = InventoryEntity.create(product.getId(), quantity);
+		inventoryRepository.save(inventory);
+
+		inventory.decreaseStock(quantity);
 
 		return orderProductRepository.save(
 			OrderProductEntity.create(
@@ -191,6 +195,5 @@ class AdminOrderServiceTest {
 			.isInstanceOf(CustomException.class)
 			.hasMessageContaining(ErrorCode.INVALID_FORCE_STATUS_TRANSITION.name());
 	}
-
 
 }

--- a/src/test/java/com/kt/service/admin/AdminProductServiceTest.java
+++ b/src/test/java/com/kt/service/admin/AdminProductServiceTest.java
@@ -70,7 +70,6 @@ class AdminProductServiceTest {
 		ProductEntity product = ProductEntity.create(
 			"상품1",
 			1000L,
-			10L,
 			category,
 			testSeller
 		);
@@ -95,7 +94,6 @@ class AdminProductServiceTest {
 			ProductEntity product = ProductEntity.create(
 				"상품" + i,
 				1000L,
-				10L,
 				category,
 				testSeller
 			);
@@ -133,7 +131,6 @@ class AdminProductServiceTest {
 			ProductEntity product = ProductEntity.create(
 				"상품" + i,
 				1000L,
-				10L,
 				categoryDog,
 				testSeller
 			);
@@ -144,7 +141,6 @@ class AdminProductServiceTest {
 			ProductEntity product = ProductEntity.create(
 				"상품" + i,
 				1000L,
-				10L,
 				categorySports,
 				testSeller
 			);
@@ -184,7 +180,6 @@ class AdminProductServiceTest {
 			ProductEntity product = ProductEntity.create(
 				"상품" + i,
 				1000L,
-				10L,
 				categorySports,
 				testSeller
 			);
@@ -219,8 +214,10 @@ class AdminProductServiceTest {
 		// given
 		CategoryEntity categorySports = CategoryEntity.create("운동", null);
 		categoryRepository.save(categorySports);
-		ProductEntity product = ProductEntity.create("상품", 1000L, 10L, categorySports, testSeller);
+		ProductEntity product = ProductEntity.create("상품", 1000L, categorySports, testSeller);
 		productRepository.save(product);
+		InventoryEntity inventory = InventoryEntity.create(product.getId(), 10L);
+		inventoryRepository.save(inventory);
 
 		// when
 		ProductResponse.Detail detail = adminProductService.detail(AccountRole.ADMIN, product.getId());

--- a/src/test/java/com/kt/service/admin/AdminProductServiceTest.java
+++ b/src/test/java/com/kt/service/admin/AdminProductServiceTest.java
@@ -1,13 +1,10 @@
 package com.kt.service.admin;
 
 import static com.kt.common.SellerEntityCreator.*;
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import com.kt.domain.entity.SellerEntity;
-import com.kt.repository.seller.SellerRepository;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -18,17 +15,19 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.kt.constant.ProductStatus;
 import com.kt.constant.AccountRole;
+import com.kt.constant.ProductStatus;
 import com.kt.constant.searchtype.ProductSearchType;
 import com.kt.domain.dto.response.ProductResponse;
 import com.kt.domain.entity.CategoryEntity;
+import com.kt.domain.entity.InventoryEntity;
 import com.kt.domain.entity.ProductEntity;
+import com.kt.domain.entity.SellerEntity;
 import com.kt.repository.CategoryRepository;
+import com.kt.repository.inventory.InventoryRepository;
 import com.kt.repository.orderproduct.OrderProductRepository;
 import com.kt.repository.product.ProductRepository;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import com.kt.repository.seller.SellerRepository;
 
 @ActiveProfiles("test")
 @SpringBootTest
@@ -37,6 +36,7 @@ class AdminProductServiceTest {
 
 	private final AdminProductService adminProductService;
 	private final ProductRepository productRepository;
+	private final InventoryRepository inventoryRepository;
 	private final CategoryRepository categoryRepository;
 	private final OrderProductRepository orderProductRepository;
 	private final SellerRepository sellerRepository;
@@ -44,8 +44,10 @@ class AdminProductServiceTest {
 
 	@Autowired
 	AdminProductServiceTest(AdminProductService adminProductService, ProductRepository productRepository,
+		InventoryRepository inventoryRepository,
 		CategoryRepository categoryRepository, OrderProductRepository orderProductRepository,
 		SellerRepository sellerRepository) {
+		this.inventoryRepository = inventoryRepository;
 		this.orderProductRepository = orderProductRepository;
 		this.adminProductService = adminProductService;
 		this.productRepository = productRepository;
@@ -101,6 +103,13 @@ class AdminProductServiceTest {
 		}
 		productRepository.saveAll(products);
 
+		List<InventoryEntity> inventories = new ArrayList<>();
+		for (ProductEntity product : products) {
+			InventoryEntity inventory = InventoryEntity.create(product.getId(), 10L);
+			inventories.add(inventory);
+		}
+		inventoryRepository.saveAll(inventories);
+
 		// when
 		PageRequest pageRequest = PageRequest.of(1, 10);
 		Page<ProductResponse.Search> search = adminProductService.search(AccountRole.ADMIN, null, null, pageRequest);
@@ -143,6 +152,13 @@ class AdminProductServiceTest {
 		}
 		productRepository.saveAll(products);
 
+		List<InventoryEntity> inventories = new ArrayList<>();
+		for (ProductEntity product : products) {
+			InventoryEntity inventory = InventoryEntity.create(product.getId(), 10L);
+			inventories.add(inventory);
+		}
+		inventoryRepository.saveAll(inventories);
+
 		// when
 		PageRequest pageRequest = PageRequest.of(0, 5);
 		Page<ProductResponse.Search> search = adminProductService.search(
@@ -172,8 +188,16 @@ class AdminProductServiceTest {
 				categorySports,
 				testSeller
 			);
-			productRepository.save(product);
+			products.add(product);
 		}
+		productRepository.saveAll(products);
+
+		List<InventoryEntity> inventories = new ArrayList<>();
+		for (ProductEntity product : products) {
+			InventoryEntity inventory = InventoryEntity.create(product.getId(), 10L);
+			inventories.add(inventory);
+		}
+		inventoryRepository.saveAll(inventories);
 
 		// when
 		PageRequest pageRequest = PageRequest.of(0, 5);

--- a/src/test/java/com/kt/service/admin/AdminUserServiceTest.java
+++ b/src/test/java/com/kt/service/admin/AdminUserServiceTest.java
@@ -1,19 +1,8 @@
 package com.kt.service.admin;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
 
 import java.time.LocalDate;
-
-import com.kt.common.AdminCreator;
-import com.kt.common.SellerEntityCreator;
-import com.kt.common.UserEntityCreator;
-import com.kt.domain.entity.AdminEntity;
-import com.kt.domain.entity.SellerEntity;
-import com.kt.repository.account.AccountRepository;
-
-import com.kt.repository.admin.AdminRepository;
-
-import lombok.extern.slf4j.Slf4j;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -27,24 +16,33 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.kt.common.AdminCreator;
+import com.kt.common.SellerEntityCreator;
+import com.kt.common.UserEntityCreator;
+import com.kt.constant.AccountRole;
 import com.kt.constant.Gender;
 import com.kt.constant.OrderProductStatus;
-import com.kt.constant.AccountRole;
 import com.kt.constant.UserStatus;
 import com.kt.domain.dto.response.UserResponse;
+import com.kt.domain.entity.AdminEntity;
 import com.kt.domain.entity.CategoryEntity;
 import com.kt.domain.entity.OrderEntity;
 import com.kt.domain.entity.OrderProductEntity;
 import com.kt.domain.entity.ProductEntity;
 import com.kt.domain.entity.ReceiverVO;
+import com.kt.domain.entity.SellerEntity;
 import com.kt.domain.entity.UserEntity;
 import com.kt.repository.CategoryRepository;
+import com.kt.repository.account.AccountRepository;
+import com.kt.repository.admin.AdminRepository;
 import com.kt.repository.order.OrderRepository;
 import com.kt.repository.orderproduct.OrderProductRepository;
 import com.kt.repository.product.ProductRepository;
 import com.kt.repository.review.ReviewRepository;
 import com.kt.repository.seller.SellerRepository;
 import com.kt.repository.user.UserRepository;
+
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Transactional
@@ -126,7 +124,6 @@ class AdminUserServiceTest {
 		testProduct = ProductEntity.create(
 			"테스트상품명",
 			1000L,
-			5L,
 			category,
 			testSeller
 		);
@@ -150,7 +147,6 @@ class AdminUserServiceTest {
 
 		ProductEntity product = ProductEntity.create(
 			"테스트물건",
-			3L,
 			3L,
 			category,
 			testSeller

--- a/src/test/java/com/kt/service/seller/SellerProductServiceTest.java
+++ b/src/test/java/com/kt/service/seller/SellerProductServiceTest.java
@@ -103,7 +103,6 @@ class SellerProductServiceTest {
 		ProductEntity product = ProductEntity.create(
 			"상품1",
 			1000L,
-			10L,
 			category,
 			testSeller
 		);
@@ -144,7 +143,6 @@ class SellerProductServiceTest {
 		ProductEntity product = ProductEntity.create(
 			"상품1",
 			1000L,
-			10L,
 			category,
 			testSeller
 		);
@@ -169,7 +167,6 @@ class SellerProductServiceTest {
 			ProductEntity product = ProductEntity.create(
 				"상품" + i,
 				1000L,
-				10L,
 				category,
 				testSeller
 			);
@@ -207,7 +204,6 @@ class SellerProductServiceTest {
 			ProductEntity product = ProductEntity.create(
 				"상품" + i,
 				1000L,
-				10L,
 				categoryDog,
 				testSeller
 			);
@@ -218,7 +214,6 @@ class SellerProductServiceTest {
 			ProductEntity product = ProductEntity.create(
 				"상품" + i,
 				1000L,
-				10L,
 				categorySports,
 				testSeller
 			);
@@ -258,7 +253,6 @@ class SellerProductServiceTest {
 			ProductEntity product = ProductEntity.create(
 				"상품" + i,
 				1000L,
-				10L,
 				categorySports,
 				testSeller
 			);
@@ -293,8 +287,10 @@ class SellerProductServiceTest {
 		// given
 		CategoryEntity categorySports = CategoryEntity.create("운동", null);
 		categoryRepository.save(categorySports);
-		ProductEntity product = ProductEntity.create("상품", 1000L, 10L, categorySports, testSeller);
+		ProductEntity product = ProductEntity.create("상품", 1000L, categorySports, testSeller);
 		productRepository.save(product);
+		InventoryEntity inventory = InventoryEntity.create(product.getId(), 10L);
+		inventoryRepository.save(inventory);
 
 		// when
 		ProductResponse.Detail detail = sellerProductService.detail(product.getId(), testSeller.getId());
@@ -309,7 +305,7 @@ class SellerProductServiceTest {
 		// given
 		CategoryEntity categorySports = CategoryEntity.create("운동", null);
 		categoryRepository.save(categorySports);
-		ProductEntity product = ProductEntity.create("상품", 1000L, 10L, categorySports, testSeller);
+		ProductEntity product = ProductEntity.create("상품", 1000L, categorySports, testSeller);
 		productRepository.save(product);
 
 		List<UUID> productIds = productRepository.findAll()
@@ -330,7 +326,7 @@ class SellerProductServiceTest {
 		// given
 		CategoryEntity categorySports = CategoryEntity.create("운동", null);
 		categoryRepository.save(categorySports);
-		ProductEntity product = ProductEntity.create("상품", 1000L, 10L, categorySports, testSeller);
+		ProductEntity product = ProductEntity.create("상품", 1000L, categorySports, testSeller);
 		productRepository.save(product);
 
 		List<UUID> productIds = productRepository.findAll()
@@ -351,7 +347,7 @@ class SellerProductServiceTest {
 		// given
 		CategoryEntity categorySports = CategoryEntity.create("운동", null);
 		categoryRepository.save(categorySports);
-		ProductEntity product = ProductEntity.create("상품", 1000L, 10L, categorySports, testSeller);
+		ProductEntity product = ProductEntity.create("상품", 1000L, categorySports, testSeller);
 		productRepository.save(product);
 		List<UUID> productIds = productRepository.findAll()
 			.stream()
@@ -372,7 +368,7 @@ class SellerProductServiceTest {
 		// given
 		CategoryEntity categorySports = CategoryEntity.create("운동", null);
 		categoryRepository.save(categorySports);
-		ProductEntity product = ProductEntity.create("상품", 1000L, 10L, categorySports, testSeller);
+		ProductEntity product = ProductEntity.create("상품", 1000L, categorySports, testSeller);
 		productRepository.save(product);
 
 		List<UUID> productIds = List.of(product.getId());
@@ -398,7 +394,6 @@ class SellerProductServiceTest {
 			ProductEntity product = ProductEntity.create(
 				"상품" + i,
 				1000L,
-				10L,
 				categorySports,
 				testSeller
 			);

--- a/src/test/java/com/kt/service/seller/SellerProductServiceTest.java
+++ b/src/test/java/com/kt/service/seller/SellerProductServiceTest.java
@@ -1,15 +1,11 @@
 package com.kt.service.seller;
 
 import static com.kt.common.SellerEntityCreator.*;
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-
-import com.kt.domain.dto.request.SellerProductRequest;
-import com.kt.domain.entity.SellerEntity;
-import com.kt.repository.seller.SellerRepository;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -22,12 +18,17 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.kt.constant.ProductStatus;
 import com.kt.constant.searchtype.ProductSearchType;
+import com.kt.domain.dto.request.SellerProductRequest;
 import com.kt.domain.dto.response.ProductResponse;
 import com.kt.domain.entity.CategoryEntity;
+import com.kt.domain.entity.InventoryEntity;
 import com.kt.domain.entity.ProductEntity;
+import com.kt.domain.entity.SellerEntity;
 import com.kt.repository.CategoryRepository;
+import com.kt.repository.inventory.InventoryRepository;
 import com.kt.repository.orderproduct.OrderProductRepository;
 import com.kt.repository.product.ProductRepository;
+import com.kt.repository.seller.SellerRepository;
 
 @ActiveProfiles("test")
 @SpringBootTest
@@ -36,6 +37,7 @@ class SellerProductServiceTest {
 
 	private final SellerProductService sellerProductService;
 	private final ProductRepository productRepository;
+	private final InventoryRepository inventoryRepository;
 	private final CategoryRepository categoryRepository;
 	private final OrderProductRepository orderProductRepository;
 	private final SellerRepository sellerRepository;
@@ -43,11 +45,13 @@ class SellerProductServiceTest {
 
 	@Autowired
 	SellerProductServiceTest(SellerProductService sellerProductService, ProductRepository productRepository,
-		CategoryRepository categoryRepository, OrderProductRepository orderProductRepository,
+		InventoryRepository inventoryRepository, CategoryRepository categoryRepository,
+		OrderProductRepository orderProductRepository,
 		SellerRepository sellerRepository) {
 		this.orderProductRepository = orderProductRepository;
 		this.sellerProductService = sellerProductService;
 		this.productRepository = productRepository;
+		this.inventoryRepository = inventoryRepository;
 		this.categoryRepository = categoryRepository;
 		this.sellerRepository = sellerRepository;
 	}
@@ -105,6 +109,8 @@ class SellerProductServiceTest {
 		);
 
 		productRepository.save(product);
+		InventoryEntity inventory = InventoryEntity.create(product.getId(), 10L);
+		inventoryRepository.save(inventory);
 
 		// when
 		SellerProductRequest.Update request = new SellerProductRequest.Update(
@@ -171,6 +177,13 @@ class SellerProductServiceTest {
 		}
 		productRepository.saveAll(products);
 
+		List<InventoryEntity> inventories = new ArrayList<>();
+		for (ProductEntity product : products) {
+			InventoryEntity inventory = InventoryEntity.create(product.getId(), 10L);
+			inventories.add(inventory);
+		}
+		inventoryRepository.saveAll(inventories);
+
 		// when
 		PageRequest pageRequest = PageRequest.of(1, 10);
 		Page<ProductResponse.Search> search = sellerProductService.search(null, null, pageRequest, testSeller.getId());
@@ -213,6 +226,13 @@ class SellerProductServiceTest {
 		}
 		productRepository.saveAll(products);
 
+		List<InventoryEntity> inventories = new ArrayList<>();
+		for (ProductEntity product : products) {
+			InventoryEntity inventory = InventoryEntity.create(product.getId(), 10L);
+			inventories.add(inventory);
+		}
+		inventoryRepository.saveAll(inventories);
+
 		// when
 		PageRequest pageRequest = PageRequest.of(0, 5);
 		Page<ProductResponse.Search> search = sellerProductService.search(
@@ -245,6 +265,13 @@ class SellerProductServiceTest {
 			products.add(product);
 		}
 		productRepository.saveAll(products);
+
+		List<InventoryEntity> inventories = new ArrayList<>();
+		for (ProductEntity product : products) {
+			InventoryEntity inventory = InventoryEntity.create(product.getId(), 10L);
+			inventories.add(inventory);
+		}
+		inventoryRepository.saveAll(inventories);
 
 		// when
 		PageRequest pageRequest = PageRequest.of(0, 5);
@@ -366,6 +393,7 @@ class SellerProductServiceTest {
 		CategoryEntity categorySports = CategoryEntity.create("운동", null);
 		categoryRepository.save(categorySports);
 		List<ProductEntity> products = new ArrayList<>();
+		List<InventoryEntity> inventories = new ArrayList<>();
 		for (int i = 0; i < 5; i++) {
 			ProductEntity product = ProductEntity.create(
 				"상품" + i,
@@ -378,6 +406,12 @@ class SellerProductServiceTest {
 		}
 		productRepository.saveAll(products);
 
+		for (ProductEntity product : products) {
+			InventoryEntity inventory = InventoryEntity.create(product.getId(), 10L);
+			inventories.add(inventory);
+		}
+		inventoryRepository.saveAll(inventories);
+
 		// when
 		sellerProductService.soldOutProducts(
 			products.stream().map(ProductEntity::getId).toList(), testSeller.getId()
@@ -385,7 +419,7 @@ class SellerProductServiceTest {
 
 		// then
 		assertThat(
-			productRepository.findAll()
+			inventoryRepository.findAll()
 				.stream()
 				.allMatch(it -> it.getStock() == 0)
 		).isTrue();


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- resolves: #이슈번호, #이슈번호 -->
resolves:

## 📝작업 내용

상품-재고 도메인 분리

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

상품의 재고 속성을 별도의 도메인(inventory)으로 분리했습니다.
상품 도메인에 의존하는 클래스와 테스트가 많다보니 작업량이 방대한 점 양해바랍니다 ㅜ
도메인 분리 이후에 동시 요청 성능 테스트 해본결과 약 20%의 성능 향상이 확인되었습니다.

민서님께서 작업하신 내용과 코드 충돌이 많이 발생할 수 있을것 같습니다.

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->