### PR TITLE
[REFACTOR] 대화방 생성 시점 변경

### DIFF
--- a/src/main/java/com/kt/ai/AIChatSessionStore.java
+++ b/src/main/java/com/kt/ai/AIChatSessionStore.java
@@ -42,6 +42,7 @@ public class AIChatSessionStore {
 	}
 
 	public void clear(UUID userId) {
+		// TODO: 챗봇 상담 실패시 실패 키 삭제 시점
 		redisCache.delete(RedisKey.AI_CHAT_SESSION.key(userId));
 	}
 }

--- a/src/main/java/com/kt/ai/controller/FAQAdminController.java
+++ b/src/main/java/com/kt/ai/controller/FAQAdminController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.kt.ai.dto.request.FAQRequest;
+import com.kt.ai.dto.request.AdminFAQRequest;
 import com.kt.ai.service.AdminFAQService;
 import com.kt.common.api.ApiResult;
 
@@ -22,13 +22,13 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequestMapping("/api/admin/faq")
 @RequiredArgsConstructor
-public class FAQAdminController {
+public class FAQAdminController implements FAQAdminSwaggerSupporter {
 
 	private final AdminFAQService adminFaqService;
 
 	@PostMapping
 	public ResponseEntity<ApiResult<Void>> createFAQ(
-		@RequestBody @Valid FAQRequest.Create request
+		@RequestBody @Valid AdminFAQRequest.Create request
 	) throws Exception {
 		adminFaqService.create(request.title(), request.content(), request.category());
 

--- a/src/main/java/com/kt/ai/controller/FAQAdminSwaggerSupporter.java
+++ b/src/main/java/com/kt/ai/controller/FAQAdminSwaggerSupporter.java
@@ -1,0 +1,36 @@
+package com.kt.ai.controller;
+
+import java.util.UUID;
+
+import org.springframework.http.ResponseEntity;
+
+import com.kt.ai.dto.request.AdminFAQRequest;
+import com.kt.common.api.ApiResult;
+import com.kt.common.support.SwaggerSupporter;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "FAQ", description = "FAQ 관련 API")
+public interface FAQAdminSwaggerSupporter extends SwaggerSupporter {
+	@Operation(
+		summary = "FAQ 질문 답변 등록",
+		description = "FAQ 질문 답변을 생성하고 벡터스토어에 업로드합니다."
+	)
+	ResponseEntity<ApiResult<Void>> createFAQ(
+		AdminFAQRequest.Create request
+	) throws Exception;
+
+	@Operation(
+		summary = "FAQ 질문 답변 삭제",
+		description = "FAQ 내 질문 답변 삭제합니다."
+	)
+	ResponseEntity<ApiResult<Void>> deleteFAQ(
+		@Schema(
+			description = "FAQ ID"
+		)
+		UUID faqId
+	);
+
+}

--- a/src/main/java/com/kt/ai/controller/FAQController.java
+++ b/src/main/java/com/kt/ai/controller/FAQController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.kt.ai.dto.request.FAQRequest;
 import com.kt.ai.dto.response.FAQResponse;
 import com.kt.ai.service.RAGService;
 import com.kt.common.api.ApiResult;
@@ -17,16 +18,16 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequestMapping("/api/ai")
 @RequiredArgsConstructor
-public class FAQController {
+public class FAQController implements FAQSwaggerSupporter {
 
 	private final RAGService ragService;
 
 	@PostMapping("/faq")
 	public ResponseEntity<ApiResult<FAQResponse.ChatBot>> askFAQ(
 		@AuthenticationPrincipal DefaultCurrentUser defaultCurrentUser,
-		@RequestBody String question
+		@RequestBody FAQRequest.AskFAQ request
 	) {
-		FAQResponse.ChatBot answer = ragService.askFAQ(defaultCurrentUser.getId(), question);
+		FAQResponse.ChatBot answer = ragService.askFAQ(defaultCurrentUser.getId(), request.question());
 
 		return ApiResult.wrap(answer);
 	}

--- a/src/main/java/com/kt/ai/controller/FAQSwaggerSupporter.java
+++ b/src/main/java/com/kt/ai/controller/FAQSwaggerSupporter.java
@@ -1,0 +1,27 @@
+package com.kt.ai.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import com.kt.ai.dto.request.FAQRequest;
+import com.kt.ai.dto.response.FAQResponse;
+import com.kt.common.api.ApiResult;
+import com.kt.common.support.SwaggerSupporter;
+import com.kt.security.DefaultCurrentUser;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "FAQ", description = "FAQ 관련 Api")
+public interface FAQSwaggerSupporter extends SwaggerSupporter {
+
+	@Operation(
+		summary = "FAQ 챗봇 질문",
+		description = "FAQ 챗봇에 질문합니다."
+	)
+	ResponseEntity<ApiResult<FAQResponse.ChatBot>> askFAQ(
+		@AuthenticationPrincipal DefaultCurrentUser defaultCurrentUser,
+		@RequestBody FAQRequest.AskFAQ request
+	);
+}

--- a/src/main/java/com/kt/ai/dto/request/AdminFAQRequest.java
+++ b/src/main/java/com/kt/ai/dto/request/AdminFAQRequest.java
@@ -1,0 +1,20 @@
+package com.kt.ai.dto.request;
+
+import com.kt.constant.FAQCategory;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public class AdminFAQRequest {
+
+	@Schema(name = "FAQCreateRequest")
+	public record Create(
+		@Schema(description = "FAQ 질문 제목", example = "배송이 오지 않아요.")
+		String title,
+		@Schema(description = "FAQ 답변 내용", example = "배송은 주문 승인 이후 2-3일 영업일 내 도착 예정입니다. 지연시 고객센터 0000-0000이나 1:1 문의 부탁드립니다.")
+		String content,
+		@Schema(description = "FAQ 카테고리", example = "ACCOUNT|ORDER|DELIVERY|RETURN|PAYMENT|PRODUCT|OTHER")
+		FAQCategory category
+	) {
+
+	}
+}

--- a/src/main/java/com/kt/ai/dto/request/FAQRequest.java
+++ b/src/main/java/com/kt/ai/dto/request/FAQRequest.java
@@ -1,16 +1,12 @@
 package com.kt.ai.dto.request;
 
-import com.kt.constant.FAQCategory;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public class FAQRequest {
-
-	@Schema(name = "FAQCreateRequest")
-	public record Create(
-		String title,
-		String content,
-		FAQCategory category
+	@Schema(name = "UserFAQRequest")
+	public record AskFAQ(
+		@Schema(description = "유저 질문")
+		String question
 	) {
 
 	}

--- a/src/main/java/com/kt/ai/service/RAGServiceImpl.java
+++ b/src/main/java/com/kt/ai/service/RAGServiceImpl.java
@@ -45,7 +45,7 @@ public class RAGServiceImpl implements RAGService {
 				chatSessionStore.clear(userId);
 
 				return new FAQResponse.ChatBot(
-					"정확한 답변이 어려워 상담사에게 연결해드릴게요. 상담연결 버튼을 누른 후 대기 부탁드려요.",
+					"정확한 답변이 어려워 상담사에게 연결해드릴게요. 상담 연결 버튼을 누른 후 메시지를 보내시고 대기 부탁드려요.",
 					conversationId,
 					true
 				);

--- a/src/main/java/com/kt/ai/service/RAGServiceImpl.java
+++ b/src/main/java/com/kt/ai/service/RAGServiceImpl.java
@@ -27,7 +27,6 @@ public class RAGServiceImpl implements RAGService {
 	private final AIChatSessionStore chatSessionStore;
 	private final RAGRetriever ragRetriever;
 	private final HandoverPublisher handoverPublisher;
-	private final ChatRoomService chatRoomService;
 
 	@Override
 	public FAQResponse.ChatBot askFAQ(UUID userId, String question) {
@@ -45,10 +44,8 @@ public class RAGServiceImpl implements RAGService {
 				);
 				chatSessionStore.clear(userId);
 
-				// TODO: service 간 호출 지양 리팩토링
-				chatRoomService.createOrWaiting(conversationId, userId);
 				return new FAQResponse.ChatBot(
-					"정확한 답변이 어려워 상담사에게 연결해드릴게요.",
+					"정확한 답변이 어려워 상담사에게 연결해드릴게요. 상담연결 버튼을 누른 후 대기 부탁드려요.",
 					conversationId,
 					true
 				);

--- a/src/main/java/com/kt/chat/controller/AdminChatController.java
+++ b/src/main/java/com/kt/chat/controller/AdminChatController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.kt.chat.domain.dto.AdminChatRequest;
 import com.kt.chat.domain.dto.ChatRoomInfoResponse;
 import com.kt.chat.service.AdminChatRoomService;
 import com.kt.common.api.ApiResult;
@@ -24,29 +25,33 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/admin/chat/rooms")
 @RequiredArgsConstructor
 
-public class AdminChatController {
+public class AdminChatController implements AdminChatSwaggerSupporter {
 
 	private final AdminChatRoomService chatRoomService;
 
+	@Override
 	@PostMapping("/handover/accept")
 	public ResponseEntity<ApiResult<Void>> accept(
 		@AuthenticationPrincipal DefaultCurrentUser defaultCurrentUser,
-		@RequestBody UUID conversationId
+		@RequestBody AdminChatRequest.AcceptChat request
 	) {
-		chatRoomService.accept(conversationId, defaultCurrentUser.getId());
+		chatRoomService.accept(request.conversationId(), defaultCurrentUser.getId());
 		return empty();
 	}
 
+	@Override
 	@GetMapping
 	public ResponseEntity<ApiResult<List<ChatRoomInfoResponse>>> getAllRooms() {
 		return wrap(chatRoomService.getAll());
 	}
 
+	@Override
 	@GetMapping("/waiting")
 	public ResponseEntity<ApiResult<List<ChatRoomInfoResponse>>> getWaitingRooms() {
 		return wrap(chatRoomService.getWaitingRooms());
 	}
 
+	@Override
 	@GetMapping("/connected")
 	public ResponseEntity<ApiResult<List<ChatRoomInfoResponse>>> getConnectedRooms() {
 		return wrap(chatRoomService.getConnectedRooms());

--- a/src/main/java/com/kt/chat/controller/AdminChatSwaggerSupporter.java
+++ b/src/main/java/com/kt/chat/controller/AdminChatSwaggerSupporter.java
@@ -1,0 +1,46 @@
+package com.kt.chat.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import com.kt.chat.domain.dto.AdminChatRequest;
+import com.kt.chat.domain.dto.ChatRoomInfoResponse;
+import com.kt.common.api.ApiResult;
+import com.kt.common.support.SwaggerSupporter;
+import com.kt.security.DefaultCurrentUser;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Chat", description = "채팅 관련 apI")
+public interface AdminChatSwaggerSupporter extends SwaggerSupporter {
+	@Operation(
+		summary = "관리자 채팅방 진입",
+		description = "관리자가 채팅방을 준비 상태로 변경합니다."
+	)
+	ResponseEntity<ApiResult<Void>> accept(
+		@AuthenticationPrincipal DefaultCurrentUser defaultCurrentUser,
+		@RequestBody AdminChatRequest.AcceptChat request
+	);
+
+	@Operation(
+		summary = "전체 채팅방 조회",
+		description = "관리자가 전체 채팅방을 조회합니다."
+	)
+	ResponseEntity<ApiResult<List<ChatRoomInfoResponse>>> getAllRooms();
+
+	@Operation(
+		summary = "대기중 채팅방 조회",
+		description = "관리자가 응답 대기중인 채팅방을 조회합니다."
+	)
+	ResponseEntity<ApiResult<List<ChatRoomInfoResponse>>> getWaitingRooms();
+
+	@Operation(
+		summary = "상담중 채팅방 조회",
+		description = "관리자가 상담중인 채팅방을 조회합니다."
+	)
+	ResponseEntity<ApiResult<List<ChatRoomInfoResponse>>> getConnectedRooms();
+}

--- a/src/main/java/com/kt/chat/controller/ChatController.java
+++ b/src/main/java/com/kt/chat/controller/ChatController.java
@@ -24,17 +24,16 @@ import com.kt.common.api.ApiResult;
 import com.kt.security.DefaultCurrentUser;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @Controller
 @RequiredArgsConstructor
-public class ChatController {
+public class ChatController implements ChatSwaggerSupporter {
 
 	private final SimpMessagingTemplate messagingTemplate;
 	private final ChatMessageService chatMessageService;
 	private final ChatRoomService chatRoomService;
 
+	@Override
 	@PostMapping("/api/chat/apply")
 	public ResponseEntity<ApiResult<Void>> applyChat(
 		@AuthenticationPrincipal DefaultCurrentUser defaultCurrentUser,

--- a/src/main/java/com/kt/chat/controller/ChatController.java
+++ b/src/main/java/com/kt/chat/controller/ChatController.java
@@ -3,8 +3,10 @@ package com.kt.chat.controller;
 import static com.kt.common.api.ApiResult.*;
 
 import java.security.Principal;
+import java.time.Instant;
 import java.util.UUID;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
@@ -13,14 +15,18 @@ import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import com.kt.chat.domain.dto.ChatRequest;
 import com.kt.chat.domain.dto.ChatResponse;
 import com.kt.chat.service.ChatMessageService;
 import com.kt.chat.service.ChatRoomService;
 import com.kt.common.api.ApiResult;
+import com.kt.common.api.PageResponse;
 import com.kt.security.DefaultCurrentUser;
 
 import lombok.RequiredArgsConstructor;
@@ -45,6 +51,19 @@ public class ChatController implements ChatSwaggerSupporter {
 		);
 
 		return empty();
+	}
+
+	@GetMapping("/api/chat/{conversationId}/messages")
+	public ResponseEntity<ApiResult<PageResponse<ChatResponse.Search>>> messages(
+		@PathVariable UUID conversationId,
+		@RequestParam(required = false) Instant cursor,
+		Pageable pageable
+	) {
+		return page(chatMessageService.getMessages(
+			conversationId,
+			cursor,
+			pageable
+		));
 	}
 
 	@MessageMapping("/chat/{conversationId}")

--- a/src/main/java/com/kt/chat/controller/ChatController.java
+++ b/src/main/java/com/kt/chat/controller/ChatController.java
@@ -1,18 +1,26 @@
 package com.kt.chat.controller;
 
+import static com.kt.common.api.ApiResult.*;
+
 import java.security.Principal;
 import java.util.UUID;
 
+import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 import com.kt.chat.domain.dto.ChatRequest;
 import com.kt.chat.domain.dto.ChatResponse;
 import com.kt.chat.service.ChatMessageService;
+import com.kt.chat.service.ChatRoomService;
+import com.kt.common.api.ApiResult;
 import com.kt.security.DefaultCurrentUser;
 
 import lombok.RequiredArgsConstructor;
@@ -25,6 +33,20 @@ public class ChatController {
 
 	private final SimpMessagingTemplate messagingTemplate;
 	private final ChatMessageService chatMessageService;
+	private final ChatRoomService chatRoomService;
+
+	@PostMapping("/api/chat/apply")
+	public ResponseEntity<ApiResult<Void>> applyChat(
+		@AuthenticationPrincipal DefaultCurrentUser defaultCurrentUser,
+		@RequestBody ChatRequest.ApplyChat request
+	) {
+		chatRoomService.createOrWaiting(
+			UUID.fromString(request.conversationId()),
+			defaultCurrentUser.getId()
+		);
+
+		return empty();
+	}
 
 	@MessageMapping("/chat/{conversationId}")
 	public void handleChat(

--- a/src/main/java/com/kt/chat/controller/ChatSwaggerSupporter.java
+++ b/src/main/java/com/kt/chat/controller/ChatSwaggerSupporter.java
@@ -1,0 +1,25 @@
+package com.kt.chat.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import com.kt.chat.domain.dto.ChatRequest;
+import com.kt.common.api.ApiResult;
+import com.kt.common.support.SwaggerSupporter;
+import com.kt.security.DefaultCurrentUser;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Chat", description = "채팅 관련 API")
+public interface ChatSwaggerSupporter extends SwaggerSupporter {
+	@Operation(
+		summary = "AI -> 관리자 상담 전환",
+		description = "유저가 관리자를 대기하는 상태의 채팅방을 생성합니다."
+	)
+	ResponseEntity<ApiResult<Void>> applyChat(
+		@AuthenticationPrincipal DefaultCurrentUser defaultCurrentUser,
+		@RequestBody ChatRequest.ApplyChat request
+	);
+}

--- a/src/main/java/com/kt/chat/domain/dto/AdminChatRequest.java
+++ b/src/main/java/com/kt/chat/domain/dto/AdminChatRequest.java
@@ -1,0 +1,11 @@
+package com.kt.chat.domain.dto;
+
+import java.util.UUID;
+
+public class AdminChatRequest {
+	public record AcceptChat(
+		UUID conversationId
+	) {
+
+	}
+}

--- a/src/main/java/com/kt/chat/domain/dto/ChatRequest.java
+++ b/src/main/java/com/kt/chat/domain/dto/ChatRequest.java
@@ -5,4 +5,10 @@ public class ChatRequest {
 		String message
 	) {
 	}
+
+	public record ApplyChat(
+		String conversationId
+	) {
+
+	}
 }

--- a/src/main/java/com/kt/chat/domain/dto/ChatResponse.java
+++ b/src/main/java/com/kt/chat/domain/dto/ChatResponse.java
@@ -1,6 +1,10 @@
 package com.kt.chat.domain.dto;
 
+import java.time.Instant;
 import java.util.UUID;
+
+import com.kt.chat.domain.entity.ChatMessageEntity;
+import com.querydsl.core.annotations.QueryProjection;
 
 public class ChatResponse {
 	public record Message(
@@ -10,4 +14,29 @@ public class ChatResponse {
 	) {
 
 	}
+
+	public record Search(
+		UUID id,
+		UUID senderId,
+		String senderRole,
+		String message,
+		Instant createdAt
+	) {
+		@QueryProjection
+		public Search {
+
+		}
+
+		public static Search from(ChatMessageEntity chatMessageEntity) {
+			return new Search(
+				chatMessageEntity.getId(),
+				chatMessageEntity.getSenderId(),
+				chatMessageEntity.getSenderRole(),
+				chatMessageEntity.getMessage(),
+				chatMessageEntity.getCreatedAt()
+			);
+		}
+
+	}
+
 }

--- a/src/main/java/com/kt/chat/repository/chatmessage/ChatMessageRepository.java
+++ b/src/main/java/com/kt/chat/repository/chatmessage/ChatMessageRepository.java
@@ -6,6 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.kt.chat.domain.entity.ChatMessageEntity;
 
-public interface ChatMessageRepository extends JpaRepository<ChatMessageEntity, UUID> {
+public interface ChatMessageRepository extends JpaRepository<ChatMessageEntity, UUID>, ChatMessageRepositoryCustom {
 
 }

--- a/src/main/java/com/kt/chat/repository/chatmessage/ChatMessageRepositoryCustom.java
+++ b/src/main/java/com/kt/chat/repository/chatmessage/ChatMessageRepositoryCustom.java
@@ -1,0 +1,18 @@
+package com.kt.chat.repository.chatmessage;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import com.kt.chat.domain.entity.ChatMessageEntity;
+
+public interface ChatMessageRepositoryCustom {
+
+	Page<ChatMessageEntity> findByConversationIdWithCursor(
+		Pageable pageable,
+		UUID conversationId,
+		Instant cursor
+	);
+}

--- a/src/main/java/com/kt/chat/repository/chatmessage/ChatMessageRepositoryImpl.java
+++ b/src/main/java/com/kt/chat/repository/chatmessage/ChatMessageRepositoryImpl.java
@@ -1,0 +1,66 @@
+package com.kt.chat.repository.chatmessage;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import com.kt.chat.domain.entity.ChatMessageEntity;
+import com.kt.chat.domain.entity.QChatMessageEntity;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class ChatMessageRepositoryImpl implements ChatMessageRepositoryCustom {
+
+	private final JPAQueryFactory jpaQueryFactory;
+	private final QChatMessageEntity chatMessage = QChatMessageEntity.chatMessageEntity;
+
+	@Override
+	public Page<ChatMessageEntity> findByConversationIdWithCursor(
+		Pageable pageable,
+		UUID conversationId,
+		Instant cursor
+	) {
+		BooleanBuilder booleanBuilder = new BooleanBuilder();
+		booleanBuilder.and(eqConversationId(conversationId));
+		booleanBuilder.and(ltCursor(cursor));
+
+		List<ChatMessageEntity> content = jpaQueryFactory
+			.selectFrom(chatMessage)
+			.where(booleanBuilder)
+			.orderBy(chatMessage.createdAt.desc())
+			.limit(pageable.getPageSize())
+			.fetch();
+
+		int total = jpaQueryFactory
+			.select(chatMessage.id)
+			.from(chatMessage)
+			.where(eqConversationId(conversationId))
+			.fetch()
+			.size();
+
+		return new PageImpl<>(content, pageable, total);
+	}
+
+	private BooleanExpression eqConversationId(UUID conversationId) {
+		if (conversationId == null) {
+			return null;
+		}
+		return chatMessage.conversationId.eq(conversationId);
+	}
+
+	private BooleanExpression ltCursor(Instant cursor) {
+		if (cursor == null) {
+			return null;
+		}
+		return chatMessage.createdAt.lt(cursor);
+	}
+
+}

--- a/src/main/java/com/kt/chat/service/ChatMessageService.java
+++ b/src/main/java/com/kt/chat/service/ChatMessageService.java
@@ -1,8 +1,20 @@
 package com.kt.chat.service;
 
+import java.time.Instant;
 import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import com.kt.chat.domain.dto.ChatResponse;
 
 public interface ChatMessageService {
 
 	void save(UUID conversationId, UUID senderId, String senderRole, String message);
+
+	Page<ChatResponse.Search> getMessages(
+		UUID conversationId,
+		Instant cursor,
+		Pageable pageable
+	);
 }

--- a/src/main/java/com/kt/chat/service/ChatMessageServiceImpl.java
+++ b/src/main/java/com/kt/chat/service/ChatMessageServiceImpl.java
@@ -1,11 +1,14 @@
 package com.kt.chat.service;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.UUID;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.kt.chat.domain.dto.ChatResponse;
 import com.kt.chat.domain.entity.ChatMessageEntity;
 import com.kt.chat.repository.chatmessage.ChatMessageRepository;
 
@@ -16,10 +19,25 @@ import lombok.RequiredArgsConstructor;
 @Transactional
 public class ChatMessageServiceImpl implements ChatMessageService {
 
-	private final ChatMessageRepository messageRepository;
+	private final ChatMessageRepository chatMessageRepository;
 
+	@Override
 	public void save(UUID conversationId, UUID senderId, String senderRole, String message) {
 		ChatMessageEntity msg = ChatMessageEntity.create(conversationId, senderId, senderRole, message);
-		messageRepository.save(msg);
+		chatMessageRepository.save(msg);
+	}
+
+	@Override
+	public Page<ChatResponse.Search> getMessages(
+		UUID conversationId,
+		Instant cursor,
+		Pageable pageable
+	) {
+		return chatMessageRepository.findByConversationIdWithCursor(
+			pageable,
+			conversationId,
+			cursor
+		).map(ChatResponse.Search::from);
+
 	}
 }

--- a/src/main/java/com/kt/config/SwaggerConfiguration.java
+++ b/src/main/java/com/kt/config/SwaggerConfiguration.java
@@ -45,7 +45,7 @@ public class SwaggerConfiguration {
 	public GroupedOpenApi userApi() {
 		return GroupedOpenApi.builder()
 			.group("User API")
-			.pathsToExclude("/api/admin/**")
+			.pathsToExclude("/api/admin/**", "/api/seller/**")
 			.build();
 	}
 

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -4,18 +4,23 @@
     <meta charset="UTF-8"/>
     <title>TECHUP 상담 시스템</title>
     <link href="/main.css" rel="stylesheet"/>
+    <link
+            as="style"
+            crossorigin
+            href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.css"
+            rel="stylesheet"
+    />
 
     <!-- STOMP -->
     <script src="https://cdn.jsdelivr.net/npm/stompjs@2.3.3/lib/stomp.min.js"></script>
 </head>
 <body>
-
 <div class="app">
-    <h1>TECHUP AI 상담 시스템</h1>
+    <h1>TECHUP AI 상담시스템</h1>
 
     <!-- 로그인 -->
     <section class="box" id="loginBox">
-        <h2>로그인</h2>
+        <div class="subtitle">로그인</div>
         <input id="loginId" placeholder="아이디"/>
         <input id="loginPw" placeholder="비밀번호" type="password"/>
         <button id="loginBtn">로그인</button>
@@ -31,24 +36,23 @@
     <!-- 사용자 -->
     <section class="panel" id="userPanel">
         <h2>사용자 화면</h2>
-
-        <div class="box">
-            <h3>AI FAQ</h3>
-            <div class="messages" id="aiMessages"></div>
-            <input id="aiInput" placeholder="AI에게 질문"/>
-            <button id="aiSendBtn">질문</button>
-            <div class="status">
-                conversationId: <span id="userConversationId">-</span>
+        <div class="wrap">
+            <div class="box">
+                <div class="subtitle">AI FAQ</div>
+                <div class="messages" id="aiMessages"></div>
+                <input id="aiInput" placeholder="AI에게 질문"/>
+                <button id="aiSendBtn">질문</button>
             </div>
-        </div>
 
-        <div class="box">
-            <h3>상담 채팅</h3>
-            <button disabled id="userConnectBtn">상담 연결</button>
-            <div class="messages" id="userChatMessages"></div>
-            <input id="userMessageInput" placeholder="메시지 입력"/>
-            <button disabled id="userSendBtn">전송</button>
-            <div class="status" id="userStatus">대기중</div>
+            <div class="box">
+                <div class="subtitle">상담 채팅</div>
+                <div class="status">conversationId: <span id="userConversationId">-</span></div>
+                <button disabled id="userConnectBtn">상담 연결</button>
+                <div class="messages" id="userChatMessages"></div>
+                <input id="userMessageInput" placeholder="메시지 입력"/>
+                <button disabled id="userSendBtn">전송</button>
+                <div class="status" id="userStatus">대기중</div>
+            </div>
         </div>
     </section>
 
@@ -56,19 +60,28 @@
     <section class="panel" id="adminPanel">
         <h2>관리자 화면</h2>
 
-        <button id="adminConnectBtn">관리자 연결</button>
+        <div class="wrap">
+            <button id="adminConnectBtn">관리자 연결</button>
 
-        <div class="box">
-            <h3>상담 대기 목록</h3>
-            <div class="list" id="waitingList"></div>
-        </div>
+            <div class="box">
+                <div class="subtitle">채팅방 목록</div>
 
-        <div class="box">
-            <h3>상담중</h3>
-            conversationId: <span id="adminConversationId">-</span>
-            <div class="messages" id="adminChatMessages"></div>
-            <input id="adminMessageInput" placeholder="메시지 입력"/>
-            <button disabled id="adminSendBtn">전송</button>
+                <div class="tabs">
+                    <button id="allRoomsBtn">전체</button>
+                    <button id="waitingRoomsBtn">대기중</button>
+                    <button id="connectedRoomsBtn">상담중</button>
+                </div>
+
+                <div class="list" id="roomList"></div>
+            </div>
+
+            <div class="box">
+                <div>conversationId: <span id="adminConversationId">-</span></div>
+
+                <div class="messages" id="adminChatMessages"></div>
+                <input id="adminMessageInput" placeholder="메시지 입력"/>
+                <button disabled id="adminSendBtn">전송</button>
+            </div>
         </div>
     </section>
 </div>

--- a/src/main/resources/static/main.css
+++ b/src/main/resources/static/main.css
@@ -1,41 +1,111 @@
+/* ---------- Global ---------- */
 body {
+    font-family: Pretendard;
     background: #0f172a;
     color: #e5e7eb;
-    font-family: Arial, sans-serif;
+    display: flex;
+    justify-content: center;
 }
 
 .app {
-    max-width: 900px;
-    margin: auto;
-    padding: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    width: 100%;
+    max-width: 800px;
+}
+
+.subtitle {
+    font-size: 24px;
+    font-weight: 600;
+    margin: 8px 0px;
+}
+
+.wrap {
+    display: flex;
+    flex-direction: column;
+
+    gap: 16px;
 }
 
 .box {
-    border: 1px solid #334155;
-    padding: 10px;
-    margin-bottom: 15px;
+    display: flex;
+    flex-direction: column;
+
+    background: #020617;
+    border: 1px solid #1e293b;
+    border-radius: 16px;
+    padding: 16px;
+
+    gap: 8px;
+    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.4);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.box:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 12px 28px rgba(0, 0, 0, 0.55);
 }
 
 input {
-    width: 100%;
-    margin: 4px 0;
+    padding: 8px 10px;
+    border-radius: 8px;
+    border: 1px solid #334155;
+    background: #020617;
+    color: #e5e7eb;
+    outline: none;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
+input::placeholder {
+    color: #64748b;
+}
+
+input:focus {
+    border-color: #3b82f6;
+    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.3);
+}
+
+/* ---------- Buttons ---------- */
 button {
-    background: #2563eb;
+    background: linear-gradient(135deg, #2563eb, #3b82f6);
     color: white;
     border: none;
-    padding: 6px;
-    margin-top: 5px;
+    padding: 8px;
+    border-radius: 10px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 0.15s ease, box-shadow 0.15s ease, opacity 0.15s ease;
+}
+
+button:hover:not(:disabled) {
+    transform: translateY(-1px);
+    box-shadow: 0 6px 16px rgba(59, 130, 246, 0.4);
+}
+
+button:active:not(:disabled) {
+    transform: translateY(0);
+    box-shadow: 0 4px 10px rgba(59, 130, 246, 0.3);
 }
 
 button:disabled {
     opacity: 0.4;
+    cursor: not-allowed;
 }
 
 .tabs {
     display: flex;
-    gap: 10px;
+    gap: 4px;
+}
+
+.tabs button {
+    background: #020617;
+    border: 1px solid #334155;
+}
+
+.tabs button.active {
+    background: #2563eb;
+    border-color: #2563eb;
 }
 
 .panel {
@@ -48,20 +118,39 @@ button:disabled {
 
 .messages {
     background: #020617;
-    height: 150px;
+    border: 1px solid #1e293b;
+    border-radius: 10px;
+    height: 180px;
     overflow-y: auto;
-    padding: 5px;
-    margin-bottom: 5px;
+    padding: 8px;
+    font-size: 14px;
+}
+
+.messages div {
+    padding: 4px 6px;
+    border-radius: 6px;
+    margin-bottom: 4px;
+}
+
+.messages div:nth-child(odd) {
+    background: rgba(148, 163, 184, 0.05);
 }
 
 .status {
-    font-size: 13px;
+    font-size: 12px;
     color: #94a3b8;
 }
 
 .list div {
     border: 1px solid #334155;
-    padding: 5px;
-    margin-bottom: 4px;
+    background: #020617;
+    padding: 8px;
+    border-radius: 10px;
     cursor: pointer;
+    transition: background 0.15s ease, transform 0.15s ease;
+}
+
+.list div:hover {
+    background: #0f172a;
+    transform: translateX(1px);
 }

--- a/src/main/resources/static/main.js
+++ b/src/main/resources/static/main.js
@@ -4,8 +4,11 @@
 let userStomp = null;
 let adminStomp = null;
 let conversationId = null;
-let loggedIn = false;
 let accessToken = null;
+let aiLocked = false;
+
+let userCursor = null;
+let adminCursor = null;
 
 /*********************************
  * 공통 fetch (JWT 자동 포함)
@@ -42,8 +45,6 @@ loginBtn.onclick = async () => {
     accessToken = json.data.accessToken;
 
     loginStatus.textContent = "로그인 성공";
-    loggedIn = true;
-
     userTab.disabled = false;
     adminTab.disabled = false;
     switchTab(true);
@@ -81,38 +82,77 @@ function connectWS(onConnect) {
  * AI FAQ
  *********************************/
 aiSendBtn.onclick = async () => {
+    if (aiLocked) return;
+
     const q = aiInput.value;
     if (!q) return;
+
+    // 요청 중에는 무조건 버튼 비활성화
+    aiSendBtn.disabled = true;
 
     add(aiMessages, "ME", q);
     aiInput.value = "";
 
-    const res = await authFetch("/api/ai/faq", {
-        method: "POST",
-        headers: {"Content-Type": "application/json"},
-        body: JSON.stringify({
-            question: q,
-        }),
-    });
+    try {
+        const res = await authFetch("/api/ai/faq", {
+            method: "POST",
+            headers: {"Content-Type": "application/json"},
+            body: JSON.stringify({question: q}),
+        });
 
-    if (!res.ok) {
-        add(aiMessages, "ERROR", "AI 호출 실패");
-        return;
-    }
+        if (!res.ok) {
+            add(aiMessages, "ERROR", "AI 호출 실패");
+            return;
+        }
 
-    const json = await res.json();
-    const data = json.data;
+        const json = await res.json();
+        const data = json.data;
 
-    add(aiMessages, "AI", data.answer);
+        add(aiMessages, "AI", data.answer);
 
-    conversationId = data.conversationId;
-    userConversationId.textContent = conversationId;
+        conversationId = data.conversationId;
+        userConversationId.textContent = conversationId;
 
-    if (data.handoverTriggered) {
-        add(aiMessages, "SYSTEM", "상담사 대기중입니다.");
-        userConnectBtn.disabled = false;
+        if (data.handoverTriggered) {
+            add(aiMessages, "SYSTEM", "상담사 대기중입니다.");
+            userConnectBtn.disabled = false;
+
+            aiLocked = true;
+            aiSendBtn.disabled = true;
+            return;
+        }
+
+        // 정상 응답이면 다시 질문 가능
+        aiSendBtn.disabled = false;
+    } catch (e) {
+        add(aiMessages, "ERROR", "네트워크 오류");
+        aiSendBtn.disabled = false;
     }
 };
+
+/*********************************
+ * 채팅 내역 로드 (REST)
+ *********************************/
+async function loadChatMessages(conversationId, container, cursor = null) {
+    const params = new URLSearchParams();
+    params.append("size", 20);
+    if (cursor) params.append("cursor", cursor);
+
+    const res = await authFetch(`/api/chat/${conversationId}/messages?${params.toString()}`);
+
+    if (!res.ok) return null;
+
+    const json = await res.json();
+    const page = json.data;
+    const messages = page.list;
+
+    // 서버 DESC → 화면 ASC
+    messages.reverse().forEach((m) => {
+        add(container, m.senderRole === "ADMIN" ? "ADMIN" : "MEMBER", m.message);
+    });
+
+    return messages.length > 0 ? messages[0].createdAt : null;
+}
 
 /*********************************
  * 사용자 채팅
@@ -120,43 +160,31 @@ aiSendBtn.onclick = async () => {
 userConnectBtn.onclick = async () => {
     if (!conversationId) return;
 
-    const res = await authFetch("/api/chat/apply", {
+    await authFetch("/api/chat/apply", {
         method: "POST",
         headers: {"Content-Type": "application/json"},
-        body: JSON.stringify({
-            conversationId: conversationId
-        }),
+        body: JSON.stringify({conversationId}),
     });
 
-    if (!res.ok) {
-        add(aiMessages, "ERROR", "상담 신청 실패");
-        return;
-    }
+    userChatMessages.innerHTML = "";
+    userCursor = await loadChatMessages(conversationId, userChatMessages);
 
     userStomp = connectWS(() => {
         userStomp.subscribe(`/sub/chat/${conversationId}`, (msg) => {
             const payload = JSON.parse(msg.body);
-
-            if (payload.senderRole === "MEMBER") {
-                add(userChatMessages, "ME", payload.message);
-            } else {
-                add(userChatMessages, "ADMIN", payload.message);
-            }
+            add(userChatMessages, payload.senderRole, payload.message);
         });
 
         userSendBtn.disabled = false;
         userStatus.textContent = "상담중";
     });
 };
+
 userSendBtn.onclick = () => {
     const msg = userMessageInput.value;
     if (!msg) return;
 
-    userStomp.send(
-        `/pub/chat/${conversationId}`,
-        {},
-        JSON.stringify({message: msg})
-    );
+    userStomp.send(`/pub/chat/${conversationId}`, {}, JSON.stringify({message: msg}));
 
     userMessageInput.value = "";
 };
@@ -164,57 +192,73 @@ userSendBtn.onclick = () => {
 /*********************************
  * 관리자
  *********************************/
-adminConnectBtn.onclick = () => {
-    adminStomp = connectWS(loadWaiting);
-};
+async function loadRooms(type) {
+    let url = "/api/admin/chat/rooms";
 
-async function loadWaiting() {
-    const res = await authFetch("/api/admin/chat/rooms/waiting");
+    if (type === "waiting") url += "/waiting";
+    if (type === "connected") url += "/connected";
+
+    const res = await authFetch(url);
+    if (!res.ok) return;
 
     const json = await res.json();
     const rooms = json.data;
-    waitingList.innerHTML = "";
+
+    roomList.innerHTML = "";
 
     rooms.forEach((r) => {
         const div = document.createElement("div");
-        div.textContent = r.conversationId;
-        div.onclick = () => accept(r.conversationId);
-        waitingList.appendChild(div);
+        div.textContent = `[${r.status}] ${r.conversationId}`;
+        div.onclick = () => openRoom(r.conversationId, r.status);
+        roomList.appendChild(div);
     });
 }
 
-async function accept(cid) {
-    await authFetch("/api/admin/chat/rooms/handover/accept", {
-        method: "POST",
-        headers: {"Content-Type": "application/json"},
-        body: JSON.stringify(cid),
-    });
-
+async function openRoom(cid, status) {
     conversationId = cid;
     adminConversationId.textContent = cid;
+    adminChatMessages.innerHTML = "";
 
-    adminStomp.subscribe(`/sub/chat/${conversationId}`, (msg) => {
+    if (status === "WAITING") {
+        await authFetch("/api/admin/chat/rooms/handover/accept", {
+            method: "POST",
+            headers: {"Content-Type": "application/json"},
+            body: JSON.stringify({conversationId: cid}),
+        });
+    }
+
+    adminCursor = await loadChatMessages(cid, adminChatMessages);
+
+    if (adminStomp && adminStomp.subscription) {
+        adminStomp.subscription.unsubscribe();
+    }
+
+    adminStomp.subscription = adminStomp.subscribe(`/sub/chat/${cid}`, (msg) => {
         const payload = JSON.parse(msg.body);
-
-        if (payload.senderRole === "ADMIN") {
-            add(adminChatMessages, "ME", payload.message);
-        } else {
-            add(adminChatMessages, "USER", payload.message);
-        }
+        add(adminChatMessages, payload.senderRole, payload.message);
     });
 
     adminSendBtn.disabled = false;
 }
 
+adminConnectBtn.onclick = () => {
+    adminStomp = connectWS(() => {
+        loadRooms("waiting");
+    });
+};
+
+allRoomsBtn.onclick = () => loadRooms("all");
+waitingRoomsBtn.onclick = () => loadRooms("waiting");
+connectedRoomsBtn.onclick = () => loadRooms("connected");
+
+/*********************************
+ * 관리자 메시지 전송
+ *********************************/
 adminSendBtn.onclick = () => {
     const msg = adminMessageInput.value;
     if (!msg) return;
 
-    adminStomp.send(
-        `/pub/chat/${conversationId}`,
-        {},
-        JSON.stringify({message: msg})
-    );
+    adminStomp.send(`/pub/chat/${conversationId}`, {}, JSON.stringify({message: msg}));
 
     adminMessageInput.value = "";
 };

--- a/src/main/resources/static/main.js
+++ b/src/main/resources/static/main.js
@@ -170,12 +170,9 @@ adminConnectBtn.onclick = () => {
 
 async function loadWaiting() {
     const res = await authFetch("/api/admin/chat/rooms/waiting");
-    // if (!res.ok) return;
-    console.log(res);
 
     const json = await res.json();
     const rooms = json.data;
-    console.log(rooms);
     waitingList.innerHTML = "";
 
     rooms.forEach((r) => {

--- a/src/main/resources/static/main.js
+++ b/src/main/resources/static/main.js
@@ -89,8 +89,10 @@ aiSendBtn.onclick = async () => {
 
     const res = await authFetch("/api/ai/faq", {
         method: "POST",
-        headers: {"Content-Type": "text/plain"},
-        body: q,
+        headers: {"Content-Type": "application/json"},
+        body: JSON.stringify({
+            question: q,
+        }),
     });
 
     if (!res.ok) {
@@ -115,7 +117,22 @@ aiSendBtn.onclick = async () => {
 /*********************************
  * 사용자 채팅
  *********************************/
-userConnectBtn.onclick = () => {
+userConnectBtn.onclick = async () => {
+    if (!conversationId) return;
+
+    const res = await authFetch("/api/chat/apply", {
+        method: "POST",
+        headers: {"Content-Type": "application/json"},
+        body: JSON.stringify({
+            conversationId: conversationId
+        }),
+    });
+
+    if (!res.ok) {
+        add(aiMessages, "ERROR", "상담 신청 실패");
+        return;
+    }
+
     userStomp = connectWS(() => {
         userStomp.subscribe(`/sub/chat/${conversationId}`, (msg) => {
             const payload = JSON.parse(msg.body);
@@ -131,7 +148,6 @@ userConnectBtn.onclick = () => {
         userStatus.textContent = "상담중";
     });
 };
-
 userSendBtn.onclick = () => {
     const msg = userMessageInput.value;
     if (!msg) return;
@@ -154,9 +170,12 @@ adminConnectBtn.onclick = () => {
 
 async function loadWaiting() {
     const res = await authFetch("/api/admin/chat/rooms/waiting");
-    if (!res.ok) return;
+    // if (!res.ok) return;
+    console.log(res);
 
-    const rooms = await res.json();
+    const json = await res.json();
+    const rooms = json.data;
+    console.log(rooms);
     waitingList.innerHTML = "";
 
     rooms.forEach((r) => {


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- resolves: #이슈번호, #이슈번호 -->
resolves:

## 📝작업 내용

RAGService 내에서 ChatRoomService를 호출하는 로직을 삭제하고,
유저가 '상담 연결' 버튼을 눌러야 대화방이 생성되며 관리자 대기중인 상담 조회가 가능합니다.

현재 화면상으로는 대화방이 분리되어있어 UX가 좋지 않지만 1개 대화방 내에서
'관리자와 연결하기'와 같은 버튼이 있어 누르고 대기하는 방식을 기대합니다.

AIChatSessionStore 내 TODO를 추가했는데,
현재 로직은 

첫 질문 시 레디스 AI_CHAT_SESSION 키 생성 -> 첫 실패시 AI_CHAT_FAIL 키 생성 -> 실패횟수 관리 
-> 3회 이상시 AI_CHAT_SESSION키 삭제 -> 상담 연결 버튼 누를시 대화방 생성

로 작동하고 있습니다. 실패 횟수는 레디스 내 AI_CHAT_FAIL 키로 관리하고 있어 한 계정으로 3회 실패 시,
값이 남아있다면 언제든 항상 대화 실패로 작동하고 있습니다. 

AIChatSessionStore.clear 내에서 모든 키를 삭제하면 AI채팅 <-> 관리자채팅이 무한 반복이 가능하여
AI_CHAT_FAIL키는 삭제하지 않았습니다.

해당 부분 AI 채팅 키 관련 발표 이전까지 고민해보겠습니다.


<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->