### PR TITLE
[FEAT] 페이 잔액 조회 API 및 서비스 추가 #273

### DIFF
--- a/src/main/java/com/kt/controller/pay/PayController.java
+++ b/src/main/java/com/kt/controller/pay/PayController.java
@@ -2,15 +2,18 @@ package com.kt.controller.pay;
 
 import com.kt.common.api.ApiResult;
 import com.kt.domain.dto.request.PayRequest;
+import com.kt.domain.dto.response.PayResponse;
 import com.kt.security.DefaultCurrentUser;
 import com.kt.service.pay.PayChargeService;
 
+import com.kt.service.pay.PayService;
 import com.kt.service.pay.PayWithdrawalService;
 
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,7 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.UUID;
 
-import static com.kt.common.api.ApiResult.empty;
+import static com.kt.common.api.ApiResult.*;
 
 @RestController
 @RequestMapping("/api/pay")
@@ -27,6 +30,7 @@ public class PayController implements PaySwaggerSupporter {
 
 	private final PayChargeService payChargeService;
 	private final PayWithdrawalService payWithdrawalService;
+	private final PayService payService;
 
 	@PostMapping("/charges")
 	public ResponseEntity<ApiResult<Void>> charge(
@@ -49,5 +53,12 @@ public class PayController implements PaySwaggerSupporter {
 		return empty();
 	}
 
+	@GetMapping("/balance")
+	public ResponseEntity<ApiResult<PayResponse.Balance>> balance(
+		@AuthenticationPrincipal DefaultCurrentUser currentUser
+	) {
+		UUID userId = currentUser.getId();
+		return wrap(payService.getBalance(userId));
+	}
 
 }

--- a/src/main/java/com/kt/domain/dto/response/PayResponse.java
+++ b/src/main/java/com/kt/domain/dto/response/PayResponse.java
@@ -1,0 +1,16 @@
+package com.kt.domain.dto.response;
+
+import com.kt.domain.entity.PayEntity;
+
+import java.math.BigDecimal;
+
+public class PayResponse {
+
+	public record Balance(
+		BigDecimal balance
+	) {
+		public static Balance from(PayEntity pay) {
+			return new Balance(pay.getBalance());
+		}
+	}
+}

--- a/src/main/java/com/kt/service/pay/PayService.java
+++ b/src/main/java/com/kt/service/pay/PayService.java
@@ -1,0 +1,9 @@
+package com.kt.service.pay;
+
+import com.kt.domain.dto.response.PayResponse;
+
+import java.util.UUID;
+
+public interface PayService {
+	PayResponse.Balance getBalance(UUID userId);
+}

--- a/src/main/java/com/kt/service/pay/PayServiceImpl.java
+++ b/src/main/java/com/kt/service/pay/PayServiceImpl.java
@@ -1,0 +1,28 @@
+package com.kt.service.pay;
+
+import com.kt.domain.dto.response.PayResponse;
+import com.kt.domain.entity.PayEntity;
+import com.kt.domain.entity.UserEntity;
+
+import com.kt.repository.user.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class PayServiceImpl implements PayService {
+
+	private final UserRepository userRepository;
+
+	@Override
+	public PayResponse.Balance getBalance(UUID userId) {
+		UserEntity user = userRepository.findByIdOrThrow(userId);
+		PayEntity pay = user.getPay();
+		return PayResponse.Balance.from(pay);
+	}
+
+}

--- a/src/test/java/com/kt/api/pay/PayGetBalanceTest.java
+++ b/src/test/java/com/kt/api/pay/PayGetBalanceTest.java
@@ -1,0 +1,70 @@
+package com.kt.api.pay;
+
+import com.kt.common.MockMvcTest;
+import com.kt.common.UserEntityCreator;
+import com.kt.constant.AccountRole;
+import com.kt.domain.dto.request.PayRequest;
+import com.kt.domain.entity.UserEntity;
+import com.kt.repository.user.UserRepository;
+
+import com.kt.security.DefaultCurrentUser;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@Slf4j
+@ActiveProfiles("test")
+@DisplayName("주문 생성 - GET /api/pay/balance")
+public class PayGetBalanceTest extends MockMvcTest {
+
+	@Autowired
+	UserRepository userRepository;
+
+	UserEntity testUser;
+	DefaultCurrentUser authenticator;
+
+	static final long CHARGE_AMOUNT = 10_000;
+
+	@BeforeEach
+	void setup() {
+		testUser = UserEntityCreator.create();
+		userRepository.save(testUser);
+		testUser.getPay().charge(CHARGE_AMOUNT);
+
+		authenticator = new DefaultCurrentUser(
+			testUser.getId(),
+			testUser.getEmail(),
+			AccountRole.MEMBER
+		);
+	}
+
+	@Test
+	void 페이_잔액_조회_성공() throws Exception {
+		PayRequest.Charge request = new PayRequest.Charge(
+			CHARGE_AMOUNT
+		);
+
+		mockMvc.perform(
+				get("/api/pay/balance")
+					.with(user(authenticator))
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(request))
+			).andDo(print())
+			.andExpect(status().isOk())
+			.andReturn();
+
+		log.info("pay balance : {}", testUser.getPay().getBalance());
+
+	}
+}

--- a/src/test/java/com/kt/service/PayServiceTest.java
+++ b/src/test/java/com/kt/service/PayServiceTest.java
@@ -1,0 +1,56 @@
+package com.kt.service;
+
+import com.kt.common.UserEntityCreator;
+import com.kt.domain.dto.response.PayResponse;
+import com.kt.domain.entity.PayEntity;
+import com.kt.domain.entity.UserEntity;
+import com.kt.repository.user.UserRepository;
+
+import com.kt.service.pay.PayService;
+
+import jakarta.transaction.Transactional;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.math.BigDecimal;
+
+@Slf4j
+@SpringBootTest
+@ActiveProfiles("test")
+public class PayServiceTest {
+	@Autowired
+	UserRepository userRepository;
+
+	@Autowired
+	PayService payService;
+
+	UserEntity testUser;
+
+	static final long CHARGE_PAY_AMOUNT = 10_000;
+
+	@BeforeEach
+	void setup() {
+		testUser = UserEntityCreator.create();
+		userRepository.save(testUser);
+		PayEntity pay = testUser.getPay();
+		pay.charge(CHARGE_PAY_AMOUNT);
+	}
+
+	@Test
+	@Transactional
+	void 페이_잔액_조회_성공() {
+		PayResponse.Balance response = payService.getBalance(testUser.getId());
+
+		Assertions.assertNotNull(response);
+		Assertions.assertEquals(response.balance(), BigDecimal.valueOf(CHARGE_PAY_AMOUNT));
+		log.info("balance : {}", response.balance());
+
+	}
+}

--- a/src/test/java/com/kt/service/PayServiceTest.java
+++ b/src/test/java/com/kt/service/PayServiceTest.java
@@ -21,6 +21,9 @@ import org.springframework.test.context.ActiveProfiles;
 
 import java.math.BigDecimal;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 @Slf4j
 @SpringBootTest
 @ActiveProfiles("test")
@@ -48,8 +51,8 @@ public class PayServiceTest {
 	void 페이_잔액_조회_성공() {
 		PayResponse.Balance response = payService.getBalance(testUser.getId());
 
-		Assertions.assertNotNull(response);
-		Assertions.assertEquals(response.balance(), BigDecimal.valueOf(CHARGE_PAY_AMOUNT));
+		assertNotNull(response);
+		assertEquals(response.balance(), BigDecimal.valueOf(CHARGE_PAY_AMOUNT));
 		log.info("balance : {}", response.balance());
 
 	}


### PR DESCRIPTION
## #️⃣연관된 이슈

resolves: #273 

## 📝작업 내용

페이 잔액 조회 API 및 서비스 생성 (테스트 추가)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->