### PR TITLE
[FEAT] 페이 거래내역 조회 API 생성 및 서비스 추가

### DIFF
--- a/src/main/java/com/kt/constant/message/ErrorCode.java
+++ b/src/main/java/com/kt/constant/message/ErrorCode.java
@@ -80,6 +80,9 @@ public enum ErrorCode {
 	PAY_BALANCE_NOT_ENOUGH(HttpStatus.BAD_REQUEST, "페이 잔액이 충분하지 않습니다."),
 	BANK_ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "계좌가 존재하지 않습니다."),
 	SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "세션을 찾을 수 없습니다."),
+	INVALID_SEARCH_PERIOD_PAIR(HttpStatus.BAD_REQUEST, "조회 시작일과 종료일 모두 입력해야 합니다."),
+	INVALID_SEARCH_PERIOD_ORDER(HttpStatus.BAD_REQUEST, "조회 시작일은 종료일보다 늦을 수 없습니다."),
+	INVALID_SEARCH_PERIOD_RANGE(HttpStatus.BAD_REQUEST, "최대 1년까지 조회할 수 있습니다."),
 	;
 
 	private final HttpStatus status;

--- a/src/main/java/com/kt/controller/bankaccount/BankAccountTransactionController.java
+++ b/src/main/java/com/kt/controller/bankaccount/BankAccountTransactionController.java
@@ -25,7 +25,7 @@ import static com.kt.common.api.ApiResult.page;
 @RestController
 @RequestMapping("/api/bank-account-transactions")
 @RequiredArgsConstructor
-public class BankAccountTransactionController {
+public class BankAccountTransactionController implements BankAccountTransactionSupporter{
 
 	private final BankAccountTransactionService bankAccountTransactionService;
 

--- a/src/main/java/com/kt/controller/bankaccount/BankAccountTransactionSupporter.java
+++ b/src/main/java/com/kt/controller/bankaccount/BankAccountTransactionSupporter.java
@@ -1,0 +1,29 @@
+package com.kt.controller.bankaccount;
+
+import com.kt.common.Paging;
+import com.kt.common.api.ApiResult;
+import com.kt.common.api.PageResponse;
+import com.kt.domain.dto.request.BankAccountTransactionRequest;
+import com.kt.domain.dto.response.BankAccountTransactionResponse;
+import com.kt.security.DefaultCurrentUser;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import org.springframework.http.ResponseEntity;
+
+
+@Tag(name = "BankAccountTransaction", description = "계좌 거래내역 관련 API")
+public interface BankAccountTransactionSupporter {
+
+	@Operation(
+		summary = "계좌 거래내역 조회",
+		description = "계좌 거래내역 조회 API"
+	)
+	ResponseEntity<ApiResult<PageResponse<BankAccountTransactionResponse.Search>>> getMyTransactions(
+		DefaultCurrentUser currentUser,
+		BankAccountTransactionRequest.Search request,
+		Paging paging
+	);
+
+}

--- a/src/main/java/com/kt/controller/pay/transaction/PayTransactionController.java
+++ b/src/main/java/com/kt/controller/pay/transaction/PayTransactionController.java
@@ -1,0 +1,43 @@
+package com.kt.controller.pay.transaction;
+
+import com.kt.common.Paging;
+import com.kt.common.api.ApiResult;
+import com.kt.common.api.PageResponse;
+import com.kt.domain.dto.request.PayTransactionRequest;
+import com.kt.domain.dto.response.PayTransactionResponse;
+import com.kt.security.DefaultCurrentUser;
+import com.kt.service.pay.transaction.PayTransactionService;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+import static com.kt.common.api.ApiResult.page;
+
+@RestController
+@RequestMapping("/api/pay-transactions")
+@RequiredArgsConstructor
+public class PayTransactionController implements PayTransactionSwaggerSupporter {
+
+	private final PayTransactionService payTransactionService;
+
+	@GetMapping
+	public ResponseEntity<ApiResult<PageResponse<PayTransactionResponse.Search>>> getMyTransactions(
+		@AuthenticationPrincipal DefaultCurrentUser currentUser,
+		@ParameterObject PayTransactionRequest.Search request,
+		@ModelAttribute Paging paging
+	) {
+		UUID userId = currentUser.getId();
+		return page(
+			payTransactionService.getTransactions(userId, request, paging.toPageable())
+		);
+	}
+}

--- a/src/main/java/com/kt/controller/pay/transaction/PayTransactionSwaggerSupporter.java
+++ b/src/main/java/com/kt/controller/pay/transaction/PayTransactionSwaggerSupporter.java
@@ -1,0 +1,28 @@
+package com.kt.controller.pay.transaction;
+
+import com.kt.common.Paging;
+import com.kt.common.api.ApiResult;
+import com.kt.common.api.PageResponse;
+import com.kt.domain.dto.request.PayTransactionRequest;
+import com.kt.domain.dto.response.PayTransactionResponse;
+import com.kt.security.DefaultCurrentUser;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "BankAccountTransaction", description = "계좌 거래내역 관련 API")
+public interface PayTransactionSwaggerSupporter {
+
+	@Operation(
+		summary = "페이 거래내역 조회",
+		description = "패이 거래내역 조회 API"
+	)
+	ResponseEntity<ApiResult<PageResponse<PayTransactionResponse.Search>>> getMyTransactions(
+		DefaultCurrentUser currentUser,
+		PayTransactionRequest.Search request,
+		Paging paging
+	);
+
+}

--- a/src/main/java/com/kt/domain/dto/request/PayTransactionRequest.java
+++ b/src/main/java/com/kt/domain/dto/request/PayTransactionRequest.java
@@ -1,0 +1,35 @@
+package com.kt.domain.dto.request;
+
+import com.kt.constant.pay.PayTransactionType;
+
+import com.kt.domain.dto.request.common.BaseTransactionPeriodResolver;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDate;
+
+public class PayTransactionRequest {
+
+	@Schema(name = "PayTransactionSearch")
+	public record Search(
+		PayTransactionType type,
+		LocalDate fromDate,
+		LocalDate toDate,
+		String keyword
+	) {
+
+		static final int PAY_TRANSACTION_DEFAULT_MONTH = 1;
+
+		public void validate() {
+			BaseTransactionPeriodResolver.validatePeriod(fromDate, toDate);
+		}
+
+		public LocalDate resolvedFromDate() {
+			return BaseTransactionPeriodResolver.resolveFromDate(fromDate, toDate, PAY_TRANSACTION_DEFAULT_MONTH);
+		}
+
+		public LocalDate resolvedToDate() {
+			return BaseTransactionPeriodResolver.resolveToDate(fromDate, toDate);
+		}
+	}
+}

--- a/src/main/java/com/kt/domain/dto/request/common/BaseTransactionPeriodResolver.java
+++ b/src/main/java/com/kt/domain/dto/request/common/BaseTransactionPeriodResolver.java
@@ -1,5 +1,8 @@
 package com.kt.domain.dto.request.common;
 
+import com.kt.constant.message.ErrorCode;
+import com.kt.exception.CustomException;
+
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
@@ -9,6 +12,8 @@ import static lombok.AccessLevel.PROTECTED;
 
 @NoArgsConstructor(access = PROTECTED)
 public final class BaseTransactionPeriodResolver {
+
+	static final int YEAR_DAYS = 365;
 
 	public static LocalDate resolveFromDate(
 		LocalDate fromDate,
@@ -36,17 +41,18 @@ public final class BaseTransactionPeriodResolver {
 		LocalDate toDate
 	) {
 		if ((fromDate == null) != (toDate == null)) {
-			throw new IllegalArgumentException("조회 시작일과 종료일은 함께 전달되어야 합니다.");
+			throw new CustomException(ErrorCode.INVALID_SEARCH_PERIOD_PAIR);
 		}
 
 		if (fromDate == null) return;
 
 		if (fromDate.isAfter(toDate)) {
-			throw new IllegalArgumentException("조회 시작일은 종료일보다 이후일 수 없습니다.");
+			throw new CustomException(ErrorCode.INVALID_SEARCH_PERIOD_ORDER);
 		}
 
-		if (ChronoUnit.DAYS.between(fromDate, toDate) > 365) {
-			throw new IllegalArgumentException("조회 기간은 최대 1년까지 가능합니다.");
+		if (ChronoUnit.DAYS.between(fromDate, toDate) > YEAR_DAYS) {
+			throw new CustomException(ErrorCode.INVALID_SEARCH_PERIOD_RANGE);
 		}
+
 	}
 }

--- a/src/main/java/com/kt/domain/dto/request/common/BaseTransactionPeriodResolver.java
+++ b/src/main/java/com/kt/domain/dto/request/common/BaseTransactionPeriodResolver.java
@@ -1,0 +1,52 @@
+package com.kt.domain.dto.request.common;
+
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@NoArgsConstructor(access = PROTECTED)
+public final class BaseTransactionPeriodResolver {
+
+	public static LocalDate resolveFromDate(
+		LocalDate fromDate,
+		LocalDate toDate,
+		int defaultMonths
+	) {
+		if (fromDate == null && toDate == null) {
+			return LocalDate.now().minusMonths(defaultMonths);
+		}
+		return fromDate;
+	}
+
+	public static LocalDate resolveToDate(
+		LocalDate fromDate,
+		LocalDate toDate
+	) {
+		if (fromDate == null && toDate == null) {
+			return LocalDate.now();
+		}
+		return toDate;
+	}
+
+	public static void validatePeriod(
+		LocalDate fromDate,
+		LocalDate toDate
+	) {
+		if ((fromDate == null) != (toDate == null)) {
+			throw new IllegalArgumentException("조회 시작일과 종료일은 함께 전달되어야 합니다.");
+		}
+
+		if (fromDate == null) return;
+
+		if (fromDate.isAfter(toDate)) {
+			throw new IllegalArgumentException("조회 시작일은 종료일보다 이후일 수 없습니다.");
+		}
+
+		if (ChronoUnit.DAYS.between(fromDate, toDate) > 365) {
+			throw new IllegalArgumentException("조회 기간은 최대 1년까지 가능합니다.");
+		}
+	}
+}

--- a/src/main/java/com/kt/domain/dto/response/PayTransactionResponse.java
+++ b/src/main/java/com/kt/domain/dto/response/PayTransactionResponse.java
@@ -1,0 +1,27 @@
+package com.kt.domain.dto.response;
+
+import com.kt.constant.pay.PayTransactionType;
+import com.querydsl.core.annotations.QueryProjection;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+public class PayTransactionResponse {
+
+	@Schema(name = "PayTransactionResponse")
+	public record Search(
+		UUID transactionId,
+		PayTransactionType type,
+		BigDecimal amount,
+		BigDecimal balanceSnapshot,
+		String from,
+		String to,
+		Instant createdAt
+	) {
+		@QueryProjection
+		public Search {}
+	}
+}

--- a/src/main/java/com/kt/domain/entity/PayTransactionEntity.java
+++ b/src/main/java/com/kt/domain/entity/PayTransactionEntity.java
@@ -45,7 +45,10 @@ public class PayTransactionEntity extends BaseEntity {
 	private BigDecimal balanceSnapshot;
 
 	@Column(nullable = false)
-	private UUID targetId;
+	private String withdrawalSource;
+
+	@Column(nullable = false)
+	private String depositSource;
 
 	private PayTransactionEntity(
 		PayEntity pay,
@@ -53,14 +56,16 @@ public class PayTransactionEntity extends BaseEntity {
 		PayTransactionPurpose transactionPurpose,
 		BigDecimal amount,
 		BigDecimal balanceSnapshot,
-		UUID targetId
+		String withdrawalSource,
+		String depositSource
 	) {
 		this.pay = pay;
 		this.transactionType = transactionType;
 		this.transactionPurpose = transactionPurpose;
 		this.amount = amount;
 		this.balanceSnapshot = balanceSnapshot;
-		this.targetId = targetId;
+		this.withdrawalSource = withdrawalSource;
+		this.depositSource = depositSource;
 	}
 
 	public static PayTransactionEntity create(
@@ -69,7 +74,8 @@ public class PayTransactionEntity extends BaseEntity {
 		final PayTransactionPurpose transactionPurpose,
 		final long amount,
 		final BigDecimal balanceSnapshot,
-		final UUID targetId
+		final String withdrawalSource,
+		final String depositSource
 	) {
 		ValidationUtil.validateRequiredEnum(transactionType, "페이 거래타입");
 		ValidationUtil.validateRequiredEnum(transactionPurpose, "페이 거래목적");
@@ -82,7 +88,8 @@ public class PayTransactionEntity extends BaseEntity {
 			transactionPurpose,
 			transactionAmount,
 			balanceSnapshot,
-			targetId
+			withdrawalSource,
+			depositSource
 		);
 	}
 

--- a/src/main/java/com/kt/repository/bankaccount/transaction/BankAccountTransactionRepository.java
+++ b/src/main/java/com/kt/repository/bankaccount/transaction/BankAccountTransactionRepository.java
@@ -8,8 +8,7 @@ import org.springframework.stereotype.Repository;
 import java.util.UUID;
 
 @Repository
-public interface BankAccountTransactionRepository extends
-	JpaRepository<BankAccountTransactionEntity, UUID>,
+public interface BankAccountTransactionRepository extends JpaRepository<BankAccountTransactionEntity, UUID>,
 	BankAccountTransactionRepositoryCustom {
 
 }

--- a/src/main/java/com/kt/repository/bankaccount/transaction/BankAccountTransactionRepositoryCustomImpl.java
+++ b/src/main/java/com/kt/repository/bankaccount/transaction/BankAccountTransactionRepositoryCustomImpl.java
@@ -33,8 +33,6 @@ public class BankAccountTransactionRepositoryCustomImpl implements BankAccountTr
 
 	private final QBankAccountTransactionEntity bankAccountTransaction = bankAccountTransactionEntity;
 
-
-
 	@Override
 	public Page<BankAccountTransactionResponse.Search> search(
 		UUID holderId,
@@ -90,9 +88,7 @@ public class BankAccountTransactionRepositoryCustomImpl implements BankAccountTr
 		return bankAccountTransaction.bankAccount.holderId.eq(holderId);
 	}
 
-	private BooleanExpression eqType(
-		BankAccountTransactionType type
-	) {
+	private BooleanExpression eqType(BankAccountTransactionType type) {
 		return type == null ? null : bankAccountTransaction.transactionType.eq(type);
 	}
 

--- a/src/main/java/com/kt/repository/pay/PayRepository.java
+++ b/src/main/java/com/kt/repository/pay/PayRepository.java
@@ -1,4 +1,4 @@
-package com.kt.repository;
+package com.kt.repository.pay;
 
 import java.util.Optional;
 

--- a/src/main/java/com/kt/repository/pay/transaction/PayTransactionRepository.java
+++ b/src/main/java/com/kt/repository/pay/transaction/PayTransactionRepository.java
@@ -8,5 +8,7 @@ import org.springframework.stereotype.Repository;
 import java.util.UUID;
 
 @Repository
-public interface PayTransactionRepository extends JpaRepository<PayTransactionEntity, UUID> {
+public interface PayTransactionRepository extends JpaRepository<PayTransactionEntity, UUID>,
+	PayTransactionRepositoryCustom {
+
 }

--- a/src/main/java/com/kt/repository/pay/transaction/PayTransactionRepository.java
+++ b/src/main/java/com/kt/repository/pay/transaction/PayTransactionRepository.java
@@ -1,4 +1,4 @@
-package com.kt.repository;
+package com.kt.repository.pay.transaction;
 
 import com.kt.domain.entity.PayTransactionEntity;
 

--- a/src/main/java/com/kt/repository/pay/transaction/PayTransactionRepositoryCustom.java
+++ b/src/main/java/com/kt/repository/pay/transaction/PayTransactionRepositoryCustom.java
@@ -1,0 +1,4 @@
+package com.kt.repository.pay.transaction;
+
+public interface PayTransactionRepositoryCustom {
+}

--- a/src/main/java/com/kt/repository/pay/transaction/PayTransactionRepositoryCustom.java
+++ b/src/main/java/com/kt/repository/pay/transaction/PayTransactionRepositoryCustom.java
@@ -1,4 +1,22 @@
 package com.kt.repository.pay.transaction;
 
+import com.kt.constant.pay.PayTransactionType;
+import com.kt.domain.dto.response.PayTransactionResponse;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
 public interface PayTransactionRepositoryCustom {
+
+	Page<PayTransactionResponse.Search> search(
+		UUID userId,
+		PayTransactionType type,
+		LocalDate fromDate,
+		LocalDate toDate,
+		String keyword,
+		Pageable pageable
+	);
 }

--- a/src/main/java/com/kt/repository/pay/transaction/PayTransactionRepositoryCustomImpl.java
+++ b/src/main/java/com/kt/repository/pay/transaction/PayTransactionRepositoryCustomImpl.java
@@ -1,0 +1,12 @@
+package com.kt.repository.pay.transaction;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class PayTransactionRepositoryCustomImpl implements PayTransactionRepositoryCustom {
+
+
+}

--- a/src/main/java/com/kt/repository/pay/transaction/PayTransactionRepositoryCustomImpl.java
+++ b/src/main/java/com/kt/repository/pay/transaction/PayTransactionRepositoryCustomImpl.java
@@ -1,12 +1,110 @@
 package com.kt.repository.pay.transaction;
 
+import com.kt.constant.pay.PayTransactionType;
+import com.kt.domain.dto.response.PayTransactionResponse;
+
+import com.kt.domain.dto.response.QPayTransactionResponse_Search;
+import com.kt.domain.entity.QPayTransactionEntity;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.UUID;
+
+import static com.kt.domain.entity.QPayTransactionEntity.payTransactionEntity;
 
 @Repository
 @RequiredArgsConstructor
 public class PayTransactionRepositoryCustomImpl implements PayTransactionRepositoryCustom {
 
+	private final JPAQueryFactory jpaQueryFactory;
 
+	private final QPayTransactionEntity payTransaction = payTransactionEntity;
+
+	@Override
+	public Page<PayTransactionResponse.Search> search(
+		UUID userId,
+		PayTransactionType type,
+		LocalDate fromDate,
+		LocalDate toDate,
+		String keyword,
+		Pageable pageable
+	) {
+
+		List<PayTransactionResponse.Search> list = jpaQueryFactory
+			.select(new QPayTransactionResponse_Search(
+				payTransaction.id,
+				payTransaction.transactionType,
+				payTransaction.amount,
+				payTransaction.balanceSnapshot,
+				payTransaction.withdrawalSource,
+				payTransaction.depositSource,
+				payTransaction.createdAt
+			))
+			.from(payTransaction)
+			.where(
+				eqUserId(userId),
+				eqType(type),
+				betweenPeriod(
+					fromDate,
+					toDate
+				),
+				containsKeyword(keyword)
+			)
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+
+		int totalCount = jpaQueryFactory
+			.select(payTransaction.count())
+			.from(payTransaction)
+			.where(
+				eqUserId(userId),
+				eqType(type),
+				betweenPeriod(
+					fromDate,
+					toDate
+				),
+				containsKeyword(keyword)
+			).fetch()
+			.size();
+
+		return new PageImpl<>(list, pageable, totalCount);
+	}
+
+	private BooleanExpression eqUserId(UUID userId) {
+		return payTransaction.pay.user.id.eq(userId);
+	}
+
+	private BooleanExpression eqType(PayTransactionType type) {
+		return type == null ? null : payTransaction.transactionType.eq(type);
+	}
+
+	private BooleanExpression betweenPeriod(LocalDate from, LocalDate to) {
+		ZoneId zoneId = ZoneId.systemDefault();
+
+		Instant fromInstant = from.atStartOfDay(zoneId).toInstant();
+		Instant toInstant = to.plusDays(1).atStartOfDay(zoneId).toInstant();
+
+		return payTransaction.createdAt.between(fromInstant, toInstant);
+	}
+
+	private BooleanExpression containsKeyword(String keyword) {
+		if (keyword == null || keyword.isBlank()) {
+			return null;
+		}
+
+		return payTransaction.depositSource.contains(keyword)
+			.or(payTransaction.withdrawalSource.contains(keyword));
+	}
 }

--- a/src/main/java/com/kt/service/OrderPaymentService.java
+++ b/src/main/java/com/kt/service/OrderPaymentService.java
@@ -12,7 +12,7 @@ import com.kt.domain.entity.PayEntity;
 import com.kt.domain.entity.ProductEntity;
 import com.kt.domain.entity.UserEntity;
 import com.kt.exception.CustomException;
-import com.kt.repository.PayRepository;
+import com.kt.repository.pay.PayRepository;
 import com.kt.repository.product.ProductRepository;
 import com.kt.repository.user.UserRepository;
 import com.kt.service.payment.PaymentSettlementService;

--- a/src/main/java/com/kt/service/OrderServiceImpl.java
+++ b/src/main/java/com/kt/service/OrderServiceImpl.java
@@ -27,7 +27,7 @@ import com.kt.domain.entity.ShippingDetailEntity;
 import com.kt.domain.entity.UserEntity;
 import com.kt.exception.CustomException;
 import com.kt.repository.AddressRepository;
-import com.kt.repository.PayRepository;
+import com.kt.repository.pay.PayRepository;
 import com.kt.repository.PaymentRepository;
 import com.kt.repository.ShippingDetailRepository;
 import com.kt.repository.inventory.InventoryRepository;

--- a/src/main/java/com/kt/service/pay/PayChargeService.java
+++ b/src/main/java/com/kt/service/pay/PayChargeService.java
@@ -64,7 +64,8 @@ public class PayChargeService {
 				PayTransactionPurpose.CHARGE,
 				amount,
 				pay.getBalance(),
-				bankAccount.getId()
+				bankAccount.getDisplayName(),
+				pay.getDisplayName()
 			);
 		payTransactionRepository.save(payTransaction);
 	}

--- a/src/main/java/com/kt/service/pay/PayChargeService.java
+++ b/src/main/java/com/kt/service/pay/PayChargeService.java
@@ -11,7 +11,7 @@ import com.kt.domain.entity.PayTransactionEntity;
 import com.kt.domain.entity.UserEntity;
 import com.kt.repository.bankaccount.BankAccountRepository;
 import com.kt.repository.bankaccount.transaction.BankAccountTransactionRepository;
-import com.kt.repository.PayTransactionRepository;
+import com.kt.repository.pay.transaction.PayTransactionRepository;
 import com.kt.repository.user.UserRepository;
 
 import jakarta.transaction.Transactional;

--- a/src/main/java/com/kt/service/pay/PayWithdrawalService.java
+++ b/src/main/java/com/kt/service/pay/PayWithdrawalService.java
@@ -9,7 +9,7 @@ import com.kt.domain.entity.BankAccountTransactionEntity;
 import com.kt.domain.entity.PayEntity;
 import com.kt.domain.entity.PayTransactionEntity;
 import com.kt.domain.entity.UserEntity;
-import com.kt.repository.PayTransactionRepository;
+import com.kt.repository.pay.transaction.PayTransactionRepository;
 import com.kt.repository.bankaccount.BankAccountRepository;
 import com.kt.repository.bankaccount.transaction.BankAccountTransactionRepository;
 import com.kt.repository.user.UserRepository;

--- a/src/main/java/com/kt/service/pay/PayWithdrawalService.java
+++ b/src/main/java/com/kt/service/pay/PayWithdrawalService.java
@@ -65,7 +65,8 @@ public class PayWithdrawalService {
 			PayTransactionPurpose.WITHDRAW,
 			amount,
 			pay.getBalance(),
-			bankAccount.getId()
+			pay.getDisplayName(),
+			bankAccount.getDisplayName()
 		);
 		payTransactionRepository.save(payTransaction);
 	}

--- a/src/main/java/com/kt/service/pay/transaction/PayTransactionService.java
+++ b/src/main/java/com/kt/service/pay/transaction/PayTransactionService.java
@@ -1,0 +1,18 @@
+package com.kt.service.pay.transaction;
+
+import com.kt.domain.dto.request.PayTransactionRequest;
+import com.kt.domain.dto.response.PayTransactionResponse;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.UUID;
+
+public interface PayTransactionService {
+
+	Page<PayTransactionResponse.Search> getTransactions(
+		UUID userId,
+		PayTransactionRequest.Search search,
+		Pageable pageable
+	);
+}

--- a/src/main/java/com/kt/service/pay/transaction/PayTransactionServiceImpl.java
+++ b/src/main/java/com/kt/service/pay/transaction/PayTransactionServiceImpl.java
@@ -1,0 +1,43 @@
+package com.kt.service.pay.transaction;
+
+import com.kt.domain.dto.request.PayTransactionRequest;
+import com.kt.domain.dto.response.PayTransactionResponse;
+import com.kt.repository.pay.transaction.PayTransactionRepository;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class PayTransactionServiceImpl implements PayTransactionService {
+
+
+	private final PayTransactionRepository payTransactionRepository;
+
+	@Override
+	public Page<PayTransactionResponse.Search> getTransactions(
+		UUID userId,
+		PayTransactionRequest.Search search,
+		Pageable pageable
+	) {
+
+		search.validate();
+		LocalDate fromDate = search.resolvedFromDate();
+		LocalDate toDate = search.resolvedToDate();
+
+		return payTransactionRepository.search(
+			userId,
+			search.type(),
+			fromDate,
+			toDate,
+			search.keyword(),
+			pageable
+		);
+	}
+}

--- a/src/main/java/com/kt/service/payment/PaymentSettlementService.java
+++ b/src/main/java/com/kt/service/payment/PaymentSettlementService.java
@@ -13,7 +13,7 @@ import com.kt.domain.entity.ProductEntity;
 import com.kt.domain.entity.SellerEntity;
 import com.kt.domain.entity.UserEntity;
 import com.kt.repository.bankaccount.transaction.BankAccountTransactionRepository;
-import com.kt.repository.PayTransactionRepository;
+import com.kt.repository.pay.transaction.PayTransactionRepository;
 import com.kt.repository.bankaccount.BankAccountRepository;
 
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/kt/service/payment/PaymentSettlementService.java
+++ b/src/main/java/com/kt/service/payment/PaymentSettlementService.java
@@ -59,7 +59,8 @@ public class PaymentSettlementService {
 				PayTransactionPurpose.ORDER_PAYMENT,
 				totalPrice,
 				pay.getBalance(),
-				bankAccount.getId()
+				pay.getDisplayName(),
+				bankAccount.getDisplayName()
 			);
 		payTransactionRepository.save(payTransaction);
 	}

--- a/src/main/java/com/kt/service/seller/SellerRefundServiceImpl.java
+++ b/src/main/java/com/kt/service/seller/SellerRefundServiceImpl.java
@@ -15,7 +15,7 @@ import com.kt.domain.entity.PaymentEntity;
 import com.kt.domain.entity.RefundHistoryEntity;
 import com.kt.domain.entity.UserEntity;
 import com.kt.exception.CustomException;
-import com.kt.repository.PayRepository;
+import com.kt.repository.pay.PayRepository;
 import com.kt.repository.inventory.InventoryRepository;
 import com.kt.repository.refund.RefundHistoryRepository;
 

--- a/src/test/java/com/kt/LockTest.java
+++ b/src/test/java/com/kt/LockTest.java
@@ -32,7 +32,7 @@ import com.kt.domain.entity.SellerEntity;
 import com.kt.domain.entity.UserEntity;
 import com.kt.repository.AddressRepository;
 import com.kt.repository.CategoryRepository;
-import com.kt.repository.PayTransactionRepository;
+import com.kt.repository.pay.transaction.PayTransactionRepository;
 import com.kt.repository.PaymentRepository;
 import com.kt.repository.account.AccountRepository;
 import com.kt.repository.bankaccount.BankAccountRepository;

--- a/src/test/java/com/kt/domain/entity/PayTransactionEntityTest.java
+++ b/src/test/java/com/kt/domain/entity/PayTransactionEntityTest.java
@@ -45,7 +45,8 @@ public class PayTransactionEntityTest {
 			PayTransactionPurpose.CHARGE,
 			AMOUNT,
 			pay.getBalance(),
-			bankAccount.getId()
+			pay.getDisplayName(),
+			bankAccount.getDisplayName()
 		);
 		assertNotNull(payTransaction);
 		assertEquals(BigDecimal.valueOf(AMOUNT), payTransaction.getBalanceSnapshot());
@@ -53,6 +54,7 @@ public class PayTransactionEntityTest {
 
 	@Test
 	void 객체생성_실패_페이_거래타입_null() {
+		PayEntity pay = testUser.getPay();
 		assertThatThrownBy(() ->
 			PayTransactionEntity.create(
 				testUser.getPay(),
@@ -60,7 +62,8 @@ public class PayTransactionEntityTest {
 				PayTransactionPurpose.CHARGE,
 				10_000,
 				BigDecimal.valueOf(10_000),
-				bankAccount.getId()
+				bankAccount.getDisplayName(),
+				pay.getDisplayName()
 			)
 		).isInstanceOfSatisfying(FieldValidationException.class, ex -> {
 			log.info("getErrorMessage : {}", ex.getErrorMessage());
@@ -70,15 +73,16 @@ public class PayTransactionEntityTest {
 
 	@Test
 	void 객체생성_실패_페이_거래목적_null() {
-
+		PayEntity pay = testUser.getPay();
 		assertThatThrownBy(() ->
 			PayTransactionEntity.create(
-				testUser.getPay(),
+				pay,
 				PayTransactionType.CREDIT,
 				null,
 				10_000,
 				BigDecimal.valueOf(10_000),
-				bankAccount.getId()
+				bankAccount.getDisplayName(),
+				pay.getDisplayName()
 			)
 		).isInstanceOfSatisfying(FieldValidationException.class, ex -> {
 			log.info("getErrorMessage : {}", ex.getErrorMessage());
@@ -88,15 +92,16 @@ public class PayTransactionEntityTest {
 
 	@Test
 	void 객체생성_실패_페이_거래금액_0_이하() {
-
+		PayEntity pay = testUser.getPay();
 		assertThatThrownBy(() ->
 			PayTransactionEntity.create(
-				testUser.getPay(),
+				pay,
 				PayTransactionType.CREDIT,
 				PayTransactionPurpose.CHARGE,
 				0,
 				BigDecimal.valueOf(10_000),
-				bankAccount.getId()
+				bankAccount.getDisplayName(),
+				pay.getDisplayName()
 			)
 		)
 			.isInstanceOfSatisfying(FieldValidationException.class, ex -> {
@@ -107,15 +112,16 @@ public class PayTransactionEntityTest {
 
 	@Test
 	void 객체생성_실패_페이_거래후_잔액_0_미만() {
-
+		PayEntity pay = testUser.getPay();
 		assertThatThrownBy(() ->
 			PayTransactionEntity.create(
-				testUser.getPay(),
+				pay,
 				PayTransactionType.DEBIT,
 				PayTransactionPurpose.WITHDRAW,
 				10_000,
 				BigDecimal.valueOf(-1),
-				bankAccount.getId()
+				pay.getDisplayName(),
+				bankAccount.getDisplayName()
 			)
 		).isInstanceOfSatisfying(
 			FieldValidationException.class, ex -> {

--- a/src/test/java/com/kt/service/PayChargeServiceTest.java
+++ b/src/test/java/com/kt/service/PayChargeServiceTest.java
@@ -5,7 +5,7 @@ import com.kt.domain.entity.BankAccountEntity;
 import com.kt.domain.entity.PayEntity;
 import com.kt.domain.entity.UserEntity;
 
-import com.kt.repository.PayTransactionRepository;
+import com.kt.repository.pay.transaction.PayTransactionRepository;
 import com.kt.repository.bankaccount.BankAccountRepository;
 import com.kt.repository.bankaccount.transaction.BankAccountTransactionRepository;
 import com.kt.repository.user.UserRepository;

--- a/src/test/java/com/kt/service/PayTransactionServiceTest.java
+++ b/src/test/java/com/kt/service/PayTransactionServiceTest.java
@@ -1,0 +1,107 @@
+package com.kt.service;
+
+import com.kt.common.UserEntityCreator;
+import com.kt.constant.pay.PayTransactionPurpose;
+import com.kt.constant.pay.PayTransactionType;
+import com.kt.domain.dto.request.PayTransactionRequest;
+import com.kt.domain.dto.response.PayTransactionResponse;
+import com.kt.domain.entity.BankAccountEntity;
+import com.kt.domain.entity.PayTransactionEntity;
+import com.kt.domain.entity.UserEntity;
+import com.kt.repository.bankaccount.BankAccountRepository;
+import com.kt.repository.pay.transaction.PayTransactionRepository;
+import com.kt.repository.user.UserRepository;
+
+import com.kt.service.pay.transaction.PayTransactionService;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Slf4j
+@SpringBootTest
+@ActiveProfiles("test")
+public class PayTransactionServiceTest {
+
+	@Autowired
+	UserRepository userRepository;
+
+	@Autowired
+	PayTransactionService payTransactionService;
+
+	@Autowired
+	BankAccountRepository bankAccountRepository;
+
+	@Autowired
+	PayTransactionRepository payTransactionRepository;
+
+	UserEntity testUser;
+
+	static final long CHARGE_PAY_AMOUNT = 1_000_000;
+
+
+	@BeforeEach
+	void setup() {
+		testUser = UserEntityCreator.create();
+		userRepository.save(testUser);
+		testUser.getPay().charge(CHARGE_PAY_AMOUNT);
+
+		savePayTransaction();
+	}
+
+	@Test
+	@Transactional
+	void 페이_거래내역_조회_성공() {
+		PayTransactionRequest.Search request = new PayTransactionRequest.Search(
+			PayTransactionType.CREDIT,
+			null,
+			null,
+			null
+		);
+		Pageable pageable = PageRequest.of(0, 10);
+
+		Page<PayTransactionResponse.Search> response =
+			payTransactionService.getTransactions(
+				testUser.getId(),
+				request,
+				pageable
+			);
+
+		Assertions.assertNotNull(response);
+		log.info("result getFist : {}", response.get().findFirst());
+		log.info("result size : {}", response.getTotalElements());
+		assertEquals(1, response.getTotalElements());
+	}
+
+	private void savePayTransaction() {
+
+		BankAccountEntity bankAccount = BankAccountEntity.create(
+			testUser, testUser.getName()
+		);
+		bankAccountRepository.save(bankAccount);
+
+		PayTransactionEntity payTransaction = PayTransactionEntity.create(
+			testUser.getPay(),
+			PayTransactionType.CREDIT,
+			PayTransactionPurpose.CHARGE,
+			CHARGE_PAY_AMOUNT,
+			testUser.getPay().getBalance(),
+			testUser.getPay().getDisplayName(),
+			bankAccount.getDisplayName()
+		);
+		payTransactionRepository.save(payTransaction);
+	}
+
+
+}

--- a/src/test/java/com/kt/service/PayWithdrawalServiceTest.java
+++ b/src/test/java/com/kt/service/PayWithdrawalServiceTest.java
@@ -4,7 +4,7 @@ import com.kt.common.UserEntityCreator;
 import com.kt.domain.entity.BankAccountEntity;
 import com.kt.domain.entity.PayEntity;
 import com.kt.domain.entity.UserEntity;
-import com.kt.repository.PayTransactionRepository;
+import com.kt.repository.pay.transaction.PayTransactionRepository;
 import com.kt.repository.bankaccount.BankAccountRepository;
 import com.kt.repository.bankaccount.transaction.BankAccountTransactionRepository;
 import com.kt.repository.user.UserRepository;

--- a/src/test/java/com/kt/service/RefundServiceTest.java
+++ b/src/test/java/com/kt/service/RefundServiceTest.java
@@ -33,7 +33,7 @@ import com.kt.domain.entity.SellerEntity;
 import com.kt.domain.entity.UserEntity;
 import com.kt.exception.CustomException;
 import com.kt.repository.CategoryRepository;
-import com.kt.repository.PayRepository;
+import com.kt.repository.pay.PayRepository;
 import com.kt.repository.PaymentRepository;
 import com.kt.repository.inventory.InventoryRepository;
 import com.kt.repository.order.OrderRepository;


### PR DESCRIPTION
## #️⃣연관된 이슈

resolves: #277 

## 📝작업 내용

페이 거래내역 API 및 서비스 추가 (Service 테스트코드 추가)
페이 입금처 및 출금처 필드 추가 (기존 targetId 제거)
계좌 및 페이 거래내역 통합 기간 요청 컴포넌트 개발 (계좌는 추후 적용)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->