### PR TITLE
[FEAT] 관리자 채팅방 내역 조회 및 채팅 내역 불러오기 기능 구현

### DIFF
--- a/src/main/java/com/kt/ai/service/RAGServiceImpl.java
+++ b/src/main/java/com/kt/ai/service/RAGServiceImpl.java
@@ -45,7 +45,7 @@ public class RAGServiceImpl implements RAGService {
 				chatSessionStore.clear(userId);
 
 				return new FAQResponse.ChatBot(
-					"정확한 답변이 어려워 상담사에게 연결해드릴게요. 상담연결 버튼을 누른 후 대기 부탁드려요.",
+					"정확한 답변이 어려워 상담사에게 연결해드릴게요. 상담 연결 버튼을 누른 후 메시지를 보내시고 대기 부탁드려요.",
 					conversationId,
 					true
 				);

--- a/src/main/java/com/kt/chat/controller/ChatController.java
+++ b/src/main/java/com/kt/chat/controller/ChatController.java
@@ -3,8 +3,10 @@ package com.kt.chat.controller;
 import static com.kt.common.api.ApiResult.*;
 
 import java.security.Principal;
+import java.time.Instant;
 import java.util.UUID;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
@@ -13,14 +15,18 @@ import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import com.kt.chat.domain.dto.ChatRequest;
 import com.kt.chat.domain.dto.ChatResponse;
 import com.kt.chat.service.ChatMessageService;
 import com.kt.chat.service.ChatRoomService;
 import com.kt.common.api.ApiResult;
+import com.kt.common.api.PageResponse;
 import com.kt.security.DefaultCurrentUser;
 
 import lombok.RequiredArgsConstructor;
@@ -45,6 +51,19 @@ public class ChatController implements ChatSwaggerSupporter {
 		);
 
 		return empty();
+	}
+
+	@GetMapping("/api/chat/{conversationId}/messages")
+	public ResponseEntity<ApiResult<PageResponse<ChatResponse.Search>>> messages(
+		@PathVariable UUID conversationId,
+		@RequestParam(required = false) Instant cursor,
+		Pageable pageable
+	) {
+		return page(chatMessageService.getMessages(
+			conversationId,
+			cursor,
+			pageable
+		));
 	}
 
 	@MessageMapping("/chat/{conversationId}")

--- a/src/main/java/com/kt/chat/domain/dto/ChatResponse.java
+++ b/src/main/java/com/kt/chat/domain/dto/ChatResponse.java
@@ -1,6 +1,10 @@
 package com.kt.chat.domain.dto;
 
+import java.time.Instant;
 import java.util.UUID;
+
+import com.kt.chat.domain.entity.ChatMessageEntity;
+import com.querydsl.core.annotations.QueryProjection;
 
 public class ChatResponse {
 	public record Message(
@@ -10,4 +14,29 @@ public class ChatResponse {
 	) {
 
 	}
+
+	public record Search(
+		UUID id,
+		UUID senderId,
+		String senderRole,
+		String message,
+		Instant createdAt
+	) {
+		@QueryProjection
+		public Search {
+
+		}
+
+		public static Search from(ChatMessageEntity chatMessageEntity) {
+			return new Search(
+				chatMessageEntity.getId(),
+				chatMessageEntity.getSenderId(),
+				chatMessageEntity.getSenderRole(),
+				chatMessageEntity.getMessage(),
+				chatMessageEntity.getCreatedAt()
+			);
+		}
+
+	}
+
 }

--- a/src/main/java/com/kt/chat/repository/chatmessage/ChatMessageRepository.java
+++ b/src/main/java/com/kt/chat/repository/chatmessage/ChatMessageRepository.java
@@ -6,6 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.kt.chat.domain.entity.ChatMessageEntity;
 
-public interface ChatMessageRepository extends JpaRepository<ChatMessageEntity, UUID> {
+public interface ChatMessageRepository extends JpaRepository<ChatMessageEntity, UUID>, ChatMessageRepositoryCustom {
 
 }

--- a/src/main/java/com/kt/chat/repository/chatmessage/ChatMessageRepositoryCustom.java
+++ b/src/main/java/com/kt/chat/repository/chatmessage/ChatMessageRepositoryCustom.java
@@ -1,0 +1,18 @@
+package com.kt.chat.repository.chatmessage;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import com.kt.chat.domain.entity.ChatMessageEntity;
+
+public interface ChatMessageRepositoryCustom {
+
+	Page<ChatMessageEntity> findByConversationIdWithCursor(
+		Pageable pageable,
+		UUID conversationId,
+		Instant cursor
+	);
+}

--- a/src/main/java/com/kt/chat/repository/chatmessage/ChatMessageRepositoryImpl.java
+++ b/src/main/java/com/kt/chat/repository/chatmessage/ChatMessageRepositoryImpl.java
@@ -17,7 +17,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
-public class ChatMesseageRepositoryImpl implements ChatMessageRepositoryCustom {
+public class ChatMessageRepositoryImpl implements ChatMessageRepositoryCustom {
 
 	private final JPAQueryFactory jpaQueryFactory;
 	private final QChatMessageEntity chatMessage = QChatMessageEntity.chatMessageEntity;

--- a/src/main/java/com/kt/chat/repository/chatmessage/ChatMesseageRepositoryImpl.java
+++ b/src/main/java/com/kt/chat/repository/chatmessage/ChatMesseageRepositoryImpl.java
@@ -1,0 +1,66 @@
+package com.kt.chat.repository.chatmessage;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import com.kt.chat.domain.entity.ChatMessageEntity;
+import com.kt.chat.domain.entity.QChatMessageEntity;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class ChatMesseageRepositoryImpl implements ChatMessageRepositoryCustom {
+
+	private final JPAQueryFactory jpaQueryFactory;
+	private final QChatMessageEntity chatMessage = QChatMessageEntity.chatMessageEntity;
+
+	@Override
+	public Page<ChatMessageEntity> findByConversationIdWithCursor(
+		Pageable pageable,
+		UUID conversationId,
+		Instant cursor
+	) {
+		BooleanBuilder booleanBuilder = new BooleanBuilder();
+		booleanBuilder.and(eqConversationId(conversationId));
+		booleanBuilder.and(ltCursor(cursor));
+
+		List<ChatMessageEntity> content = jpaQueryFactory
+			.selectFrom(chatMessage)
+			.where(booleanBuilder)
+			.orderBy(chatMessage.createdAt.desc())
+			.limit(pageable.getPageSize())
+			.fetch();
+
+		int total = jpaQueryFactory
+			.select(chatMessage.id)
+			.from(chatMessage)
+			.where(eqConversationId(conversationId))
+			.fetch()
+			.size();
+
+		return new PageImpl<>(content, pageable, total);
+	}
+
+	private BooleanExpression eqConversationId(UUID conversationId) {
+		if (conversationId == null) {
+			return null;
+		}
+		return chatMessage.conversationId.eq(conversationId);
+	}
+
+	private BooleanExpression ltCursor(Instant cursor) {
+		if (cursor == null) {
+			return null;
+		}
+		return chatMessage.createdAt.lt(cursor);
+	}
+
+}

--- a/src/main/java/com/kt/chat/service/ChatMessageService.java
+++ b/src/main/java/com/kt/chat/service/ChatMessageService.java
@@ -1,8 +1,20 @@
 package com.kt.chat.service;
 
+import java.time.Instant;
 import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import com.kt.chat.domain.dto.ChatResponse;
 
 public interface ChatMessageService {
 
 	void save(UUID conversationId, UUID senderId, String senderRole, String message);
+
+	Page<ChatResponse.Search> getMessages(
+		UUID conversationId,
+		Instant cursor,
+		Pageable pageable
+	);
 }

--- a/src/main/java/com/kt/chat/service/ChatMessageServiceImpl.java
+++ b/src/main/java/com/kt/chat/service/ChatMessageServiceImpl.java
@@ -1,11 +1,14 @@
 package com.kt.chat.service;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.UUID;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.kt.chat.domain.dto.ChatResponse;
 import com.kt.chat.domain.entity.ChatMessageEntity;
 import com.kt.chat.repository.chatmessage.ChatMessageRepository;
 
@@ -16,10 +19,23 @@ import lombok.RequiredArgsConstructor;
 @Transactional
 public class ChatMessageServiceImpl implements ChatMessageService {
 
-	private final ChatMessageRepository messageRepository;
+	private final ChatMessageRepository chatMessageRepository;
 
 	public void save(UUID conversationId, UUID senderId, String senderRole, String message) {
 		ChatMessageEntity msg = ChatMessageEntity.create(conversationId, senderId, senderRole, message);
-		messageRepository.save(msg);
+		chatMessageRepository.save(msg);
+	}
+
+	public Page<ChatResponse.Search> getMessages(
+		UUID conversationId,
+		Instant cursor,
+		Pageable pageable
+	) {
+		return chatMessageRepository.findByConversationIdWithCursor(
+			pageable,
+			conversationId,
+			cursor
+		).map(ChatResponse.Search::from);
+
 	}
 }

--- a/src/main/java/com/kt/chat/service/ChatMessageServiceImpl.java
+++ b/src/main/java/com/kt/chat/service/ChatMessageServiceImpl.java
@@ -21,11 +21,13 @@ public class ChatMessageServiceImpl implements ChatMessageService {
 
 	private final ChatMessageRepository chatMessageRepository;
 
+	@Override
 	public void save(UUID conversationId, UUID senderId, String senderRole, String message) {
 		ChatMessageEntity msg = ChatMessageEntity.create(conversationId, senderId, senderRole, message);
 		chatMessageRepository.save(msg);
 	}
 
+	@Override
 	public Page<ChatResponse.Search> getMessages(
 		UUID conversationId,
 		Instant cursor,

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -4,18 +4,23 @@
     <meta charset="UTF-8"/>
     <title>TECHUP 상담 시스템</title>
     <link href="/main.css" rel="stylesheet"/>
+    <link
+            as="style"
+            crossorigin
+            href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.css"
+            rel="stylesheet"
+    />
 
     <!-- STOMP -->
     <script src="https://cdn.jsdelivr.net/npm/stompjs@2.3.3/lib/stomp.min.js"></script>
 </head>
 <body>
-
 <div class="app">
-    <h1>TECHUP AI 상담 시스템</h1>
+    <h1>TECHUP AI 상담시스템</h1>
 
     <!-- 로그인 -->
     <section class="box" id="loginBox">
-        <h2>로그인</h2>
+        <div class="subtitle">로그인</div>
         <input id="loginId" placeholder="아이디"/>
         <input id="loginPw" placeholder="비밀번호" type="password"/>
         <button id="loginBtn">로그인</button>
@@ -31,24 +36,23 @@
     <!-- 사용자 -->
     <section class="panel" id="userPanel">
         <h2>사용자 화면</h2>
-
-        <div class="box">
-            <h3>AI FAQ</h3>
-            <div class="messages" id="aiMessages"></div>
-            <input id="aiInput" placeholder="AI에게 질문"/>
-            <button id="aiSendBtn">질문</button>
-            <div class="status">
-                conversationId: <span id="userConversationId">-</span>
+        <div class="wrap">
+            <div class="box">
+                <div class="subtitle">AI FAQ</div>
+                <div class="messages" id="aiMessages"></div>
+                <input id="aiInput" placeholder="AI에게 질문"/>
+                <button id="aiSendBtn">질문</button>
             </div>
-        </div>
 
-        <div class="box">
-            <h3>상담 채팅</h3>
-            <button disabled id="userConnectBtn">상담 연결</button>
-            <div class="messages" id="userChatMessages"></div>
-            <input id="userMessageInput" placeholder="메시지 입력"/>
-            <button disabled id="userSendBtn">전송</button>
-            <div class="status" id="userStatus">대기중</div>
+            <div class="box">
+                <div class="subtitle">상담 채팅</div>
+                <div class="status">conversationId: <span id="userConversationId">-</span></div>
+                <button disabled id="userConnectBtn">상담 연결</button>
+                <div class="messages" id="userChatMessages"></div>
+                <input id="userMessageInput" placeholder="메시지 입력"/>
+                <button disabled id="userSendBtn">전송</button>
+                <div class="status" id="userStatus">대기중</div>
+            </div>
         </div>
     </section>
 
@@ -56,26 +60,28 @@
     <section class="panel" id="adminPanel">
         <h2>관리자 화면</h2>
 
-        <button id="adminConnectBtn">관리자 연결</button>
+        <div class="wrap">
+            <button id="adminConnectBtn">관리자 연결</button>
 
-        <div class="box">
-            <h3>채팅방 목록</h3>
+            <div class="box">
+                <div class="subtitle">채팅방 목록</div>
 
-            <div class="tabs">
-                <button id="allRoomsBtn">전체</button>
-                <button id="waitingRoomsBtn">대기중</button>
-                <button id="connectedRoomsBtn">상담중</button>
+                <div class="tabs">
+                    <button id="allRoomsBtn">전체</button>
+                    <button id="waitingRoomsBtn">대기중</button>
+                    <button id="connectedRoomsBtn">상담중</button>
+                </div>
+
+                <div class="list" id="roomList"></div>
             </div>
 
-            <div class="list" id="roomList"></div>
-        </div>
+            <div class="box">
+                <div>conversationId: <span id="adminConversationId">-</span></div>
 
-        <div class="box">
-            <h3>상담중</h3>
-            conversationId: <span id="adminConversationId">-</span>
-            <div class="messages" id="adminChatMessages"></div>
-            <input id="adminMessageInput" placeholder="메시지 입력"/>
-            <button disabled id="adminSendBtn">전송</button>
+                <div class="messages" id="adminChatMessages"></div>
+                <input id="adminMessageInput" placeholder="메시지 입력"/>
+                <button disabled id="adminSendBtn">전송</button>
+            </div>
         </div>
     </section>
 </div>

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -59,8 +59,15 @@
         <button id="adminConnectBtn">관리자 연결</button>
 
         <div class="box">
-            <h3>상담 대기 목록</h3>
-            <div class="list" id="waitingList"></div>
+            <h3>채팅방 목록</h3>
+
+            <div class="tabs">
+                <button id="allRoomsBtn">전체</button>
+                <button id="waitingRoomsBtn">대기중</button>
+                <button id="connectedRoomsBtn">상담중</button>
+            </div>
+
+            <div class="list" id="roomList"></div>
         </div>
 
         <div class="box">

--- a/src/main/resources/static/main.css
+++ b/src/main/resources/static/main.css
@@ -1,41 +1,111 @@
+/* ---------- Global ---------- */
 body {
+    font-family: Pretendard;
     background: #0f172a;
     color: #e5e7eb;
-    font-family: Arial, sans-serif;
+    display: flex;
+    justify-content: center;
 }
 
 .app {
-    max-width: 900px;
-    margin: auto;
-    padding: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    width: 100%;
+    max-width: 800px;
+}
+
+.subtitle {
+    font-size: 24px;
+    font-weight: 600;
+    margin: 8px 0px;
+}
+
+.wrap {
+    display: flex;
+    flex-direction: column;
+
+    gap: 16px;
 }
 
 .box {
-    border: 1px solid #334155;
-    padding: 10px;
-    margin-bottom: 15px;
+    display: flex;
+    flex-direction: column;
+
+    background: #020617;
+    border: 1px solid #1e293b;
+    border-radius: 16px;
+    padding: 16px;
+
+    gap: 8px;
+    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.4);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.box:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 12px 28px rgba(0, 0, 0, 0.55);
 }
 
 input {
-    width: 100%;
-    margin: 4px 0;
+    padding: 8px 10px;
+    border-radius: 8px;
+    border: 1px solid #334155;
+    background: #020617;
+    color: #e5e7eb;
+    outline: none;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
+input::placeholder {
+    color: #64748b;
+}
+
+input:focus {
+    border-color: #3b82f6;
+    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.3);
+}
+
+/* ---------- Buttons ---------- */
 button {
-    background: #2563eb;
+    background: linear-gradient(135deg, #2563eb, #3b82f6);
     color: white;
     border: none;
-    padding: 6px;
-    margin-top: 5px;
+    padding: 8px;
+    border-radius: 10px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 0.15s ease, box-shadow 0.15s ease, opacity 0.15s ease;
+}
+
+button:hover:not(:disabled) {
+    transform: translateY(-1px);
+    box-shadow: 0 6px 16px rgba(59, 130, 246, 0.4);
+}
+
+button:active:not(:disabled) {
+    transform: translateY(0);
+    box-shadow: 0 4px 10px rgba(59, 130, 246, 0.3);
 }
 
 button:disabled {
     opacity: 0.4;
+    cursor: not-allowed;
 }
 
 .tabs {
     display: flex;
-    gap: 10px;
+    gap: 4px;
+}
+
+.tabs button {
+    background: #020617;
+    border: 1px solid #334155;
+}
+
+.tabs button.active {
+    background: #2563eb;
+    border-color: #2563eb;
 }
 
 .panel {
@@ -48,20 +118,39 @@ button:disabled {
 
 .messages {
     background: #020617;
-    height: 150px;
+    border: 1px solid #1e293b;
+    border-radius: 10px;
+    height: 180px;
     overflow-y: auto;
-    padding: 5px;
-    margin-bottom: 5px;
+    padding: 8px;
+    font-size: 14px;
+}
+
+.messages div {
+    padding: 4px 6px;
+    border-radius: 6px;
+    margin-bottom: 4px;
+}
+
+.messages div:nth-child(odd) {
+    background: rgba(148, 163, 184, 0.05);
 }
 
 .status {
-    font-size: 13px;
+    font-size: 12px;
     color: #94a3b8;
 }
 
 .list div {
     border: 1px solid #334155;
-    padding: 5px;
-    margin-bottom: 4px;
+    background: #020617;
+    padding: 8px;
+    border-radius: 10px;
     cursor: pointer;
+    transition: background 0.15s ease, transform 0.15s ease;
+}
+
+.list div:hover {
+    background: #0f172a;
+    transform: translateX(1px);
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- resolves: #이슈번호, #이슈번호 -->
resolves:

## 📝작업 내용


관리자 측에서 채팅방 이동이 가능하도록 구현했습니다.

QueryDsl 사용하여 채팅 내역 불러오고, 클라이언트 측에서 채팅방 id 클릭할 때 
구독 변경하고 기존 채팅 내역 띄워줍니다.

스웨거, 테스트코드는 오늘 내로 다루도록 하겠습니다~!

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
### 스크린샷 (선택)

https://github.com/user-attachments/assets/2fd4dce0-e659-47e9-ac5b-d3df5d5b0200


## 💬리뷰 요구사항(선택)

이번 PR로 채팅 기능 구현은 마무리하도록 하겠습니다!
아마 세현님 영상 촬영하셨을 것 같은데, 이거는 제가 욕심낸거라 발표 영상에 반영은 진짜 마지막에 시간 남으시면 부탁드리겠습니다..

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->